### PR TITLE
Make some S3 related classes and methods public

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
@@ -54,7 +54,7 @@ public class AmazonS3ProxyFactory {
      *         change the underlying implementation.
      * @return AOP-Proxy that intercepts all method calls using the {@link SimpleStorageRedirectInterceptor}
      */
-    static AmazonS3 createProxy(AmazonS3 amazonS3) {
+    public static AmazonS3 createProxy(AmazonS3 amazonS3) {
         Assert.notNull(amazonS3, "AmazonS3 client must not be null");
 
         if (AopUtils.isAopProxy(amazonS3)) {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -62,7 +62,7 @@ import java.util.concurrent.Future;
  * @author Alain Sahli
  * @since 1.0
  */
-class SimpleStorageResource extends AbstractResource implements WritableResource {
+public class SimpleStorageResource extends AbstractResource implements WritableResource {
 
     private final String bucketName;
     private final String objectName;
@@ -72,11 +72,11 @@ class SimpleStorageResource extends AbstractResource implements WritableResource
 
     private volatile ObjectMetadata objectMetadata;
 
-    SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor) {
+    public SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor) {
         this(amazonS3, bucketName, objectName, taskExecutor, null);
     }
 
-    SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor, String versionId) {
+    public SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor, String versionId) {
         this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
         this.bucketName = bucketName;
         this.objectName = objectName;


### PR DESCRIPTION
`SimpleStorageResource` was package private making it difficult to use outside of this library. Making this public allows users to use or extend this convenient `Resource` implementation in ways the library doesn't currently support.

`AmazonS3ProxyFactory` was a public class but the factory method was package private. Making this public lets others leverage the convienent AOP logic contained within for S3 clients.