### PR TITLE
Add redirect support to AmazonS3 operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-aws-core/pom.xml
+++ b/spring-cloud-aws-core/pom.xml
@@ -34,6 +34,10 @@
 			<artifactId>spring-beans</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-core</artifactId>
 		</dependency>

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.core.io.s3;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.util.ClassUtils;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.util.StringInputStream;
+
+/**
+ * Proxy to wrap an {@link AmazonS3} handler and handle redirects wrapped inside {@link AmazonS3Exception}.
+ *
+ * @author Greg Turnquist
+ * @since 1.1
+ */
+public class AmazonS3ProxyFactory {
+
+	private static final Logger log = LoggerFactory.getLogger(AmazonS3ProxyFactory.class);
+
+	/**
+	 * Take any {@link AmazonS3} and wrap it in a Spring AOP proxy to handle redirects.
+	 *
+	 * @param amazonS3
+	 * @return
+	 */
+	static AmazonS3 createProxy(AmazonS3 amazonS3) {
+
+		/**
+		 * Is this already a proxy? If so, don't wrap it again.
+		 */
+		if (AopUtils.isAopProxy(amazonS3)) {
+
+			Advised advised = (Advised) amazonS3;
+
+			/**
+			 * Already advised by {@link AmazonRedirectInterceptor}?
+			 */
+			for (Advisor advisor : advised.getAdvisors()) {
+				if (ClassUtils.isAssignableValue(AmazonRedirectInterceptor.class, advisor.getAdvice())) {
+					return amazonS3;
+				}
+			}
+
+			/**
+			 * If not, then add it.
+			 */
+			try {
+				advised.addAdvice(new AmazonRedirectInterceptor((AmazonS3) advised.getTargetSource().getTarget()));
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+
+			return amazonS3;
+		}
+
+		ProxyFactory factory = new ProxyFactory(amazonS3);
+		factory.setProxyTargetClass(true);
+		factory.addAdvice(new AmazonRedirectInterceptor(amazonS3));
+
+		return (AmazonS3) factory.getProxy();
+	}
+
+	/**
+	 * Listen for {@link AmazonS3} exceptions, handle the redirect, and try again.
+	 * Otherwise, rethrow the error.
+	 *
+	 * NOTE: This has the side effect of updating the S3 client for subsequent calls.
+	 */
+	static class AmazonRedirectInterceptor implements MethodInterceptor {
+
+		private final AmazonS3 amazonS3;
+
+		public AmazonRedirectInterceptor(AmazonS3 amazonS3) {
+			this.amazonS3 = amazonS3;
+		}
+
+		@Override
+		public Object invoke(MethodInvocation invocation) throws Throwable {
+
+			try {
+				return invocation.proceed();
+			} catch (AmazonS3Exception e) {
+				if (301 == e.getStatusCode()) {
+					handleAmazonS3Redirect(this.amazonS3, e);
+					return invocation.proceed();
+				} else {
+					throw e;
+				}
+			}
+		}
+
+		/**
+		 * Handle a 301 Redirect from Amazon S3 by parsing the endpoint.
+		 *
+		 * @param amazonS3
+		 * @param e
+		 */
+		private void handleAmazonS3Redirect(AmazonS3 amazonS3, AmazonS3Exception e) {
+
+			try {
+				Document errorResponseDoc = DocumentBuilderFactory
+						.newInstance()
+						.newDocumentBuilder()
+						.parse(new StringInputStream(e.getErrorResponseXml()));
+
+				XPathExpression endpointXpathExtr = XPathFactory.newInstance().newXPath().compile("/Error/Endpoint");
+
+				amazonS3.setEndpoint(endpointXpathExtr.evaluate(errorResponseDoc));
+			}
+			catch (Exception ex) {
+				throw new RuntimeException(e);
+			}
+
+		}
+	}
+
+}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
@@ -16,14 +16,16 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -32,12 +34,12 @@ import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 /**
  * A {@link ResourcePatternResolver} implementation which allows an ant-style path matching when
@@ -73,7 +75,7 @@ public class PathMatchingSimpleStorageResourcePatternResolver implements Resourc
 	public PathMatchingSimpleStorageResourcePatternResolver(AmazonS3 amazonS3, ResourceLoader simpleStorageResourceLoader,
 															ResourcePatternResolver resourcePatternResolverDelegate) {
 		Assert.notNull(amazonS3);
-		this.amazonS3 = amazonS3;
+		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 		this.simpleStorageResourceLoader = simpleStorageResourceLoader;
 		this.resourcePatternResolverDelegate = resourcePatternResolverDelegate;
 	}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -114,4 +114,5 @@ final class SimpleStorageNameUtils {
 		}
 		return location.substring(S3_PROTOCOL_PREFIX.length());
 	}
+
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -16,26 +16,6 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PartETag;
-import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.model.UploadPartResult;
-import com.amazonaws.util.BinaryUtils;
-import org.springframework.core.io.AbstractResource;
-import org.springframework.core.io.WritableResource;
-import org.springframework.core.task.TaskExecutor;
-import org.springframework.core.task.support.ExecutorServiceAdapter;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -53,6 +33,27 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
+
+import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.WritableResource;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.ExecutorServiceAdapter;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import com.amazonaws.util.BinaryUtils;
 
 /**
  * {@link org.springframework.core.io.Resource} implementation for {@code com.amazonaws.services.s3.model.S3Object}
@@ -77,7 +78,7 @@ class SimpleStorageResource extends AbstractResource implements WritableResource
 	}
 
 	SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor, String versionId) {
-		this.amazonS3 = amazonS3;
+		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 		this.bucketName = bucketName;
 		this.objectName = objectName;
 		this.taskExecutor = taskExecutor;

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -25,6 +24,8 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.util.ClassUtils;
+
+import com.amazonaws.services.s3.AmazonS3;
 
 /**
  * @author Agim Emruli
@@ -43,12 +44,12 @@ public class SimpleStorageResourceLoader implements ResourceLoader, Initializing
 	private TaskExecutor taskExecutor;
 
 	public SimpleStorageResourceLoader(AmazonS3 amazonS3, ResourceLoader delegate) {
-		this.amazonS3 = amazonS3;
+		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 		this.delegate = delegate;
 	}
 
 	public SimpleStorageResourceLoader(AmazonS3 amazonS3, ClassLoader classLoader) {
-		this.amazonS3 = amazonS3;
+		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 		this.delegate = new DefaultResourceLoader(classLoader);
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
@@ -1,0 +1,107 @@
+package org.springframework.cloud.aws.core.io.s3;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.object.IsCompatibleType.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+/**
+ * @author Greg Turnquist
+ */
+public class AmazonS3ProxyFactoryTest {
+
+	@Test
+	public void verifyBasicAdvice() throws Exception {
+
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		assertThat(AopUtils.isAopProxy(amazonS3), is(false));
+
+		AmazonS3 proxy = AmazonS3ProxyFactory.createProxy(amazonS3);
+		assertThat(AopUtils.isAopProxy(proxy), is(true));
+
+		Advised advised = (Advised) proxy;
+		assertThat(advised.getAdvisors().length, is(1));
+		assertThat(advised.getAdvisors()[0].getAdvice(),
+				instanceOf(AmazonS3ProxyFactory.AmazonRedirectInterceptor.class));
+		assertThat(AopUtils.isAopProxy(advised.getTargetSource().getTarget()), is(false));
+	}
+
+	@Test
+	public void verifyDoubleWrappingHandled() throws Exception {
+
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+
+		AmazonS3 proxy = AmazonS3ProxyFactory.createProxy(AmazonS3ProxyFactory.createProxy(amazonS3));
+		assertThat(AopUtils.isAopProxy(proxy), is(true));
+
+		Advised advised = (Advised) proxy;
+		assertThat(advised.getAdvisors().length, is(1));
+		assertThat(advised.getAdvisors()[0].getAdvice(),
+				instanceOf(AmazonS3ProxyFactory.AmazonRedirectInterceptor.class));
+		assertThat(AopUtils.isAopProxy(advised.getTargetSource().getTarget()), is(false));
+	}
+
+	@Test
+	public void verifyPolymorphicHandling() {
+
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		AmazonS3 proxy1 = AmazonS3ProxyFactory.createProxy(amazonS3);
+
+		assertThat(proxy1.getClass(), typeCompatibleWith(AmazonS3.class));
+		assertThat(proxy1.getClass(), not(typeCompatibleWith(AmazonS3Client.class)));
+
+		AmazonS3Client amazonS3Client = new AmazonS3Client();
+		AmazonS3 proxy2 = AmazonS3ProxyFactory.createProxy(amazonS3Client);
+
+		assertThat(proxy2.getClass(), typeCompatibleWith(AmazonS3.class));
+		assertThat(proxy2.getClass(), typeCompatibleWith(AmazonS3Client.class));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void verifyAddingRedirectAdviceToExistingProxy() {
+
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+
+		ProxyFactory factory = new ProxyFactory(amazonS3);
+		factory.addAdvice(new TestAdvice());
+		AmazonS3 proxy1 = (AmazonS3) factory.getProxy();
+
+		assertThat(((Advised) proxy1).getAdvisors().length, is(1));
+
+		AmazonS3 proxy2 = AmazonS3ProxyFactory.createProxy(proxy1);
+		Advised advised = (Advised) proxy2;
+
+		assertThat(advised.getAdvisors().length, is(2));
+
+		List<Class<? extends MethodInterceptor>> advisorClasses = new ArrayList<>();
+		for (Advisor advisor : advised.getAdvisors()) {
+			advisorClasses.add(((MethodInterceptor) advisor.getAdvice()).getClass());
+		}
+		assertThat(advisorClasses, hasItems(TestAdvice.class, AmazonS3ProxyFactory.AmazonRedirectInterceptor.class));
+
+	}
+
+	static class TestAdvice implements MethodInterceptor {
+
+		@Override
+		public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+			return methodInvocation.proceed();
+		}
+	}
+}

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -16,37 +16,38 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.junit.Test;
-import org.mockito.ArgumentMatcher;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.util.PathMatcher;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.PathMatcher;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 /**
  * @author Alain Sahli
  * @author Agim Emruli
+ * @author Greg Turnquist
  * @since 1.0
  */
 public class PathMatchingSimpleStorageResourcePatternResolverTest {
@@ -110,6 +111,41 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		patternResolver.getResources("s3://foo/bar");
 
 		verify(pathMatcher, times(1)).isPattern("foo/bar");
+	}
+
+	@Test
+	public void testWithRedirectError() throws Exception {
+		AmazonS3 amazonS3 = prepareMocksForRedirectError();
+
+		ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
+		Resource[] resources = resourceLoader.getResources("s3://spring.io/*.txt");
+		assertThat(resources.length, is(1));
+		assertThat(resources[0].contentLength(), is(5L));
+	}
+
+	private AmazonS3 prepareMocksForRedirectError() {
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+
+		AmazonS3Exception exception = new AmazonS3Exception("Mock error", "<Error><EndPoint>new.path.com</EndPoint></Error>");
+		exception.setStatusCode(301);
+
+		S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
+		s3ObjectSummary.setKey("stub_key.txt");
+		s3ObjectSummary.setBucketName("spring.io");
+
+		ObjectListing objectListing = new ObjectListing();
+		objectListing.setBucketName("spring.io");
+		objectListing.getObjectSummaries().add(s3ObjectSummary);
+
+		when(amazonS3.listObjects(any(ListObjectsRequest.class)))
+				.thenThrow(exception).thenReturn(objectListing);
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(5);
+
+		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(objectMetadata);
+
+		return amazonS3;
 	}
 
 	private AmazonS3 prepareMockForTestTruncatedListings() {


### PR DESCRIPTION
Doing s3 operations in buckets found in different regions causes AmazonS3 SDK to throw an AmazonS3Exception. This patch wraps AmazonS3 in a proxy that traps for 301 exceptions, parses the error response XML for the proper EndPoint, updates amazonS3, and tries again.
