### PR TITLE
Fix exception for SimpleStorageNameUtils.getObjectNameFromLocation("s3://myBucket/")

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -66,11 +66,16 @@ final class SimpleStorageNameUtils {
             return getObjectNameFromLocation(location.substring(0, location.indexOf(VERSION_DELIMITER)));
         }
 
+        int endIndex = location.length();
         if (location.endsWith(PATH_DELIMITER)) {
-            return location.substring(++bucketEndIndex, location.length() - 1);
+            endIndex--;
         }
 
-        return location.substring(++bucketEndIndex, location.length());
+        if (bucketEndIndex >= endIndex) {
+            return "";
+        }
+
+        return location.substring(++bucketEndIndex, endIndex);
     }
 
     static String getVersionIdFromLocation(String location) {

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -68,6 +68,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
         ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
 
         assertEquals("test the single '*' wildcard", 2, resourceLoader.getResources("s3://myBucket/foo*/bar*/test.txt").length);
+        assertEquals("test the bucket name only", 1, resourceLoader.getResources("s3://myBucket/").length);
         assertEquals("test the '?' wildcard", 2, resourceLoader.getResources("s3://myBucke?/fooOne/ba?One/test.txt").length);
         assertEquals("test the double '**' wildcard", 5, resourceLoader.getResources("s3://myBucket/**/test.txt").length);
         assertEquals("test all together", 5, resourceLoader.getResources("s3://myBucke?/**/*.txt").length);
@@ -94,6 +95,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
         assertEquals("Test that all parts are returned when object summaries are truncated", 5, resourceLoader.getResources("s3://myBucket/**/test.txt").length);
         assertEquals("Test that all parts are return when common prefixes are truncated", 1, resourceLoader.getResources("s3://myBucket/fooOne/ba*/test.txt").length);
+        assertEquals("Test that all parts are returned when only bucket name is used", 1, resourceLoader.getResources("s3://myBucket/").length);
     }
 
     private AmazonS3 prepareMockForTestTruncatedListings() {

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
@@ -104,6 +104,7 @@ public class SimpleStorageNameUtilsTest {
     public void testGetObjectNameFromLocation() throws Exception {
         assertEquals("bar", getObjectNameFromLocation("s3://foo/bar"));
         assertEquals("ba*", getObjectNameFromLocation("s3://foo/ba*"));
+        assertEquals("", getObjectNameFromLocation("s3://foo/"));
         assertEquals("bar", getObjectNameFromLocation("s3://foo/bar^versionIdValue"));
 
         assertEquals("bar/baz/boo", getObjectNameFromLocation("s3://foo/bar/baz/boo/"));


### PR DESCRIPTION
A call to `resourcePatternResolver.getResources("s3://myBucket/*")` results
in a StringIndexOutOfBoundsException.