### PR TITLE
Allow for the use of temporary credentials

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,8 +71,9 @@ configuration files that configure the necessary parameters to build the
 environment.
 
 Please create a new file named access.properties. This file must contain
-three properties named accessKey,secretKey and rdsPassword. These two
-properties accessKey and secretKey are account/user specific and should
+three properties named accessKey,secretKey and rdsPassword.  If you are
+using temporary credentials, it must also contain sessionToken.  The
+accessKey and secretKey properties are account/user specific and should
 never be shared to anyone. To retrieve these settings you have to open
 your account inside the AWS console and retrieve them through the
 https://portal.aws.amazon.com/gp/aws/securityCredentials[Security
@@ -87,6 +88,7 @@ An example file will look like this
 -------------------------------------------
 cloud.aws.credentials.accessKey=ilaugsjdlkahgsdlaksdhg
 cloud.aws.credentials.secretKey=aöksjdhöadjs,höalsdhjköalsdjhasd+
+cloud.aws.credentials.sessionToken=abcdefg    # only if using temporary credentials!
 rdsPassword=someVerySecretPassword
 -------------------------------------------
 

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ configuration files that configure the necessary parameters to build the
 environment.
 
 Please create a new file named access.properties. This file must contain
-three properties named accessKey,secretKey and rdsPassword.  If you are
+three properties named accessKey, secretKey and rdsPassword.  If you are
 using temporary credentials, it must also contain sessionToken.  The
 accessKey and secretKey properties are account/user specific and should
 never be shared to anyone. To retrieve these settings you have to open

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -48,6 +48,7 @@ public class ContextCredentialsAutoConfiguration {
 		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 			registerCredentialsProvider(registry, this.environment.getProperty("cloud.aws.credentials.accessKey"),
 					this.environment.getProperty("cloud.aws.credentials.secretKey"),
+					this.environment.getProperty("cloud.aws.credentials.sessionToken", String.class, ""),
 					this.environment.getProperty("cloud.aws.credentials.instanceProfile", Boolean.class, true) &&
 							!this.environment.containsProperty("cloud.aws.credentials.accessKey"),
 					this.environment.getProperty("cloud.aws.credentials.profileName", ProfilesConfigFile.DEFAULT_PROFILE_NAME),

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
@@ -37,7 +37,10 @@ public class ContextCredentialsConfigurationRegistrar implements ImportBeanDefin
 				importingClassMetadata.getAnnotationAttributes(EnableContextCredentials.class.getName(), false));
 		Assert.notNull(annotationAttributes,
 				"@EnableContextCredentials is not present on importing class " + importingClassMetadata.getClassName());
-		registerCredentialsProvider(registry, annotationAttributes.getString("accessKey"), annotationAttributes.getString("secretKey"),
+		registerCredentialsProvider(registry,
+				annotationAttributes.getString("accessKey"),
+				annotationAttributes.getString("secretKey"),
+				annotationAttributes.getString("sessionToken"),
 				annotationAttributes.getBoolean("instanceProfile"),
 				annotationAttributes.getString("profileName"),
 				annotationAttributes.getString("profilePath"));

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
@@ -51,7 +51,7 @@ public @interface EnableContextCredentials {
 	/**
 	 * Configures the session token that will be used by the credentials provider.  Only temporary credentials require
 	 * a session token to authenticate
-	 * @return secretKey that should be used for all web service requests
+	 * @return sessionToken that should be used for all web service requests
 	 */
 	String sessionToken() default "";
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
@@ -49,6 +49,13 @@ public @interface EnableContextCredentials {
 	String secretKey() default "";
 
 	/**
+	 * Configures the session token that will be used by the credentials provider.  Only temporary credentials require
+	 * a session token to authenticate
+	 * @return secretKey that should be used for all web service requests
+	 */
+	String sessionToken() default "";
+
+	/**
 	 * Enables a instance profile specific credentials provider
 	 * @return true if the instance profile credentials provider should be configured
 	 */

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.context.config.support;
 
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
@@ -68,15 +69,18 @@ public final class ContextConfigurationUtils {
 		AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider(registry, REGION_PROVIDER_BEAN_NAME);
 	}
 
-	public static void registerCredentialsProvider(BeanDefinitionRegistry registry, String accessKey, String secretKey, boolean instanceProfile, String profileName, String profilePath) {
+	public static void registerCredentialsProvider(BeanDefinitionRegistry registry, String accessKey, String secretKey, String sessionToken, boolean instanceProfile, String profileName, String profilePath) {
 		BeanDefinitionBuilder factoryBeanBuilder = BeanDefinitionBuilder.genericBeanDefinition(CredentialsProviderFactoryBean.class);
 
 		ManagedList<BeanDefinition> awsCredentialsProviders = new ManagedList<>();
 
 		if (StringUtils.hasText(accessKey)) {
-			BeanDefinitionBuilder credentials = BeanDefinitionBuilder.rootBeanDefinition(BasicAWSCredentials.class);
+			BeanDefinitionBuilder credentials = BeanDefinitionBuilder.rootBeanDefinition(sessionToken.isEmpty() ? BasicAWSCredentials.class : BasicSessionCredentials.class);
 			credentials.addConstructorArgValue(accessKey);
 			credentials.addConstructorArgValue(secretKey);
+			if(!sessionToken.isEmpty()) {
+				credentials.addConstructorArgValue(sessionToken);
+			}
 
 			BeanDefinitionBuilder provider = BeanDefinitionBuilder.rootBeanDefinition(StaticCredentialsProvider.class);
 			provider.addConstructorArgValue(credentials.getBeanDefinition());

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.aws.context.config.xml;
 
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -48,7 +50,7 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 
 	private static final String ACCESS_KEY_ATTRIBUTE_NAME = "access-key";
 	private static final String SECRET_KEY_ATTRIBUTE_NAME = "secret-key";
-
+	private static final String SESSION_TOKEN_ATTRIBUTE_NAME = "session-token";
 
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext) throws BeanDefinitionStoreException {
@@ -111,9 +113,17 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 	 * @return - the bean definition with an {@link com.amazonaws.auth.BasicAWSCredentials} class
 	 */
 	private static BeanDefinition getCredentials(Element credentialsProviderElement, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition("com.amazonaws.auth.BasicAWSCredentials");
+		boolean hasSessionToken = credentialsProviderElement.hasAttribute(SESSION_TOKEN_ATTRIBUTE_NAME);
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(hasSessionToken ? BasicSessionCredentials.class :
+				BasicAWSCredentials.class);
 		builder.addConstructorArgValue(getAttributeValue(ACCESS_KEY_ATTRIBUTE_NAME, credentialsProviderElement, parserContext));
 		builder.addConstructorArgValue(getAttributeValue(SECRET_KEY_ATTRIBUTE_NAME, credentialsProviderElement, parserContext));
+
+		if(hasSessionToken) {
+			builder.addConstructorArgValue(getAttributeValue(SESSION_TOKEN_ATTRIBUTE_NAME, credentialsProviderElement, parserContext));
+		}
+
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
@@ -279,6 +279,16 @@
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="session-token">
+			<xsd:annotation>
+				<xsd:documentation>
+					The session token which is assigned for the particular access key.  This is only needed when using temporary credentials.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:element name="stack-configuration">

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.aws.context.config.xml;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
@@ -105,6 +107,17 @@ public class ContextCredentialsBeanDefinitionParserTest {
 		this.expectedException.expectMessage("The 'secret-key' attribute must not be empty");
 		//noinspection ResultOfObjectAllocationIgnored
 		new ClassPathXmlApplicationContext(getClass().getSimpleName() + "-testWithEmptySecretKey.xml", getClass());
+	}
+
+	@Test
+	public void testWithSessionToken() throws Exception {
+		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(getClass().getSimpleName() + "-testWithSessionToken.xml", getClass());
+
+		AWSCredentialsProvider awsCredentialsProvider = applicationContext.getBean(AWSCredentialsProvider.class);
+		AWSSessionCredentials credentials = (AWSSessionCredentials) awsCredentialsProvider.getCredentials();
+		assertEquals("staticAccessKey", credentials.getAWSAccessKeyId());
+		assertEquals("staticSecretKey", credentials.getAWSSecretKey());
+		assertEquals("staticSessionToken", credentials.getSessionToken());
 	}
 
 	@Test

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithSessionToken.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithSessionToken.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2014 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="staticAccessKey" secret-key="staticSecretKey" session-token="staticSessionToken" />
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
@@ -31,7 +31,9 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
  * @author Agim Emruli
  */
 @Configuration
-@EnableContextCredentials(accessKey = "${cloud.aws.credentials.accessKey}", secretKey = "${cloud.aws.credentials.secretKey}")
+@EnableContextCredentials(accessKey = "${cloud.aws.credentials.accessKey}",
+		secretKey = "${cloud.aws.credentials.secretKey}",
+		sessionToken = "${cloud.aws.credentials.sessionToken:#{null}}")
 @EnableStackConfiguration(stackName = "IntegrationTestStack")
 @PropertySource("file://${els.config.dir}/access.properties")
 @EnableContextRegion(region = "eu-west-1")

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
@@ -24,7 +24,8 @@
                            http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
-		<aws-context:simple-credentials access-key="${cloud.aws.credentials.accessKey}" secret-key="${cloud.aws.credentials.secretKey}" />
+		<aws-context:simple-credentials access-key="${cloud.aws.credentials.accessKey}" secret-key="${cloud.aws.credentials.secretKey}"
+				session-token="${cloud.aws.credentials.sessionToken:#{null}}"/>
 	</aws-context:context-credentials>
 
 	<aws-context:context-region region="eu-west-1" />


### PR DESCRIPTION
This is especially useful when running the integration tests.  There is no need to establish a new IAM user.  Temporary credentials can be taken from any running instance with:

`curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials`
