### PR TITLE
AWS Secrets Manager Configuration

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -40,6 +40,9 @@ which can be used with JDBC or any other support data access technology by Sprin
 point-to-point communication. Publish-subscribe messaging is supported with the integration of the http://aws.amazon.com/sns/[Simple Notification Service].
 * *Spring Cloud AWS Parameter Store Configuration* enables Spring Cloud applications to use the https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html[AWS Parameter Store]
 as a Bootstrap Property Source, comparable to the support provided for the Spring Cloud Config Server or Consul's key-value store.
+* *Spring Cloud AWS Secrets Manager Configuration* enables Spring Cloud applications to use the https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager]
+as a Bootstrap Property Source, comparable to the support provided for the Spring Cloud Config Server or Consul's key-value store.
+
 
 == Basic setup
 Before using the Spring Cloud AWS module developers have to pick the dependencies and configure the Spring Cloud AWS module.
@@ -116,7 +119,7 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
 ==== SDK credentials configuration
 In order to make calls to the Amazon Web Service the credentials must be configured for the the Amazon SDK. Spring Cloud AWS
 provides support to configure an application context specific credentials that are used for _each_ service call for requests done
-by Spring Cloud AWS components, with the exception of the Parameter Store Configuration.
+by Spring Cloud AWS components, with the exception of the Parameter Store and Secrets Manager Configuration.
 Therefore there must be *exactly one* configuration of the credentials for an entire application context.
 
 [TIP]
@@ -190,8 +193,8 @@ The access-key and secret-key are defined using a placeholder expressions along 
 errors if the properties are not configured at all.
 ====
 
-===== Parameter Store Configuration credentials and region configuration
-The Parameter Store Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
+===== Parameter Store and Secrets Manager Configuration credentials and region configuration
+The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
 client, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and `com.amazonaws.regions.DefaultAwsRegionProviderChain`.
 If you want to override this, then you need to
 http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
@@ -663,6 +666,77 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 |`aws.paramstore.enabled`
 |`true`
 |Can be used to disable the Parameter Store Configuration support even though the auto-configuration is on the classpath.
+|===
+
+=== Integrating your Spring Cloud application with the AWS Secrets Manager
+
+Spring Cloud provides support for centralized configuration, which can be read and made available as a regular Spring
+`PropertySource` when the application is started. The Secrets Manager Configuration allows you to use this mechanism
+with the https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager].
+
+Simply add a dependency on the `spring-cloud-starter-aws-secrets-manager-config` starter module to activate the support.
+The support is similar to the support provided for the Spring Cloud Config Server or Consul's key-value store:
+configuration parameters can be defined to be shared across all services or for a specific service and can be
+profile-specific.
+
+All configuration parameters are retrieved from a common path prefix, which defaults to `/secret`. From there shared
+parameters are retrieved from a path that defaults to `application` and service-specific parameters use a path that
+defaults to the configured `spring.application.name`. You can use both dots and forward slashes to specify the names
+of configuration keys. Names of activated profiles will be appended to the path using a separator that defaults to an
+underscore.
+
+That means that for a service called `my-service` the module by default would find and use these parameters:
+[cols="2*", options="header"]
+|===
+|parameter key
+|description
+
+|`/secret/application`
+|Shared by all services that have the Configuration support enabled. Can be overridden with a service- or profile-specific property.
+
+|`/secret/application_production`
+|Shared by all services that have the Configuration support enabled and have a `production` Spring profile activated.
+ Can be overridden with a service-specific property.
+
+|`/secret/my-service`
+|Specific to the `my-service` service..
+
+|`/secret/my-service_production`
+|Specific to the `my-service` service when a `production` Spring profile is activated.
+|===
+
+You can configure the following settings in a Spring Cloud `bootstrap.properties` or `bootstrap.yml` file
+(note that relaxed property binding is applied, so you don't have to use this exact syntax):
+[cols="3*", options="header"]
+|===
+|property
+|default
+|explanation
+
+|`aws.secretsmanager.prefix`
+|`/secret`
+|Prefix indicating first level for every property loaded from the Secrets Manager.
+ Value must start with a forward slash followed by one or more valid path segments or be empty.
+
+|`aws.secretsmanager.defaultContext`
+|`application`
+|Name of the context that defines properties shared across all services
+
+|`aws.secretsmanager.profileSeparator`
+|`_`
+|String that separates an appended profile from the context name.
+
+|`aws.secretsmanager.failFast`
+|`true`
+|Indicates if an error while retrieving the secrets should fail starting the application.
+
+|`aws.secretsmanager.name`
+|the configured value for `spring.application.name`
+|Name to use when constructing the path for the properties to look up for this specific service.
+
+|`aws.secretsmanager.enabled`
+|`true`
+|Can be used to disable the Secrets Manager Configuration support even though the auto-configuration is on the classpath.
 |===
 
 == Managing cloud environments

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,12 @@
 		<module>spring-cloud-aws-autoconfigure</module>
 		<module>spring-cloud-aws-actuator</module>
 		<module>spring-cloud-aws-parameter-store-config</module>
+		<module>spring-cloud-aws-secrets-manager-config</module>
 		<module>spring-cloud-starter-aws</module>
 		<module>spring-cloud-starter-aws-jdbc</module>
 		<module>spring-cloud-starter-aws-messaging</module>
 		<module>spring-cloud-starter-aws-parameter-store-config</module>
+		<module>spring-cloud-starter-aws-secrets-manager-config</module>
 		<module>docs</module>
 	</modules>
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -101,6 +101,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-aws-secrets-manager-config</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-aws-context</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -132,6 +137,11 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-aws-secrets-manager-config/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2014 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-aws</artifactId>
+		<version>2.0.2.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
+	<name>Spring Cloud AWS Secrets Manager Configuration</name>
+	<description>Spring Cloud AWS Secrets Manager Configuration</description>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-context</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+/**
+ * Configuration properties for the AWS Secrets Manager integration.
+ * Mostly based on the Spring Cloud Consul Configuration equivalent.
+ *
+ * @author Fabio Maia
+ * @since 2.0.0
+ */
+@ConfigurationProperties(AwsSecretsManagerProperties.CONFIG_PREFIX)
+@Validated
+public class AwsSecretsManagerProperties {
+
+    public static final String CONFIG_PREFIX = "aws.secretsmanager";
+
+    /**
+     * Prefix indicating first level for every property.
+     * Value must start with a forward slash followed by a valid path segment or be empty.
+     * Defaults to "/config".
+     */
+    @NotNull @Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
+    private String prefix = "/secret";
+    @NotEmpty
+    private String defaultContext = "application";
+    @NotNull @Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
+    private String profileSeparator = "_";
+
+    /** Throw exceptions during config lookup if true, otherwise, log warnings. */
+    private boolean failFast = true;
+
+    /** Alternative to spring.application.name to use in looking up values in AWS Secrets Manager. */
+    private String name;
+
+    /** Is AWS Secrets Manager support enabled. */
+    private boolean enabled = true;
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getDefaultContext() {
+        return defaultContext;
+    }
+
+    public void setDefaultContext(String defaultContext) {
+        this.defaultContext = defaultContext;
+    }
+
+    public String getProfileSeparator() {
+        return profileSeparator;
+    }
+
+    public void setProfileSeparator(String profileSeparator) {
+        this.profileSeparator = profileSeparator;
+    }
+
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.env.EnumerablePropertySource;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Retrieves secret value under the given context / path from the AWS Secrets Manager
+ * using the provided SM client.
+ *
+ * @author Fabio Maia
+ * @since 2.0.0
+ */
+public class AwsSecretsManagerPropertySource extends EnumerablePropertySource<AWSSecretsManager> {
+    private final ObjectMapper jsonMapper = new ObjectMapper();
+
+    private String context;
+    private Map<String, Object> properties = new LinkedHashMap<>();
+
+    public AwsSecretsManagerPropertySource(String context, AWSSecretsManager smClient) {
+        super(context, smClient);
+        this.context = context;
+    }
+
+    public void init() {
+        GetSecretValueRequest secretValueRequest = new GetSecretValueRequest();
+        secretValueRequest.setSecretId(context);
+        readSecretValue(secretValueRequest);
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        Set<String> strings = properties.keySet();
+        return strings.toArray(new String[strings.size()]);
+    }
+
+    @Override
+    public Object getProperty(String name) {
+        return properties.get(name);
+    }
+
+    private void readSecretValue(GetSecretValueRequest secretValueRequest) {
+        try {
+            GetSecretValueResult secretValueResult = source.getSecretValue(secretValueRequest);
+            Map<String, Object> secretMap = jsonMapper.readValue(secretValueResult.getSecretString(), new TypeReference<Map<String, Object>>(){});
+
+            for (Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
+                properties.put(secretEntry.getKey(), secretEntry.getValue());
+            }
+        }
+        catch(ResourceNotFoundException e) {
+            logger.debug("AWS secret not found from " + secretValueRequest.getSecretId());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.util.ReflectionUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds a {@link CompositePropertySource} with various {@link AwsSecretsManagerPropertySource} instances based on
+ * active profiles, application name and default context permutations.
+ * Mostly copied from Spring Cloud Consul's config support.
+ *
+ * @author Fabio Maia
+ * @since 2.0.0
+ */
+public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLocator {
+
+    private AWSSecretsManager smClient;
+    private AwsSecretsManagerProperties properties;
+    private List<String> contexts = new ArrayList<>();
+
+    private Log logger = LogFactory.getLog(getClass());
+
+    public AwsSecretsManagerPropertySourceLocator(AWSSecretsManager smClient, AwsSecretsManagerProperties properties) {
+        this.smClient = smClient;
+        this.properties = properties;
+    }
+
+    public List<String> getContexts() {
+        return contexts;
+    }
+
+    @Override
+    public PropertySource<?> locate(Environment environment) {
+        if (!(environment instanceof ConfigurableEnvironment)) {
+            return null;
+        }
+
+        ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
+
+        String appName = properties.getName();
+
+        if (appName == null) {
+            appName = env.getProperty("spring.application.name");
+        }
+
+        List<String> profiles = Arrays.asList(env.getActiveProfiles());
+
+        String prefix = this.properties.getPrefix();
+
+        String defaultContext = prefix + "/" + this.properties.getDefaultContext();
+        this.contexts.add(defaultContext);
+        addProfiles(this.contexts, defaultContext, profiles);
+
+        String baseContext = prefix + "/" + appName;
+        this.contexts.add(baseContext);
+        addProfiles(this.contexts, baseContext, profiles);
+
+        Collections.reverse(this.contexts);
+
+        CompositePropertySource composite = new CompositePropertySource("aws-secrets-manager");
+
+        for (String propertySourceContext : this.contexts) {
+            try {
+                composite.addPropertySource(create(propertySourceContext));
+            } catch (Exception e) {
+                if (this.properties.isFailFast()) {
+                    logger.error("Fail fast is set and there was an error reading configuration from AWS Secrets Manager:\n"
+                        + e.getMessage());
+                    ReflectionUtils.rethrowRuntimeException(e);
+                } else {
+                    logger.warn("Unable to load AWS secret from " + propertySourceContext, e);
+                }
+            }
+        }
+
+        return composite;
+    }
+
+    private AwsSecretsManagerPropertySource create(String context) {
+        AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(context, this.smClient);
+        propertySource.init();
+        return propertySource;
+    }
+
+    private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
+        for (String profile : profiles) {
+            contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+        }
+    }
+
+}

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AwsSecretsManagerPropertySourceTest {
+
+    private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
+    private AwsSecretsManagerPropertySource propertySource =
+            new AwsSecretsManagerPropertySource("/config/myservice", smClient);
+
+    @Test
+    public void shouldParseSecretValue() {
+        GetSecretValueResult secretValueResult = new GetSecretValueResult();
+        secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+
+        when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+            .thenReturn(secretValueResult);
+
+        propertySource.init();
+
+        assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2");
+        assertThat(propertySource.getProperty("key1")).isEqualTo("value1");
+        assertThat(propertySource.getProperty("key2")).isEqualTo("value2");
+    }
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager-config/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2014 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-aws</artifactId>
+		<version>2.0.2.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-cloud-starter-aws-secrets-manager-config</artifactId>
+	<name>Spring Cloud AWS Secrets Manager Configuration Starter</name>
+	<description>Spring Cloud AWS Secrets Manager Configuration Starter</description>
+	<url>https://projects.spring.io/spring-cloud</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>https://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<!-- note that we don't depend on spring-cloud-aws-autoconfigure: that module brings in
+		     spring-cloud-aws-context and unwanted autoconfiguration when you just want to use
+		     the Secrets Manager configuration support.
+		     We simply include our own auto-configuration for Spring Cloud in this starter instead. -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties(AwsSecretsManagerProperties.class)
-//@AutoConfigureAfter(ContextRegionProviderAutoConfiguration.class)
 @ConditionalOnClass({ AWSSecretsManager.class, AwsSecretsManagerPropertySourceLocator.class })
 @ConditionalOnProperty(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX, name= "enabled", matchIfMissing = true)
 public class AwsSecretsManagerBootstrapConfiguration {

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerProperties;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Cloud Bootstrap Configuration for setting up an {@link AwsSecretsManagerPropertySourceLocator} and its
+ * dependencies.
+ *
+ * @author Fabio Maia
+ * @since 2.0.0
+ */
+@Configuration
+@EnableConfigurationProperties(AwsSecretsManagerProperties.class)
+//@AutoConfigureAfter(ContextRegionProviderAutoConfiguration.class)
+@ConditionalOnClass({ AWSSecretsManager.class, AwsSecretsManagerPropertySourceLocator.class })
+@ConditionalOnProperty(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX, name= "enabled", matchIfMissing = true)
+public class AwsSecretsManagerBootstrapConfiguration {
+
+    @Bean
+    AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(
+            AWSSecretsManager smClient, AwsSecretsManagerProperties properties) {
+        return new AwsSecretsManagerPropertySourceLocator(smClient, properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    AWSSecretsManager smClient() {
+        return AWSSecretsManagerClientBuilder.defaultClient();
+    }
+
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+org.springframework.cloud.aws.autoconfigure.secretsmanager.AwsSecretsManagerBootstrapConfiguration

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.provides
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-cloud-aws-secrets-manager-config


### PR DESCRIPTION
(Disclaimer: Heavly inspired on AWS Parameter Store pull request)

The spring-cloud-aws-autoconfigure has a non-optional dependency on spring-cloud-aws-context, so depending on it triggers all sorts of unwanted autoconfiguration. Excluding the -context module from the secrets-manager starter doesn't work either, as some autoconfiguration classes import classes from the -context module. Therefore we simply provde our own (Spring Cloud) autoconfiguration in the starter.