### PR TITLE
Align default number of worker threads to default SQS batch size

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
@@ -58,7 +58,8 @@ abstract class AbstractMessageListenerContainer
 
 	private static final String RECEIVING_MESSAGE_ATTRIBUTES = "All";
 
-	private static final int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
+	//Visible to child classes for thread pool sizing
+	protected static final int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
 
 	private static final int DEFAULT_WAIT_TIME_IN_SECONDS = 20;
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -201,7 +201,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					.setCorePoolSize(spinningThreads * DEFAULT_WORKER_THREADS);
 
 			int maxNumberOfMessagePerBatch = getMaxNumberOfMessages() != null
-					? getMaxNumberOfMessages() : DEFAULT_WORKER_THREADS;
+					? getMaxNumberOfMessages() : DEFAULT_MAX_NUMBER_OF_MESSAGES;
 			threadPoolTaskExecutor
 					.setMaxPoolSize(spinningThreads * (maxNumberOfMessagePerBatch + 1));
 		}


### PR DESCRIPTION
This is a continuation of the discussion in #359.  The default number of worker threads was less than the default number of messages pulled per batch from SQS, so this resulted in `TaskRejectedException`s being thrown.

Are there any concerns around increasing the default threads to 10 to match the SQS batch size?