### PR TITLE
fix for default task executor having unbounded max pool size

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -103,11 +103,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	@Override
 	protected void initialize() {
+		super.initialize();
+
 		if (this.taskExecutor == null) {
 			this.defaultTaskExecutor = true;
 			this.taskExecutor = createDefaultTaskExecutor();
 		}
-		super.initialize();
+
 		initializeRunningStateByQueue();
 		this.scheduledFutureByQueue = new ConcurrentHashMap<>(getRegisteredQueues().size());
 	}
@@ -160,7 +162,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			threadPoolTaskExecutor.setCorePoolSize(spinningThreads * DEFAULT_WORKER_THREADS);
 
 			int maxNumberOfMessagePerBatch = getMaxNumberOfMessages() != null ? getMaxNumberOfMessages() : DEFAULT_WORKER_THREADS;
-			threadPoolTaskExecutor.setMaxPoolSize(spinningThreads * maxNumberOfMessagePerBatch);
+			threadPoolTaskExecutor.setMaxPoolSize(spinningThreads * (maxNumberOfMessagePerBatch + 1));
 		}
 
 		// No use of a thread pool executor queue to avoid retaining message to long in memory

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
@@ -49,6 +50,9 @@ import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.DestinationResolutionException;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.handler.HandlerMethod;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -57,6 +61,7 @@ import org.springframework.util.StopWatch;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -120,6 +125,36 @@ public class SimpleMessageListenerContainerTest {
 		ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) container.getTaskExecutor();
 		assertNotNull(taskExecutor);
 		assertEquals("testContainerName-", taskExecutor.getThreadNamePrefix());
+	}
+
+	@Test
+	public void testWithDefaultTaskExecutorAndOneHandler() throws Exception {
+		int testedMaxNumberOfMessages = 10;
+
+		Map<QueueMessageHandler.MappingInformation, HandlerMethod> messageHandlerMethods = Collections.singletonMap(
+				new QueueMessageHandler.MappingInformation(Collections.singleton("testQueue"),
+						SqsMessageDeletionPolicy.ALWAYS), (HandlerMethod) null);
+
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+
+		QueueMessageHandler mockedHandler = mock(QueueMessageHandler.class);
+		AmazonSQSAsync mockedSqs = mock(AmazonSQSAsync.class, withSettings().stubOnly());
+
+		when(mockedSqs.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(new GetQueueAttributesResult());
+		when(mockedSqs.getQueueUrl(any(GetQueueUrlRequest.class))).thenReturn(new GetQueueUrlResult().withQueueUrl("testQueueUrl"));
+		when(mockedHandler.getHandlerMethods()).thenReturn(messageHandlerMethods);
+
+		container.setMaxNumberOfMessages(testedMaxNumberOfMessages);
+		container.setAmazonSqs(mockedSqs);
+		container.setMessageHandler(mockedHandler);
+
+		container.afterPropertiesSet();
+
+		int expectedPoolMaxSize = messageHandlerMethods.size() * (testedMaxNumberOfMessages + 1);
+
+		ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) container.getTaskExecutor();
+		assertNotNull(taskExecutor);
+		assertEquals(expectedPoolMaxSize, taskExecutor.getMaxPoolSize());
 	}
 
 	@Test


### PR DESCRIPTION
The default task executor created in SimpleMessageListenerContainer has in all circumstances undefined max pool size. While this might not be extremely bad, it's a bit unnecessary and misleading. 

The reason is that inside the SimpleMessageListenerContainer.initialize method, the task executor is created before the call to super.initialize(). The createDefaultTaskExecutor() method uses the number of registered queues (getRegisteredQueues().size()) as the base for defining the max pool size, but the list of registered queues is created only when super.initialize() is called. So the order is wrong.

Added to that, the computed max pool size is wrong (spinningThreads *  maxNumberOfMessagePerBatch), because the SimpleMessageListenerContainer uses an extra thread per registered queue for fetching the messages. The proper number should be 

spinningThreads * (maxNumberOfMessagePerBatch + 1)

If only the first fix is applied (moving super.initialize() to the top of SimpleMessageListenerContainer.initialize), the threadpool will reject tasks, since it's queue size is 0.