### PR TITLE
Conditional on aws cloud environment

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.aws.actuate.metrics.BufferingCloudWatchMetricSe
 import org.springframework.cloud.aws.actuate.metrics.CloudWatchMetricSender;
 import org.springframework.cloud.aws.actuate.metrics.CloudWatchMetricWriter;
 import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
 import org.springframework.cloud.aws.core.region.RegionProvider;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Import;
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableConfigurationProperties(CloudWatchMetricProperties.class)
 @ConditionalOnProperty(prefix = "cloud.aws.cloudwatch", name = "namespace")

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricAutoConfiguration.java
@@ -44,9 +44,9 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnAwsCloudEnvironment
+@ConditionalOnProperty(prefix = "cloud.aws.cloudwatch", name = "namespace")
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableConfigurationProperties(CloudWatchMetricProperties.class)
-@ConditionalOnProperty(prefix = "cloud.aws.cloudwatch", name = "namespace")
 public class CloudWatchMetricAutoConfiguration {
 
     @Autowired(required = false)

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -20,6 +20,7 @@ import net.spy.memcached.MemcachedClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
 import org.springframework.cloud.aws.cache.config.annotation.EnableElastiCache;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -27,6 +28,7 @@ import org.springframework.context.annotation.Import;
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableElastiCache
 @ConditionalOnClass(MemcachedClient.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnAwsCloudEnvironment
+@ConditionalOnClass(MemcachedClient.class)
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableElastiCache
-@ConditionalOnClass(MemcachedClient.class)
 public class ElastiCacheAutoConfiguration {
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.context;
 
 import com.amazonaws.auth.profile.ProfilesConfigFile;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.context.config.annotation.ContextDefaultConfigurationRegistrar;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +33,7 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import({ContextDefaultConfigurationRegistrar.class, ContextCredentialsAutoConfiguration.Registrar.class})
 public class ContextCredentialsAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -30,6 +31,7 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
 public class ContextRegionProviderAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.context.config.annotation.ContextResourceLoaderConfiguration;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import(ContextResourceLoaderAutoConfiguration.Registrar.class)
 public class ContextResourceLoaderAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.core.env.Environment;
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @Import({ContextCredentialsAutoConfiguration.class, ContextDefaultConfigurationRegistrar.class})
 public class ContextStackAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -43,11 +43,11 @@ import java.util.Map;
  */
 @Configuration
 @ConditionalOnAwsCloudEnvironment
-@AutoConfigureBefore(DataSourceAutoConfiguration.class)
-@Import(AmazonRdsDatabaseAutoConfiguration.Registrar.class)
 @ConditionalOnClass(name = {"com.amazonaws.services.rds.AmazonRDSClient",
 		"org.springframework.cloud.aws.jdbc.config.annotation.AmazonRdsInstanceConfiguration"})
 @ConditionalOnMissingBean(AmazonRdsInstanceConfiguration.class)
+@AutoConfigureBefore(DataSourceAutoConfiguration.class)
+@Import(AmazonRdsDatabaseAutoConfiguration.Registrar.class)
 public class AmazonRdsDatabaseAutoConfiguration {
 
 	public static class Registrar extends AmazonRdsInstanceConfiguration.AbstractRegistrar implements EnvironmentAware {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.bind.PropertySourceUtils;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.cloud.aws.jdbc.config.annotation.AmazonRdsInstanceConfiguration;
 import org.springframework.context.EnvironmentAware;
@@ -41,6 +42,7 @@ import java.util.Map;
  * @author Alain Sahli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @AutoConfigureBefore(DataSourceAutoConfiguration.class)
 @Import(AmazonRdsDatabaseAutoConfiguration.Registrar.class)
 @ConditionalOnClass(name = {"com.amazonaws.services.rds.AmazonRDSClient",

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
 import org.springframework.cloud.aws.core.region.RegionProvider;
 import org.springframework.cloud.aws.mail.simplemail.SimpleEmailServiceJavaMailSender;
@@ -39,6 +40,7 @@ import javax.mail.Session;
  * @author Agim Emruli
  */
 @Configuration
+@ConditionalOnAwsCloudEnvironment
 @ConditionalOnClass(MailSender.class)
 @Import(ContextCredentialsAutoConfiguration.class)
 public class MailSenderAutoConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
@@ -27,9 +27,9 @@ import org.springframework.context.annotation.Configuration;
  * @author Alain Sahli
  * @author Agim Emruli
  */
+@Configuration
 @ConditionalOnAwsCloudEnvironment
 @ConditionalOnClass(name = "org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer")
-@Configuration
 public class MessagingAutoConfiguration {
 
 	@ConditionalOnMissingBean(type = "org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer")

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.messaging;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.cloud.aws.messaging.config.annotation.EnableSns;
 import org.springframework.cloud.aws.messaging.config.annotation.EnableSqs;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Alain Sahli
  * @author Agim Emruli
  */
+@ConditionalOnAwsCloudEnvironment
 @ConditionalOnClass(name = "org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer")
 @Configuration
 public class MessagingAutoConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricWriterAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/actuate/CloudWatchMetricWriterAutoConfigurationTest.java
@@ -17,9 +17,13 @@
 package org.springframework.cloud.aws.autoconfigure.actuate;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.cloud.aws.actuate.metrics.BufferingCloudWatchMetricSender;
 import org.springframework.cloud.aws.actuate.metrics.CloudWatchMetricWriter;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
+import org.springframework.cloud.aws.autoconfigure.context.MetaDataServer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -32,7 +36,10 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Simon Buettner
  */
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class CloudWatchMetricWriterAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private MockEnvironment env;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
@@ -23,10 +23,14 @@ import com.amazonaws.services.elasticache.model.DescribeCacheClustersResult;
 import com.amazonaws.services.elasticache.model.Endpoint;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
+import org.springframework.cloud.aws.autoconfigure.context.MetaDataServer;
 import org.springframework.cloud.aws.core.env.stack.ListableStackResourceFactory;
 import org.springframework.cloud.aws.core.env.stack.StackResource;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -38,7 +42,10 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class ElastiCacheAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private AnnotationConfigApplicationContext context;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -23,8 +23,10 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import org.apache.http.client.CredentialsProvider;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.io.ClassPathResource;
@@ -40,7 +42,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Agim Emruli
  */
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class ContextCredentialsAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private AnnotationConfigApplicationContext context;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.aws.autoconfigure.context;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
 import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -31,7 +33,10 @@ import static org.junit.Assert.assertNotNull;
 /**
  * @author Agim Emruli
  */
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class ContextRegionProviderAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private AnnotationConfigApplicationContext context;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
 import org.springframework.cloud.aws.core.io.s3.PathMatchingSimpleStorageResourcePatternResolver;
 import org.springframework.cloud.aws.core.io.s3.SimpleStorageResourceLoader;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -31,7 +33,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class ContextResourceLoaderAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private AnnotationConfigApplicationContext context;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaData.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaData.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Rule;
+
+/**
+ * Describes the required context information for a given test using the
+ * {@link MetaDataServer} as a JUnit {@link Rule}.
+ *
+ * @author Matt Benson
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface MetaData {
+	/**
+	 * Describes a context served by the {@link MetaDataServer}.
+	 */
+	public @interface Context {
+		/**
+		 * Context path.
+		 */
+		String path();
+
+		/**
+		 * Context payload.
+		 */
+		String value() default "";
+
+		/**
+		 * Whether to use a {@code null} payload.
+		 */
+		boolean nullValue() default false;
+	}
+
+	/**
+	 * Context values to register with the {@link MetaDataServer}.
+	 */
+	Context[] value();
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
@@ -23,9 +23,13 @@ import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.amazonaws.services.rds.model.Endpoint;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
+import org.springframework.cloud.aws.autoconfigure.context.MetaDataServer;
 import org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean;
 import org.springframework.cloud.aws.jdbc.rds.AmazonRdsReadReplicaAwareDataSourceFactoryBean;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -37,7 +41,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class AmazonRdsDatabaseAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	private AnnotationConfigApplicationContext context;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfigurationTest.java
@@ -17,6 +17,9 @@
 package org.springframework.cloud.aws.autoconfigure.mail;
 
 import org.junit.Test;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData;
+import org.springframework.cloud.aws.autoconfigure.context.MetaData.Context;
+import org.springframework.cloud.aws.autoconfigure.context.MetaDataServer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -24,7 +27,12 @@ import org.springframework.mail.javamail.JavaMailSender;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
+import org.junit.ClassRule;
+
+@MetaData(@Context(path = "/latest/meta-data/instance-id", value = "testInstanceId"))
 public class MailSenderAutoConfigurationTest {
+	@ClassRule
+	public static MetaDataServer metaDataServer = new MetaDataServer();
 
 	@Test
 	public void mailSender_MailSenderWithJava_configuresJavaMailSender() throws Exception {
@@ -32,12 +40,18 @@ public class MailSenderAutoConfigurationTest {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(MailSenderAutoConfiguration.class);
 
-		//Act
-		context.refresh();
+		try {
+			// Act
+			context.refresh();
 
-		//Assert
-		assertNotNull(context.getBean(MailSender.class));
-		assertNotNull(context.getBean(JavaMailSender.class));
-		assertSame(context.getBean(MailSender.class), context.getBean(JavaMailSender.class));
+			// Assert
+			assertNotNull(context.getBean(MailSender.class));
+			assertNotNull(context.getBean(JavaMailSender.class));
+			assertSame(context.getBean(MailSender.class),
+					context.getBean(JavaMailSender.class));
+		}
+		finally {
+			context.close();
+		}
 	}
 }


### PR DESCRIPTION
As discussed on gitter, these changes preclude any of the spring-cloud-aws autoconfiguration from running when included in a non-AWS environment. I have signed the CLA.

_Edit:_ I see that the new CLA allows the system to know that automatically. Nice!
