### PR TITLE
Fetch object meta-data lazily Resolves #41

### DIFF
--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
@@ -80,7 +80,7 @@ public class SimpleStorageResourceLoaderTest {
 
 		assertNotNull(resourceLoader.getResource("s3://prefix.bucket/object.suffix"));
 
-		verify(amazonS3, times(2)).getObjectMetadata("bucket", "object");
+		verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
 	}
 
 


### PR DESCRIPTION
Prior to this commit the instance meta-data have been fetched while creating the resource within the resource loader. This approach assumes that resources can never be created after fetching them from the resource loader. Because of the fact that resource can be created after getting them from the resource loader the data is tried to be fetched only when it is needed. The single storage resource still contains a cache, meaning that after retrieving the object meta data it will used the cached ones.
If users wants to re-retrieve fresh meta-data they need to re-request the resource from the storage loader. The caching has been introduced because API calls are considered expensive. And getting the file size etc. should not result each time into an API call.