### PR TITLE
Maven Configuration Improvements

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -34,7 +34,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
+				<version>${maven-deploy-plugin.version}</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 		<tomcat.version>8.0.33</tomcat.version>
 		<javax-mail.version>1.5.5</javax-mail.version>
 		<log4j.version>1.2.17</log4j.version>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-aws-actuator/pom.xml
+++ b/spring-cloud-aws-actuator/pom.xml
@@ -26,6 +26,8 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-aws-actuator</artifactId>
+	<name>Spring Cloud AWS Actuator</name>
+	<description>Spring Cloud AWS Actuator</description>
 
 	<dependencies>
 		<dependency>

--- a/spring-cloud-aws-context/pom.xml
+++ b/spring-cloud-aws-context/pom.xml
@@ -25,8 +25,8 @@
 	</parent>
 
 	<artifactId>spring-cloud-aws-context</artifactId>
-	<name>Spring Cloud AWS Context Module</name>
-	<description>Spring Cloud AWS Context Module</description>
+	<name>Spring Cloud AWS Context</name>
+	<description>Spring Cloud AWS Context</description>
 
 	<dependencies>
 		<dependency>

--- a/spring-cloud-aws-core/pom.xml
+++ b/spring-cloud-aws-core/pom.xml
@@ -25,8 +25,8 @@
 	</parent>
 
 	<artifactId>spring-cloud-aws-core</artifactId>
-	<name>Spring Cloud AWS Core Module</name>
-	<description>Spring Cloud AWS Core Module</description>
+	<name>Spring Cloud AWS Core</name>
+	<description>Spring Cloud AWS Core</description>
 
 	<dependencies>
 		<dependency>

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -27,7 +27,7 @@
 	<artifactId>spring-cloud-aws-dependencies</artifactId>
 	<version>1.2.2.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<name>spring-cloud-aws-dependencies</name>
+	<name>Spring Cloud AWS Dependencies</name>
 	<description>Spring Cloud AWS Dependencies</description>
 	<properties>
 		<aws-java-sdk.version>1.11.125</aws-java-sdk.version>

--- a/spring-cloud-aws-jdbc/pom.xml
+++ b/spring-cloud-aws-jdbc/pom.xml
@@ -25,8 +25,8 @@
 	</parent>
 
 	<artifactId>spring-cloud-aws-jdbc</artifactId>
-	<name>Spring Cloud AWS Jdbc Module</name>
-	<description>Spring Cloud AWS Jdbc Module</description>
+	<name>Spring Cloud AWS JDBC</name>
+	<description>Spring Cloud AWS JDBC</description>
 
 	<dependencies>
 		<dependency>

--- a/spring-cloud-aws-messaging/pom.xml
+++ b/spring-cloud-aws-messaging/pom.xml
@@ -25,8 +25,8 @@
 	</parent>
 
 	<artifactId>spring-cloud-aws-messaging</artifactId>
-	<name>Spring Cloud AWS Messaging Module</name>
-	<description>Spring Cloud AWS Messaging Module</description>
+	<name>Spring Cloud AWS Messaging</name>
+	<description>Spring Cloud AWS Messaging</description>
 
 	<dependencies>
 		<dependency>

--- a/spring-cloud-starter-aws-jdbc/pom.xml
+++ b/spring-cloud-starter-aws-jdbc/pom.xml
@@ -24,8 +24,8 @@
 		<version>1.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-aws-jdbc</artifactId>
-	<name>spring-cloud-starter-aws-jdbc</name>
-	<description>Spring Cloud Starter AWS JDBC</description>
+	<name>Spring Cloud AWS JDBC Starter</name>
+	<description>Spring Cloud AWS JDBC Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>

--- a/spring-cloud-starter-aws-messaging/pom.xml
+++ b/spring-cloud-starter-aws-messaging/pom.xml
@@ -24,8 +24,8 @@
 		<version>1.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-aws-messaging</artifactId>
-	<name>spring-cloud-starter-aws-messaging</name>
-	<description>Spring Cloud Starter AWS Messaging</description>
+	<name>Spring Cloud AWS Messaging Starter</name>
+	<description>Spring Cloud AWS Messaging Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>

--- a/spring-cloud-starter-aws/pom.xml
+++ b/spring-cloud-starter-aws/pom.xml
@@ -24,8 +24,8 @@
 		<version>1.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-aws</artifactId>
-	<name>spring-cloud-starter-aws</name>
-	<description>Spring Cloud Starter AWS</description>
+	<name>Spring Cloud AWS Starter</name>
+	<description>Spring Cloud AWS Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>


### PR DESCRIPTION
This PR applies a consistent naming convention to all modules, inspired by other Spring projects.

This also resolves a minor build warning by specifying the version of the `maven-deploy-plugin`.