### PR TITLE
Fixes gh-298

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -23,11 +23,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerRegionProvider;
 
 /**
+ * Region auto configuration, based on <a href=https://cloud.spring.io/spring-cloud-aws/spring-cloud-aws.html#_configuring_region>cloud.aws.region</a>
+ * settings
+ *
  * @author Agim Emruli
+ * @author Petromir Dzhunev
  */
 @Configuration
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
@@ -40,7 +45,7 @@ public class ContextRegionProviderAutoConfiguration {
         @Override
         public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
             registerRegionProvider(registry, this.environment.getProperty("cloud.aws.region.auto", Boolean.class, true) &&
-                            !(this.environment.containsProperty("cloud.aws.region.static")),
+                            !StringUtils.hasText(this.environment.getProperty("cloud.aws.region.static")),
                     this.environment.getProperty("cloud.aws.region.static"));
         }
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Agim Emruli
+ * @author Petromir Dzhunev
  */
 public class ContextRegionProviderAutoConfigurationTest {
 
@@ -49,6 +50,21 @@ public class ContextRegionProviderAutoConfigurationTest {
         this.context = new AnnotationConfigApplicationContext();
         this.context.register(ContextRegionProviderAutoConfiguration.class);
         TestPropertyValues.of("cloud.aws.region.auto").applyTo(this.context);
+
+        //Act
+        this.context.refresh();
+
+        //Assert
+        assertNotNull(this.context.getBean(Ec2MetadataRegionProvider.class));
+    }
+
+    @Test
+    public void regionProvider_autoDetectionConfigured_emptyStaticRegionConfigured_Ec2metaDataRegionProviderConfigured() throws Exception {
+        //Arrange
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(ContextRegionProviderAutoConfiguration.class);
+        TestPropertyValues.of("cloud.aws.region.auto").applyTo(this.context);
+        TestPropertyValues.of("cloud.aws.region.static:").applyTo(this.context);
 
         //Act
         this.context.refresh();


### PR DESCRIPTION
Check for existence of cloud.aws.region.static is change to not fail when empty string is used.