### PR TITLE
Support path separator for profile separation.

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -45,7 +45,7 @@ public class AwsParamStoreProperties {
     private String prefix = "/config";
     @NotEmpty
     private String defaultContext = "application";
-    @NotNull @Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
+    @NotNull @Pattern(regexp = "[a-zA-Z0-9.\\-_/]+")
     private String profileSeparator = "_";
 
     /** Throw exceptions during config lookup if true, otherwise, log warnings. */


### PR DESCRIPTION
We would like to be able to use path separators for profiles to be able to specify profile specific config under a separate path like: `/some-base-path/my-application/dev/...`