### PR TITLE
Add Support for FIFO SQS Queues

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
@@ -82,7 +82,7 @@ public class QueueMessageChannel extends AbstractMessageChannel implements Polla
             sendMessageRequest.setMessageGroupId(message.getHeaders().get(SqsMessageHeaders.SQS_GROUP_ID_HEADER, String.class));
         }
 
-        if (message.getHeaders().containsKey(SqsMessageHeaders.SQS_GROUP_ID_HEADER)) {
+        if (message.getHeaders().containsKey(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER)) {
             sendMessageRequest.setMessageDeduplicationId(message.getHeaders().get(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER, String.class));
         }
 
@@ -143,7 +143,9 @@ public class QueueMessageChannel extends AbstractMessageChannel implements Polla
     }
 
     private static boolean isSkipHeader(String headerName) {
-        return SqsMessageHeaders.SQS_DELAY_HEADER.equals(headerName);
+        return SqsMessageHeaders.SQS_DELAY_HEADER.equals(headerName) ||
+        		SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER.equals(headerName) ||
+        		SqsMessageHeaders.SQS_GROUP_ID_HEADER.equals(headerName);
     }
 
     private MessageAttributeValue getBinaryMessageAttribute(ByteBuffer messageHeaderValue) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
@@ -78,6 +78,14 @@ public class QueueMessageChannel extends AbstractMessageChannel implements Polla
     private SendMessageRequest prepareSendMessageRequest(Message<?> message) {
         SendMessageRequest sendMessageRequest = new SendMessageRequest(this.queueUrl, String.valueOf(message.getPayload()));
 
+        if (message.getHeaders().containsKey(SqsMessageHeaders.SQS_GROUP_ID_HEADER)) {
+            sendMessageRequest.setMessageGroupId(message.getHeaders().get(SqsMessageHeaders.SQS_GROUP_ID_HEADER, String.class));
+        }
+
+        if (message.getHeaders().containsKey(SqsMessageHeaders.SQS_GROUP_ID_HEADER)) {
+            sendMessageRequest.setMessageDeduplicationId(message.getHeaders().get(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER, String.class));
+        }
+
         if (message.getHeaders().containsKey(SqsMessageHeaders.SQS_DELAY_HEADER)) {
             sendMessageRequest.setDelaySeconds(message.getHeaders().get(SqsMessageHeaders.SQS_DELAY_HEADER, Integer.class));
         }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -31,7 +31,7 @@ public class SqsMessageHeaders extends MessageHeaders {
 
     public static final String SQS_DELAY_HEADER = "delay";
     public static final String SQS_GROUP_ID_HEADER = "message-group-id";
-    public static final Object SQS_DEDUPLICATION_ID_HEADER = "message-deduplication-id";
+    public static final String SQS_DEDUPLICATION_ID_HEADER = "message-deduplication-id";
 
 
     public SqsMessageHeaders(Map<String, Object> headers) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -30,6 +30,9 @@ import java.util.Map;
 public class SqsMessageHeaders extends MessageHeaders {
 
     public static final String SQS_DELAY_HEADER = "delay";
+    public static final String SQS_GROUP_ID_HEADER = "message-group-id";
+    public static final Object SQS_DEDUPLICATION_ID_HEADER = "message-deduplication-id";
+
 
     public SqsMessageHeaders(Map<String, Object> headers) {
         super(headers);

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
@@ -632,4 +632,44 @@ public class QueueMessageChannelTest {
         assertNull(sendMessageRequest.getDelaySeconds());
         assertFalse(sendMessageRequest.getMessageAttributes().containsKey(SqsMessageHeaders.SQS_DELAY_HEADER));
     }
+    
+    @Test
+    public void sendMessage_withGroupIdHeader_shouldSetGroupIdOnSendMessageRequestAndNotSetItAsHeaderAsMessageAttribute() throws Exception {
+        // Arrange
+        AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
+
+        ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        when(amazonSqs.sendMessage(sendMessageRequestArgumentCaptor.capture())).thenReturn(new SendMessageResult());
+
+        QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs, "http://testQueue");
+        Message<String> message = MessageBuilder.withPayload("Hello").setHeader(SqsMessageHeaders.SQS_GROUP_ID_HEADER, "id-5").build();
+
+        // Act
+        queueMessageChannel.send(message);
+
+        // Assert
+        SendMessageRequest sendMessageRequest = sendMessageRequestArgumentCaptor.getValue();
+        assertEquals("id-5", sendMessageRequest.getMessageGroupId());
+        assertFalse(sendMessageRequest.getMessageAttributes().containsKey(SqsMessageHeaders.SQS_GROUP_ID_HEADER));
+    }
+    
+    @Test
+    public void sendMessage_withDeduplicationIdHeader_shouldSetDeduplicationIdOnSendMessageRequestAndNotSetItAsHeaderAsMessageAttribute() throws Exception {
+        // Arrange
+        AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
+
+        ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        when(amazonSqs.sendMessage(sendMessageRequestArgumentCaptor.capture())).thenReturn(new SendMessageResult());
+
+        QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs, "http://testQueue");
+        Message<String> message = MessageBuilder.withPayload("Hello").setHeader(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER, "id-5").build();
+
+        // Act
+        queueMessageChannel.send(message);
+
+        // Assert
+        SendMessageRequest sendMessageRequest = sendMessageRequestArgumentCaptor.getValue();
+        assertEquals("id-5", sendMessageRequest.getMessageDeduplicationId());
+        assertFalse(sendMessageRequest.getMessageAttributes().containsKey(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER));
+    }
 }


### PR DESCRIPTION
FIFO SQS Queues require population of `Message Group Id` and optionally a `Deduplication Id`.  This PR allows both of those properties to be set via headers in the input `Message<>`.  

Closes #246 