### PR TITLE
Add ability to customize MessageConverters for SQS listeners

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -29,6 +29,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Arrays;
 
 /**
  * @author Alain Sahli
@@ -82,8 +85,9 @@ public class SqsConfiguration {
             this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
         }
 
-        if (this.mappingJackson2MessageConverter != null) {
-            this.queueMessageHandlerFactory.setMappingJackson2MessageConverter(this.mappingJackson2MessageConverter);
+        if (CollectionUtils.isEmpty(this.queueMessageHandlerFactory.getMessageConverters())
+                && this.mappingJackson2MessageConverter != null) {
+            this.queueMessageHandlerFactory.setMessageConverters(Arrays.asList(this.mappingJackson2MessageConverter));
         }
 
         this.queueMessageHandlerFactory.setBeanFactory(this.beanFactory);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -28,9 +28,11 @@ import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerCon
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 
 /**
  * @author Alain Sahli
+ * @author Maciej Walkowiak
  * @since 1.0
  */
 @Configuration
@@ -48,6 +50,9 @@ public class SqsConfiguration {
 
     @Autowired(required = false)
     private final QueueMessageHandlerFactory queueMessageHandlerFactory = new QueueMessageHandlerFactory();
+
+    @Autowired(required = false)
+    private MappingJackson2MessageConverter mappingJackson2MessageConverter;
 
     @Bean
     public SimpleMessageListenerContainer simpleMessageListenerContainer(AmazonSQSAsync amazonSqs) {
@@ -75,6 +80,10 @@ public class SqsConfiguration {
     private QueueMessageHandler getMessageHandler(AmazonSQSAsync amazonSqs) {
         if (this.queueMessageHandlerFactory.getAmazonSqs() == null) {
             this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
+        }
+
+        if (this.mappingJackson2MessageConverter != null) {
+            this.queueMessageHandlerFactory.setMappingJackson2MessageConverter(this.mappingJackson2MessageConverter);
         }
 
         this.queueMessageHandlerFactory.setBeanFactory(this.beanFactory);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -30,7 +30,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.converter.CompositeMessageConverter;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.SimpleMessageConverter;
 import org.springframework.messaging.handler.HandlerMethod;
@@ -69,14 +68,14 @@ public class QueueMessageHandler extends AbstractMethodMessageHandler<QueueMessa
     static final String ACKNOWLEDGMENT = "Acknowledgment";
     static final String VISIBILITY = "Visibility";
 
-    private final MappingJackson2MessageConverter mappingJackson2MessageConverter;
+    private final List<MessageConverter> messageConverters;
 
-    public QueueMessageHandler(MappingJackson2MessageConverter mappingJackson2MessageConverter) {
-        this.mappingJackson2MessageConverter = mappingJackson2MessageConverter;
+    public QueueMessageHandler(List<MessageConverter> messageConverters) {
+        this.messageConverters = messageConverters;
     }
 
     public QueueMessageHandler() {
-        this.mappingJackson2MessageConverter = null;
+        this.messageConverters = Collections.emptyList();
     }
 
     @Override
@@ -216,11 +215,7 @@ public class QueueMessageHandler extends AbstractMethodMessageHandler<QueueMessa
     }
 
     private CompositeMessageConverter createPayloadArgumentCompositeConverter() {
-        List<MessageConverter> payloadArgumentConverters = new ArrayList<>();
-
-        if (this.mappingJackson2MessageConverter != null) {
-            payloadArgumentConverters.add(this.mappingJackson2MessageConverter);
-        }
+        List<MessageConverter> payloadArgumentConverters = new ArrayList<>(this.messageConverters);
 
         ObjectMessageConverter objectMessageConverter = new ObjectMessageConverter();
         objectMessageConverter.setStrictContentTypeMatch(true);

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -667,7 +667,7 @@ public class QueueMessageHandlerTest {
 
         @Bean
         QueueMessageHandler queueMessageHandler() {
-            return new QueueMessageHandler(mappingJackson2MessageConverter());
+            return new QueueMessageHandler(Arrays.asList(mappingJackson2MessageConverter()));
         }
 
         @Bean

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -35,10 +35,14 @@ import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 import org.springframework.cloud.aws.messaging.config.annotation.NotificationMessage;
 import org.springframework.cloud.aws.messaging.config.annotation.NotificationSubject;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.MethodParameter;
@@ -82,6 +86,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Agim Emruli
  * @author Alain Sahli
+ * @author Maciej Walkowiak
  * @since 1.0
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -112,15 +117,13 @@ public class QueueMessageHandlerTest {
 
     @Test
     public void receiveMessage_methodWithCustomObjectAsParameter_parameterIsConverted() {
-        StaticApplicationContext applicationContext = new StaticApplicationContext();
-        applicationContext.registerSingleton("incomingMessageHandler", IncomingMessageHandlerWithCustomParameter.class);
-        applicationContext.registerSingleton("queueMessageHandler", QueueMessageHandler.class);
-        applicationContext.refresh();
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(QueueMessageHandlerWithJacksonConfiguration.class);
+
+        DummyKeyValueHolder messagePayload = new DummyKeyValueHolder("myKey", "A value");
+        MappingJackson2MessageConverter jsonMapper = applicationContext.getBean(MappingJackson2MessageConverter.class);
+        Message<?> message = jsonMapper.toMessage(messagePayload, new MessageHeaders(Collections.singletonMap(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue")));
 
         MessageHandler messageHandler = applicationContext.getBean(MessageHandler.class);
-        DummyKeyValueHolder messagePayload = new DummyKeyValueHolder("myKey", "A value");
-        MappingJackson2MessageConverter jsonMapper = new MappingJackson2MessageConverter();
-        Message<?> message = jsonMapper.toMessage(messagePayload, new MessageHeaders(Collections.singletonMap(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue")));
         messageHandler.handleMessage(message);
 
         IncomingMessageHandlerWithCustomParameter messageListener = applicationContext.getBean(IncomingMessageHandlerWithCustomParameter.class);
@@ -657,6 +660,25 @@ public class QueueMessageHandlerTest {
         public void receive(String message) {
         }
 
+    }
+
+    @TestConfiguration
+    static class QueueMessageHandlerWithJacksonConfiguration {
+
+        @Bean
+        QueueMessageHandler queueMessageHandler() {
+            return new QueueMessageHandler(mappingJackson2MessageConverter());
+        }
+
+        @Bean
+        IncomingMessageHandlerWithCustomParameter incomingMessageHandlerWithCustomParameter() {
+            return new IncomingMessageHandlerWithCustomParameter();
+        }
+
+        @Bean
+        MappingJackson2MessageConverter mappingJackson2MessageConverter() {
+            return new MappingJackson2MessageConverter();
+        }
     }
 
 }


### PR DESCRIPTION
- since Jackson is always on the classpath it's safe to use it without conditional check
- allows to customize `MessageConverter`s by setting it on `QueueMessageHandlerFactory`
- if not set, default `MappingJackson2MessageConverter` is used
- no runtime dependency to `spring-web` anymore

Fixes: #292, #193, potentially #264