### PR TITLE
Allow Spring Boot users to use the DefaultAWSCredentialsProviderChain

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -285,7 +285,14 @@ Spring Cloud AWS provides the following properties to configure the credentials 
 |cloud.aws.credentials.instanceProfile
 |true
 |Configures an instance profile credentials provider with no further configuration
+
+|cloud.aws.credentials.useDefaultAwsCredentialsChain
+|true
+|Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain
 |===
+
+
+
 
 ===== Configuring region
 Like for the credentials, the Spring Cloud AWS module also supports the configuration of the region inside the Spring

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -18,15 +18,18 @@ package org.springframework.cloud.aws.autoconfigure.context;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import org.apache.http.client.CredentialsProvider;
 import org.junit.After;
 import org.junit.Test;
-import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -69,6 +72,22 @@ public class ContextCredentialsAutoConfigurationTest {
 		assertEquals(2, credentialsProviders.size());
 		assertTrue(InstanceProfileCredentialsProvider.class.isInstance(credentialsProviders.get(0)));
 		assertTrue(ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)));
+	}
+
+
+	@Test
+	public void credentialsProvider_propertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider() {
+		this.context = new AnnotationConfigApplicationContext();
+		this.context.register(ContextCredentialsAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"cloud.aws.credentials.useDefaultAwsCredentialsChain:true"
+				);
+		this.context.refresh();
+
+		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME, AWSCredentialsProvider.class);
+		assertNotNull(awsCredentialsProvider);
+
+		assertTrue(awsCredentialsProvider.getClass().isAssignableFrom(DefaultAWSCredentialsProviderChain.class));
 	}
 
 	@Test
@@ -150,4 +169,6 @@ public class ContextCredentialsAutoConfigurationTest {
 		assertEquals("testAccessKey", provider.getCredentials().getAWSAccessKeyId());
 		assertEquals("testSecretKey", provider.getCredentials().getAWSSecretKey());
 	}
+
+
 }

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.context.config.support;
 
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
@@ -66,6 +67,12 @@ public final class ContextConfigurationUtils {
 
 		BeanDefinitionReaderUtils.registerBeanDefinition(new BeanDefinitionHolder(beanDefinition, REGION_PROVIDER_BEAN_NAME), registry);
 		AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider(registry, REGION_PROVIDER_BEAN_NAME);
+	}
+
+	public static void registerDefaultAWSCredentialsProvider(BeanDefinitionRegistry registry) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(DefaultAWSCredentialsProviderChain.class);
+		registry.registerBeanDefinition(CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME, builder.getBeanDefinition());
+		AmazonWebserviceClientConfigurationUtils.replaceDefaultCredentialsProvider(registry, CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME);
 	}
 
 	public static void registerCredentialsProvider(BeanDefinitionRegistry registry, String accessKey, String secretKey, boolean instanceProfile, String profileName, String profilePath) {


### PR DESCRIPTION
Amazon [recommends using the DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/java-sdk/latest/developer-guide/credentials.html) instead of creating a custom chain. 

The custom chain that is created has some limitations (notably for me, the lack of support for using session tokens) - rather than invest time in mapping custom spring properties, I would rather just use the DefaultAWSCredentialsProviderChain which allows me to specify environment variables for my access credentials when running locally and will use an InstanceProfile when running on my EC2 instance. 
