### PR TITLE
fix  MessageAttributeDataTypes (Number)

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
@@ -32,7 +32,12 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
-
+/**
+ * @author Agim Emruli
+ * @author Alain Sahli
+ * @author Bart Van Loocke
+ * @since 1.0
+ */
 public class TopicMessageChannel extends AbstractMessageChannel {
 
     public static final String NOTIFICATION_SUBJECT_HEADER = "NOTIFICATION_SUBJECT_HEADER";
@@ -56,7 +61,7 @@ public class TopicMessageChannel extends AbstractMessageChannel {
     private final AmazonSNS amazonSns;
     private final String topicArn;
 
-    public CorrectedTopicMessageChannel(AmazonSNS amazonSns, String topicArn) {
+    public TopicMessageChannel(AmazonSNS amazonSns, String topicArn) {
         this.amazonSns = amazonSns;
         this.topicArn = topicArn;
     }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.aws.messaging.core;
 
+
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
+import org.springframework.cloud.aws.messaging.core.MessageAttributeDataTypes;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.AbstractMessageChannel;
@@ -30,19 +32,31 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Agim Emruli
- * @author Alain Sahli
- * @since 1.0
- */
+
 public class TopicMessageChannel extends AbstractMessageChannel {
 
     public static final String NOTIFICATION_SUBJECT_HEADER = "NOTIFICATION_SUBJECT_HEADER";
 
+
+
+    public static final String INT = "Number.int";
+
+    public static final String BOOLEAN = "Number.Boolean";
+
+    public static final String BYTE = "Number.byte";
+
+    public static final String DOUBLE = "Number.double";
+
+    public static final String FLOAT = "Number.float";
+
+    public static final String LONG = "Number.long";
+
+    public static final String SHORT = "Number.short";
+
     private final AmazonSNS amazonSns;
     private final String topicArn;
 
-    public TopicMessageChannel(AmazonSNS amazonSns, String topicArn) {
+    public CorrectedTopicMessageChannel(AmazonSNS amazonSns, String topicArn) {
         this.amazonSns = amazonSns;
         this.topicArn = topicArn;
     }
@@ -108,7 +122,30 @@ public class TopicMessageChannel extends AbstractMessageChannel {
 
     private MessageAttributeValue getNumberMessageAttribute(Object messageHeaderValue) {
         Assert.isTrue(NumberUtils.STANDARD_NUMBER_TYPES.contains(messageHeaderValue.getClass()), "Only standard number types are accepted as message header.");
+        String type = getType(messageHeaderValue);
 
-        return new MessageAttributeValue().withDataType(MessageAttributeDataTypes.NUMBER + "." + messageHeaderValue.getClass().getName()).withStringValue(messageHeaderValue.toString());
+        return new MessageAttributeValue().withDataType(type).withStringValue(messageHeaderValue.toString());
+
+    }
+
+    private static String getType(Object value) {
+        if (value instanceof Integer) {
+            return INT;
+        } else if (value instanceof Long) {
+            return LONG;
+        } else if (value instanceof Boolean) {
+            return BOOLEAN;
+        } else if (value instanceof Byte) {
+            return BYTE;
+        } else if (value instanceof Double) {
+            return DOUBLE;
+        } else if (value instanceof Float) {
+            return FLOAT;
+        } else if (value instanceof Short) {
+            return SHORT;
+        } else {
+           return MessageAttributeDataTypes.NUMBER + "." + value.getClass().getName();
+        }
     }
 }
+

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
@@ -153,17 +153,17 @@ public class TopicMessageChannelTest {
         // Assert
         assertTrue(sent);
         Map<String, MessageAttributeValue> messageAttributes = publishRequestArgumentCaptor.getValue().getMessageAttributes();
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Double", messageAttributes.get("double").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".double", messageAttributes.get("double").getDataType());
         assertEquals(String.valueOf(doubleValue), messageAttributes.get("double").getStringValue());
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Long", messageAttributes.get("long").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".long", messageAttributes.get("long").getDataType());
         assertEquals(String.valueOf(longValue), messageAttributes.get("long").getStringValue());
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Integer", messageAttributes.get("integer").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".int", messageAttributes.get("integer").getDataType());
         assertEquals(String.valueOf(integerValue), messageAttributes.get("integer").getStringValue());
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Byte", messageAttributes.get("byte").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".byte", messageAttributes.get("byte").getDataType());
         assertEquals(String.valueOf(byteValue), messageAttributes.get("byte").getStringValue());
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Short", messageAttributes.get("short").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".short", messageAttributes.get("short").getDataType());
         assertEquals(String.valueOf(shortValue), messageAttributes.get("short").getStringValue());
-        assertEquals(MessageAttributeDataTypes.NUMBER + ".java.lang.Float", messageAttributes.get("float").getDataType());
+        assertEquals(MessageAttributeDataTypes.NUMBER + ".float", messageAttributes.get("float").getDataType());
         assertEquals(String.valueOf(floatValue), messageAttributes.get("float").getStringValue());
         assertEquals(MessageAttributeDataTypes.NUMBER + ".java.math.BigInteger", messageAttributes.get("bigInteger").getDataType());
         assertEquals(String.valueOf(bigIntegerValue), messageAttributes.get("bigInteger").getStringValue());


### PR DESCRIPTION
possible values are Number.int & Number.long

The Amazon SQS Java Messaging Library will fail on this (SNS-SQS) 
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/getting-started.html