### PR TITLE
Remove unnecessary S3 API call

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
@@ -257,9 +257,7 @@ public class PathMatchingSimpleStorageResourcePatternResolver implements Resourc
             String keyPath = SimpleStorageNameUtils.getLocationForBucketAndObject(bucketName, objectSummary.getKey());
             if (this.pathMatcher.match(keyPattern, objectSummary.getKey())) {
                 Resource resource = this.resourcePatternResolverDelegate.getResource(keyPath);
-                if (resource.exists()) {
-                    resources.add(resource);
-                }
+                resources.add(resource);
             }
         }
 


### PR DESCRIPTION
When creating a Resource from an ObjectSummary, we already know that the
object exists. Otherwise, we would not have an ObjectSummary about it.

So we can remove the exists() check, which causes a HEAD request for
every single matching object.

This reduces the number of HTTP calls from n+1 to 1.