### PR TITLE
Update AWS SDK and Jackson dependencies.

### DIFF
--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -30,10 +30,9 @@
 	<name>Spring Cloud AWS Dependencies</name>
 	<description>Spring Cloud AWS Dependencies</description>
 	<properties>
-		<aws-java-sdk.version>1.11.251</aws-java-sdk.version>
+		<aws-java-sdk.version>1.11.336</aws-java-sdk.version>
 		<elasticache.version>1.1.1</elasticache.version>
 		<jmemcached.version>1.0.0</jmemcached.version>
-		<jackson.version>2.9.3</jackson.version>
 		<spring-cloud-context.version>1.3.2.RELEASE</spring-cloud-context.version>
 	</properties>
 	<dependencyManagement>
@@ -69,13 +68,6 @@
 						<groupId>commons-logging</groupId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson</groupId>
-				<artifactId>jackson-bom</artifactId>
-				<version>${jackson.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>com.thimbleware.jmemcached</groupId>


### PR DESCRIPTION
- AWS SDK dependencies updated to latest version
- removed usage of jackson-bom and leaving it for Spring Boot dependency management

Fixes #327 for `2.0` branch.
Should solve #313.