### PR TITLE
Add support to SimpleStorageResourceLoader for versioned S3 objects

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
@@ -67,7 +67,8 @@ public class SimpleStorageResourceLoader implements ResourceLoader, Initializing
 	public Resource getResource(String location) {
 		if (SimpleStorageNameUtils.isSimpleStorageResource(location)) {
 			return new SimpleStorageResource(this.amazonS3, SimpleStorageNameUtils.getBucketNameFromLocation(location),
-					SimpleStorageNameUtils.getObjectNameFromLocation(location), this.taskExecutor);
+					SimpleStorageNameUtils.getObjectNameFromLocation(location), this.taskExecutor,
+					SimpleStorageNameUtils.getVersionIdFromLocation(location));
 		}
 
 		return this.delegate.getResource(location);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -18,12 +18,15 @@ package org.springframework.cloud.aws.core.io.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.util.ClassUtils;
@@ -37,6 +40,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -146,7 +150,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		ObjectListing objectListingWithPrefixFooOneBarOne = createObjectListingMock(Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/test.txt")), Collections.<String>emptyList(), false);
 		when(amazonS3.listObjects(argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/")))).thenReturn(objectListingWithPrefixFooOneBarOne);
 
-		when(amazonS3.getObjectMetadata(anyString(), anyString())).thenReturn(new ObjectMetadata());
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(new ObjectMetadata());
 
 		return amazonS3;
 	}
@@ -164,7 +168,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		when(amazonS3.listObjects(argThat(new ListObjectsRequestMatcher("anotherBucket", null, null)))).thenReturn(objectListingWithOneFile);
 		when(amazonS3.listObjects(argThat(new ListObjectsRequestMatcher("myBuckez", null, null)))).thenReturn(emptyObjectListing);
 
-		when(amazonS3.getObjectMetadata(anyString(), anyString())).thenReturn(new ObjectMetadata());
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(new ObjectMetadata());
 		return amazonS3;
 	}
 
@@ -230,7 +234,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		);
 		when(amazonS3.listObjects(argThat(new ListObjectsRequestMatcher("myBucket", null, null)))).thenReturn(fullObjectListing);
 
-		when(amazonS3.getObjectMetadata(anyString(), anyString())).thenReturn(new ObjectMetadata());
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(new ObjectMetadata());
 
 		return amazonS3;
 	}

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
@@ -22,7 +22,9 @@ import org.junit.rules.ExpectedException;
 
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getBucketNameFromLocation;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObject;
+import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObjectAndVersionId;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getObjectNameFromLocation;
+import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getVersionIdFromLocation;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.isSimpleStorageResource;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.stripProtocol;
 import static org.junit.Assert.assertEquals;
@@ -59,6 +61,8 @@ public class SimpleStorageNameUtilsTest {
 
 		assertEquals("foo", getBucketNameFromLocation("s3://foo/bar/baz/boo/"));
 		assertEquals("fo*", getBucketNameFromLocation("s3://fo*/bar/baz/boo/"));
+		
+		assertEquals("foo", getBucketNameFromLocation("s3://foo/bar/baz/boo/^versionIdValue"));
 	}
 
 	@Test
@@ -100,11 +104,19 @@ public class SimpleStorageNameUtilsTest {
 	public void testGetObjectNameFromLocation() throws Exception {
 		assertEquals("bar", getObjectNameFromLocation("s3://foo/bar"));
 		assertEquals("ba*", getObjectNameFromLocation("s3://foo/ba*"));
+		assertEquals("bar", getObjectNameFromLocation("s3://foo/bar^versionIdValue"));
 
 		assertEquals("bar/baz/boo", getObjectNameFromLocation("s3://foo/bar/baz/boo/"));
 		assertEquals("bar/ba*/boo", getObjectNameFromLocation("s3://foo/bar/ba*/boo/"));
 		assertEquals("bar/baz/boo.txt", getObjectNameFromLocation("s3://foo/bar/baz/boo.txt/"));
 		assertEquals("bar/ba*/boo.txt", getObjectNameFromLocation("s3://foo/bar/ba*/boo.txt/"));
+		assertEquals("bar/ba*/boo.txt", getObjectNameFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue"));
+	}
+	
+	@Test
+	public void testGetVersionIdFromLocation() throws Exception {
+		assertEquals("versionIdValue", getVersionIdFromLocation("s3://foo/bar^versionIdValue"));
+		assertEquals("versionIdValue", getVersionIdFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue"));
 	}
 
 	@Test
@@ -127,12 +139,20 @@ public class SimpleStorageNameUtilsTest {
 		assertEquals("s3://foo/bar/baz", getLocationForBucketAndObject("foo", "bar/baz"));
 		assertEquals("s3://foo/bar/baz.txt", getLocationForBucketAndObject("foo", "bar/baz.txt"));
 	}
+	
+	@Test
+	public void testGetLocationForObjectNameAndBucketAndVersionId() throws Exception {
+		assertEquals("s3://foo/bar^versionIdValue", getLocationForBucketAndObjectAndVersionId("foo", "bar", "versionIdValue"));
+		assertEquals("s3://foo/bar/baz^versionIdValue", getLocationForBucketAndObjectAndVersionId("foo", "bar/baz", "versionIdValue"));
+		assertEquals("s3://foo/bar/baz.txt^versionIdValue", getLocationForBucketAndObjectAndVersionId("foo", "bar/baz.txt", "versionIdValue"));
+	}
 
 	@Test
 	public void testStripProtocol() throws Exception {
 		assertEquals("foo/bar", stripProtocol("s3://foo/bar"));
 		assertEquals("foo/bar/baz", stripProtocol("s3://foo/bar/baz"));
 		assertEquals("foo/bar.txt", stripProtocol("s3://foo/bar.txt"));
+		assertEquals("foo/bar.txt^versionIdValue", stripProtocol("s3://foo/bar.txt^versionIdValue"));
 		assertEquals("", stripProtocol("s3://"));
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
@@ -51,7 +51,6 @@ public class SimpleStorageResourceLoaderTest {
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);
 		assertNotNull(resource);
-
 	}
 
 	@Test
@@ -60,6 +59,21 @@ public class SimpleStorageResourceLoaderTest {
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
 
 		SimpleStorageResourceLoader resourceLoader = new SimpleStorageResourceLoader(amazonS3);
+
+		String resourceName = "s3://bucket/object/";
+		Resource resource = resourceLoader.getResource(resourceName);
+		assertNotNull(resource);
+	}
+	
+	@Test
+	public void testGetResourceWithVersionId() throws Exception {
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+
+		SimpleStorageResourceLoader resourceLoader = new SimpleStorageResourceLoader(amazonS3);
+
+		ObjectMetadata metadata = new ObjectMetadata();
+		
+		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(metadata);
 
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);
@@ -82,7 +96,6 @@ public class SimpleStorageResourceLoaderTest {
 
 		verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
 	}
-
 
 	@Test
 	public void testGetResourceWithMalFormedUrl() throws Exception {
@@ -126,6 +139,7 @@ public class SimpleStorageResourceLoaderTest {
 		resourceLoader.getResource("s3://bucket/key");
 		resourceLoader.getResource("S3://BuCket/key");
 		resourceLoader.getResource("s3://bucket/folder1/folder2/key");
+		resourceLoader.getResource("s3://bucket/folder1/folder2/key^versionIdValue");
 	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.core.io.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.Test;
 import org.springframework.core.io.Resource;
@@ -25,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,7 +48,7 @@ public class SimpleStorageResourceLoaderTest {
 		SimpleStorageResourceLoader resourceLoader = new SimpleStorageResourceLoader(amazonS3);
 
 		ObjectMetadata metadata = new ObjectMetadata();
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(metadata);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(metadata);
 
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);
@@ -73,7 +75,7 @@ public class SimpleStorageResourceLoaderTest {
 
 		ObjectMetadata metadata = new ObjectMetadata();
 		
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(metadata);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(metadata);
 
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
@@ -77,7 +77,7 @@ public class SimpleStorageResourceLoaderTest {
 		
 		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(metadata);
 
-		String resourceName = "s3://bucket/object/";
+		String resourceName = "s3://bucket/object^versionIdValue";
 		Resource resource = resourceLoader.getResource(resourceName);
 		assertNotNull(resource);
 	}

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -16,23 +16,6 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectResult;
-import com.amazonaws.services.s3.model.S3Object;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.springframework.core.task.SyncTaskExecutor;
-
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Date;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -40,6 +23,26 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
 
 /**
  * @author Agim Emruli
@@ -53,7 +56,7 @@ public class SimpleStorageResourceTest {
 	public void exists_withExistingObjectMetadata_returnsTrue() throws Exception {
 		//Arrange
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(new ObjectMetadata());
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(new ObjectMetadata());
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
@@ -66,7 +69,7 @@ public class SimpleStorageResourceTest {
 	public void exists_withoutExistingObjectMetadata_returnsFalse() throws Exception {
 		//Arrange
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(null);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(null);
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
@@ -81,7 +84,7 @@ public class SimpleStorageResourceTest {
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
 		ObjectMetadata objectMetadata = new ObjectMetadata();
 		objectMetadata.setContentLength(1234L);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(objectMetadata);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(objectMetadata);
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
@@ -97,7 +100,7 @@ public class SimpleStorageResourceTest {
 		ObjectMetadata objectMetadata = new ObjectMetadata();
 		Date lastModified = new Date();
 		objectMetadata.setLastModified(lastModified);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(objectMetadata);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(objectMetadata);
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
@@ -113,7 +116,7 @@ public class SimpleStorageResourceTest {
 		this.expectedException.expectMessage("not found");
 
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(null);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(null);
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
 
 		//Act
@@ -130,7 +133,7 @@ public class SimpleStorageResourceTest {
 		this.expectedException.expectMessage("not found");
 
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(null);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(null);
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
 
 		//Act
@@ -143,7 +146,7 @@ public class SimpleStorageResourceTest {
 	public void getFileName_existingObject_returnsFileNameWithoutBucketNameFromParameterWithoutActuallyFetchingTheFile() throws Exception {
 		//Arrange
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(null);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(null);
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());
@@ -157,12 +160,12 @@ public class SimpleStorageResourceTest {
 		//Arrange
 		AmazonS3 amazonS3 = mock(AmazonS3.class);
 		ObjectMetadata objectMetadata = mock(ObjectMetadata.class);
-		when(amazonS3.getObjectMetadata("bucket", "object")).thenReturn(objectMetadata);
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(objectMetadata);
 
 		S3Object s3Object = new S3Object();
 		s3Object.setObjectMetadata(objectMetadata);
 		s3Object.setObjectContent(new ByteArrayInputStream(new byte[]{42}));
-		when(amazonS3.getObject("bucket", "object")).thenReturn(s3Object);
+		when(amazonS3.getObject(any(GetObjectRequest.class))).thenReturn(s3Object);
 
 		//Act
 		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucket", "object", new SyncTaskExecutor());


### PR DESCRIPTION
Versioning in S3 is a means of keeping multiple variants of an object
in the same bucket.

This commit adds support for loading resources of specific versions of
objects within a version-enabled bucket
e.g. `"s3://bucket/object^versionId"`

- Added version delimiter (`^`) to separate object names from version Ids
- Changed Amazon S3 clients use of `getObject()` and `getObjectMetadata()` to
  use `GetObjectRequest` and `GetObjectMetadataRequest` objects rather than
  just `"bucket"` and `"object"`
- Updated unit tests to match on use of `GetObjectRequest` and
  `GetObjectMetadataRequest` types rather than specific requests of `"bucket"`
  and `"object"`