### PR TITLE
#125 AutoDetectingStackNameProvider should use instance tags to support auto scaling groups

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,7 +23,6 @@ import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnv
 import org.springframework.cloud.aws.context.config.annotation.ContextDefaultConfigurationRegistrar;
 import org.springframework.cloud.aws.context.config.annotation.ContextStackConfiguration;
 import org.springframework.cloud.aws.core.env.stack.config.StackResourceRegistryFactoryBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
@@ -44,10 +42,10 @@ public class ContextStackAutoConfiguration {
 		private Environment environment;
 
 		@Override
-		@Bean
-		public StackResourceRegistryFactoryBean stackResourceRegistryFactoryBean(AmazonCloudFormation amazonCloudFormation) {
-			return new StackResourceRegistryFactoryBean(amazonCloudFormation, this.environment.getProperty("cloud.aws.stack.name"));
+		public String getStackName() {
+			return this.environment.getProperty("cloud.aws.stack.name");
 		}
+
 	}
 
 
@@ -58,9 +56,9 @@ public class ContextStackAutoConfiguration {
 	public static class StackAutoDetectConfiguration extends ContextStackConfiguration {
 
 		@Override
-		@Bean
-		public StackResourceRegistryFactoryBean stackResourceRegistryFactoryBean(AmazonCloudFormation amazonCloudFormation) {
-			return new StackResourceRegistryFactoryBean(amazonCloudFormation);
+		public String getStackName() {
+			return null;
 		}
+
 	}
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackNameProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackNameProvider.java
@@ -21,7 +21,7 @@ package org.springframework.cloud.aws.core.env.stack.config;
  *
  * @author Christian Stettler
  */
-interface StackNameProvider {
+public interface StackNameProvider {
 
 	/**
 	 * Returns the name of the current stack.

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
 import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.StackResourceSummary;
+
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.cloud.aws.core.env.stack.ListableStackResourceFactory;
 import org.springframework.cloud.aws.core.env.stack.StackResource;
@@ -47,14 +48,6 @@ public class StackResourceRegistryFactoryBean extends AbstractFactoryBean<Listab
 	public StackResourceRegistryFactoryBean(AmazonCloudFormation amazonCloudFormationClient, StackNameProvider stackNameProvider) {
 		this.amazonCloudFormationClient = amazonCloudFormationClient;
 		this.stackNameProvider = stackNameProvider;
-	}
-
-	public StackResourceRegistryFactoryBean(AmazonCloudFormation amazonCloudFormationClient, String stackName) {
-		this(amazonCloudFormationClient, new StaticStackNameProvider(stackName));
-	}
-
-	public StackResourceRegistryFactoryBean(AmazonCloudFormation amazonCloudFormationClient) {
-		this(amazonCloudFormationClient, new AutoDetectingStackNameProvider(amazonCloudFormationClient));
 	}
 
 	@Override

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StaticStackNameProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StaticStackNameProvider.java
@@ -24,11 +24,11 @@ import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
  * @author Christian Stettler
  */
 @RuntimeUse
-class StaticStackNameProvider implements StackNameProvider {
+public class StaticStackNameProvider implements StackNameProvider {
 
 	private final String stackName;
 
-	StaticStackNameProvider(String stackName) {
+	public StaticStackNameProvider(String stackName) {
 		this.stackName = stackName;
 	}
 


### PR DESCRIPTION
the main change is in `AutoDetectingStackNameProvider` and rather simple at that. If an `EC2Client` is available, it is used to describe the instance tags. Missing permissions to do so would require in an exception. This could be handled better but it is the same as for missing permissions to describe stack resources.

It wasn't easy to get the `AmazonEC2` client injected which is what caused all the other changes:

- `ContextStackConfiguration` uses autowired fields instead of methods
- `ContextStackAutoConfiguration` makes better reuse of the code from `ContextStackConfiguration`, only changing the way a static stack name is configured
- `StackNameProvider` and its implementation are now public, making it easier to customize
- `StackConfigurationBeanDefinitionParser` added attribute `amazon-ec2`