### PR TITLE
Do cloudwatch autoconfiguration before the fallback is configured

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Jon Schneider
  * @author Dawid Kublik
+ * @author Jan Sauer
  * @since 2.0.0
  */
 @Configuration

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -23,6 +23,11 @@ import io.micrometer.cloudwatch.CloudWatchConfig;
 import io.micrometer.cloudwatch.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -44,6 +49,9 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @Import(ContextCredentialsAutoConfiguration.class)
+@AutoConfigureBefore({ CompositeMeterRegistryAutoConfiguration.class,
+        SimpleMetricsExportAutoConfiguration.class })
+@AutoConfigureAfter(MetricsAutoConfiguration.class)
 @EnableConfigurationProperties(CloudWatchProperties.class)
 @ConditionalOnProperty(prefix = "management.metrics.export.cloudwatch", name = "namespace")
 @ConditionalOnClass({CloudWatchMeterRegistry.class, RegionProvider.class})


### PR DESCRIPTION
`simpleMeterRegistry` is created befor the cloudwatch registry. This leads to
two `MeterRegistry` beans and a `NoUniqueBeanDefinitionException`.

This PR adds `AutoConfigureBefore` and `AutoConfigureAfter` annotations, as
done by the other sring-boot-actuator-autoconfigure exporters. This ensures
that the cloudwatch configuration is done befor simplemeter, which is then no
longer created.

Fixes #301