### PR TITLE
accessKey or secretKey exists Disable DefaultAWSCredentialsProviderChain

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.StringUtils;
 
 import static com.amazonaws.auth.profile.internal.AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerCredentialsProvider;
@@ -50,11 +51,12 @@ public class ContextCredentialsAutoConfiguration {
         @Override
         public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
             Boolean useDefaultCredentialsChain = this.environment.getProperty("cloud.aws.credentials.useDefaultAwsCredentialsChain", Boolean.class, false);
-            if (useDefaultCredentialsChain) {
+            String accessKey = this.environment.getProperty("cloud.aws.credentials.accessKey");
+            String secretKey = this.environment.getProperty("cloud.aws.credentials.secretKey");
+            if (useDefaultCredentialsChain && (StringUtils.isEmpty(accessKey) || StringUtils.isEmpty(secretKey))) {
                 registerDefaultAWSCredentialsProvider(registry);
             } else {
-                registerCredentialsProvider(registry, this.environment.getProperty("cloud.aws.credentials.accessKey"),
-                        this.environment.getProperty("cloud.aws.credentials.secretKey"),
+                registerCredentialsProvider(registry, accessKey, secretKey,
                         this.environment.getProperty("cloud.aws.credentials.instanceProfile", Boolean.class, true) &&
                                 !this.environment.containsProperty("cloud.aws.credentials.accessKey"),
                         this.environment.getProperty("cloud.aws.credentials.profileName", DEFAULT_PROFILE_NAME),

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -74,6 +74,23 @@ public class ContextCredentialsAutoConfigurationTest {
 
 
     @Test
+    public void credentialsProvider_propertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider_existAccessKeyAndSecretKey() {
+        this.context = new AnnotationConfigApplicationContext();
+        this.context.register(ContextCredentialsAutoConfiguration.class);
+        TestPropertyValues.of(
+                "cloud.aws.credentials.accessKey:testAccessKey",
+                "cloud.aws.credentials.secretKey:testSecretKey",
+                "cloud.aws.credentials.useDefaultAwsCredentialsChain:true").applyTo(this.context);
+        this.context.refresh();
+
+        AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME, AWSCredentialsProvider.class);
+        assertNotNull(awsCredentialsProvider);
+
+        assertEquals("testAccessKey", awsCredentialsProvider.getCredentials().getAWSAccessKeyId());
+        assertEquals("testSecretKey", awsCredentialsProvider.getCredentials().getAWSSecretKey());
+    }
+
+    @Test
     public void credentialsProvider_propertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider() {
         this.context = new AnnotationConfigApplicationContext();
         this.context.register(ContextCredentialsAutoConfiguration.class);


### PR DESCRIPTION
If the accessKey or secretKey property exists, I think it is better not to use DefaultAWSCredentialsProviderChain.