### PR TITLE
Treat queueStopTimeout as milliseconds

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -149,7 +149,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
             if (queueSpinningThread != null) {
                 try {
-                    queueSpinningThread.get(getQueueStopTimeout(), TimeUnit.SECONDS);
+                    queueSpinningThread.get(getQueueStopTimeout(), TimeUnit.MILLISECONDS);
                 } catch (ExecutionException | TimeoutException e) {
                     getLogger().warn("An exception occurred while stopping queue '" + logicalQueueName + "'", e);
                 } catch (InterruptedException e) {


### PR DESCRIPTION
SimpleMessageListenerContainer::getQueueStopTimeout returns 10000 milliseconds as default value. The timeout was mistakenly handled as seconds which caused a timeout of ~166hours.