### PR TITLE
Add ability to turn off Amazon client auto configuration.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.cloud.aws.context.config.annotation.ContextDefaultConfigurationRegistrar;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
@@ -31,10 +32,12 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
 @Import({ContextDefaultConfigurationRegistrar.class, ContextCredentialsAutoConfiguration.Registrar.class})
 @ConditionalOnClass(name = "com.amazonaws.auth.AWSCredentialsProvider")
+@ConditionalOnAwsEnabled
 public class ContextCredentialsAutoConfiguration {
 
     public static class Registrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -28,25 +29,27 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
+@ConditionalOnAwsEnabled
 public class ContextRegionProviderAutoConfiguration {
 
-    static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
+	static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
 
-        private Environment environment;
+		private Environment environment;
 
-        @Override
-        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
-            registerRegionProvider(registry, this.environment.getProperty("cloud.aws.region.auto", Boolean.class, true) &&
-                            !(this.environment.containsProperty("cloud.aws.region.static")),
-                    this.environment.getProperty("cloud.aws.region.static"));
-        }
+		@Override
+		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+			registerRegionProvider(registry, this.environment.getProperty("cloud.aws.region.auto", Boolean.class, true) &&
+							!(this.environment.containsProperty("cloud.aws.region.static")),
+					this.environment.getProperty("cloud.aws.region.static"));
+		}
 
-        @Override
-        public void setEnvironment(Environment environment) {
-            this.environment = environment;
-        }
-    }
+		@Override
+		public void setEnvironment(Environment environment) {
+			this.environment = environment;
+		}
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.autoconfigure.context;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.cloud.aws.context.config.annotation.ContextResourceLoaderConfiguration;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
@@ -28,10 +29,12 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
 @Import(ContextResourceLoaderAutoConfiguration.Registrar.class)
 @ConditionalOnClass(name = "com.amazonaws.services.s3.AmazonS3Client")
+@ConditionalOnAwsEnabled
 public class ContextResourceLoaderAutoConfiguration {
 
     public static class Registrar extends ContextResourceLoaderConfiguration.Registrar implements EnvironmentAware {

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 public class ContextCredentialsAutoConfigurationTest {
 
@@ -149,5 +151,15 @@ public class ContextCredentialsAutoConfigurationTest {
         ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders.get(1);
         assertEquals("testAccessKey", provider.getCredentials().getAWSAccessKeyId());
         assertEquals("testSecretKey", provider.getCredentials().getAWSSecretKey());
+    }
+
+    @Test
+    public void credentialsProvider_autoConfiguration_disabled() {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(ContextCredentialsAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(this.context,
+                "spring.cloud.aws.enabled:false");
+        this.context.refresh();
+        assertFalse(context.containsBean(AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME));
     }
 }

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnAwsEnabled.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnAwsEnabled.java
@@ -1,0 +1,17 @@
+package org.springframework.cloud.aws.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * @author Anwar Chirakkattil
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Conditional(OnAwsEnabledCondition.class)
+public @interface ConditionalOnAwsEnabled {
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnAwsEnabledCondition.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnAwsEnabledCondition.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.aws.context.annotation;
+
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static java.lang.Boolean.TRUE;
+import static org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION;
+
+/**
+ * @author Anwar Chirakkattil
+ */
+public class OnAwsEnabledCondition implements ConfigurationCondition {
+
+    private static final String SPRING_CLOUD_AWS_ENABLED = "spring.cloud.aws.enabled";
+
+    @Override
+    public ConfigurationPhase getConfigurationPhase() {
+        return PARSE_CONFIGURATION;
+    }
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        Boolean awsEnabled = Boolean.valueOf(context.getEnvironment().getProperty(SPRING_CLOUD_AWS_ENABLED, "true"));
+        return TRUE.equals(awsEnabled);
+    }
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.context.config.annotation;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -27,8 +28,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
+@ConditionalOnAwsEnabled
 public class ContextCredentialsConfigurationRegistrar implements ImportBeanDefinitionRegistrar {
 
     @Override

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextDefaultConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextDefaultConfigurationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.context.config.annotation;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -26,8 +27,10 @@ import org.springframework.core.type.AnnotationMetadata;
  * Configuration class that configures "default" beans that are used by all components.
  *
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
+@ConditionalOnAwsEnabled
 public class ContextDefaultConfigurationRegistrar implements ImportBeanDefinitionRegistrar {
 
     @Override

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.context.config.annotation;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -27,8 +28,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
+@ConditionalOnAwsEnabled
 public class ContextRegionConfigurationRegistrar implements ImportBeanDefinitionRegistrar {
 
     @Override

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.cloud.aws.context.support.io.ResourceLoaderBeanPostProcessor;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.context.annotation.Configuration;
@@ -31,9 +32,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * @author Agim Emruli
+ * @author Anwar Chirakkattil
  */
 @Configuration
 @Import(ContextResourceLoaderConfiguration.Registrar.class)
+@ConditionalOnAwsEnabled
 public class ContextResourceLoaderConfiguration {
 
     public static class Registrar implements ImportBeanDefinitionRegistrar {

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnAwsEnabledConditionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnAwsEnabledConditionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.annotation;
+
+import org.junit.Test;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Anwar Chirakkattil
+ */
+public class OnAwsEnabledConditionTest {
+
+    @Test
+    public void condition_default_includes_shouldCreateBeanFoo() throws Exception {
+        // Arrange & Act
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(OnAwsEnabledConditionTest.ConfigWithAwsEnabledCondition.class);
+
+        // Assert
+        assertTrue(applicationContext.containsBean("foo"));
+    }
+
+    @Test
+    public void condition_withAwsDisabled_shouldNotCreateBeanFoo() throws Exception {
+        // Arrange & Act
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.register(ConfigWithAwsEnabledCondition.class);
+        EnvironmentTestUtils.addEnvironment(applicationContext, "spring.cloud.aws.enabled:false");
+        applicationContext.refresh();
+
+        // Assert
+        assertFalse(applicationContext.containsBean("foo"));
+    }
+
+    @Configuration
+    @ConditionalOnAwsEnabled
+    protected static class ConfigWithAwsEnabledCondition {
+
+        @Bean
+        public String foo() {
+            return "foo";
+        }
+    }
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
@@ -22,8 +22,13 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsEnabled;
 import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.RegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -154,6 +159,24 @@ public class ContextRegionConfigurationRegistrarTest {
         //Assert
     }
 
+    @Test
+    public void regionProvider_withAwsDisabled() throws Exception {
+
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(ApplicationConfigurationWithAwsDisabled.class);
+        this.expectedException.expect(BeansException.class);
+        this.expectedException.expectMessage("No qualifying bean of type 'org.springframework.cloud.aws.core.region.RegionProvider' available");
+
+        EnvironmentTestUtils.addEnvironment(this.context, "spring.cloud.aws.enabled:false");
+
+        //Act
+        this.context.refresh();
+
+        //Assert
+        this.context.getBean(RegionProvider.class);
+    }
+
+
     @Configuration
     @EnableContextRegion(region = "eu-west-1")
     static class ApplicationConfigurationWithStaticRegionProvider {
@@ -197,6 +220,13 @@ public class ContextRegionConfigurationRegistrarTest {
     @Configuration
     @EnableContextRegion(region = "eu-wast-1")
     static class ApplicationConfigurationWithWrongRegion {
+
+    }
+
+    @Configuration
+    @EnableContextRegion
+    @ConditionalOnAwsEnabled
+    static class ApplicationConfigurationWithAwsDisabled {
 
     }
 }


### PR DESCRIPTION
 By default everything is turned on and hence all changes are backward compatible. 
 Specifying property `spring.cloud.aws.enabled=false` will turn off auto configuration
 Fixes #227