### PR TITLE
Add configuration properties bindings

### DIFF
--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -103,6 +103,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
+import static com.amazonaws.auth.profile.internal.AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
+import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerCredentialsProvider;
+import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerDefaultAWSCredentialsProvider;
+
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,10 +34,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.StringUtils;
 
-import static com.amazonaws.auth.profile.internal.AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
-import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerCredentialsProvider;
-import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerDefaultAWSCredentialsProvider;
-
 /**
  * @author Agim Emruli
  */
@@ -42,21 +42,21 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @ConditionalOnClass(name = "com.amazonaws.auth.AWSCredentialsProvider")
 public class ContextCredentialsAutoConfiguration {
 
-    /**
-     * The prefix used for AWS credentials related properties.
-     */
-    public static final String AWS_CREDENTIALS_PROPERTY_PREFIX = "cloud.aws.credentials";
+	/**
+	 * The prefix used for AWS credentials related properties.
+	 */
+	public static final String AWS_CREDENTIALS_PROPERTY_PREFIX = "cloud.aws.credentials";
 
-    /**
-     * Bind AWS credentials related properties to a property instance.
-     *
-     * @return An {@link AwsCredentialsProperties} instance
-     */
-    @Bean
-    @ConfigurationProperties(prefix = AWS_CREDENTIALS_PROPERTY_PREFIX)
-    public AwsCredentialsProperties awsCredentialsProperties() {
-        return new AwsCredentialsProperties();
-    }
+	/**
+	 * Bind AWS credentials related properties to a property instance.
+	 *
+	 * @return An {@link AwsCredentialsProperties} instance
+	 */
+	@Bean
+	@ConfigurationProperties(prefix = AWS_CREDENTIALS_PROPERTY_PREFIX)
+	public AwsCredentialsProperties awsCredentialsProperties() {
+		return new AwsCredentialsProperties();
+	}
 
     public static class Registrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -42,7 +42,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @ConditionalOnClass(name = "com.amazonaws.auth.AWSCredentialsProvider")
 public class ContextCredentialsAutoConfiguration {
 
-    private static final String AWS_CREDENTIALS_PROPERTY_PREFIX = "cloud.aws.credentials";
+    /**
+     * The prefix used for AWS credentials related properties.
+     */
+    public static final String AWS_CREDENTIALS_PROPERTY_PREFIX = "cloud.aws.credentials";
 
     /**
      * Bind AWS credentials related properties to a property instance.

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -17,7 +17,10 @@
 package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.aws.autoconfigure.context.properties.AwsRegionProperties;
 import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -38,15 +41,28 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
 public class ContextRegionProviderAutoConfiguration {
 
+    private static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
+
+    /**
+     * Bind AWS region related properties to a property instance.
+     *
+     * @return An {@link AwsRegionProperties} instance
+     */
+    @Bean
+    @ConfigurationProperties(prefix = AWS_REGION_PROPERTIES_PREFIX)
+    public AwsRegionProperties awsRegionProperties() {
+        return new AwsRegionProperties();
+    }
+
     static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
 
         private Environment environment;
 
         @Override
         public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
-            registerRegionProvider(registry, this.environment.getProperty("cloud.aws.region.auto", Boolean.class, true) &&
-                            !StringUtils.hasText(this.environment.getProperty("cloud.aws.region.static")),
-                    this.environment.getProperty("cloud.aws.region.static"));
+            registerRegionProvider(registry, this.environment.getProperty(AWS_REGION_PROPERTIES_PREFIX + ".auto", Boolean.class, true) &&
+                            !StringUtils.hasText(this.environment.getProperty(AWS_REGION_PROPERTIES_PREFIX + ".static")),
+                    this.environment.getProperty(AWS_REGION_PROPERTIES_PREFIX + ".static"));
         }
 
         @Override

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
+import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerRegionProvider;
+
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.aws.autoconfigure.context.properties.AwsRegionProperties;
@@ -28,8 +30,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerRegionProvider;
-
 /**
  * Region auto configuration, based on <a href=https://cloud.spring.io/spring-cloud-aws/spring-cloud-aws.html#_configuring_region>cloud.aws.region</a>
  * settings
@@ -41,21 +41,21 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
 public class ContextRegionProviderAutoConfiguration {
 
-    /**
-     * The prefix used for AWS region related properties.
-     */
-    public static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
+	/**
+	 * The prefix used for AWS region related properties.
+	 */
+	public static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
 
-    /**
-     * Bind AWS region related properties to a property instance.
-     *
-     * @return An {@link AwsRegionProperties} instance
-     */
-    @Bean
-    @ConfigurationProperties(prefix = AWS_REGION_PROPERTIES_PREFIX)
-    public AwsRegionProperties awsRegionProperties() {
-        return new AwsRegionProperties();
-    }
+	/**
+	 * Bind AWS region related properties to a property instance.
+	 *
+	 * @return An {@link AwsRegionProperties} instance
+	 */
+	@Bean
+	@ConfigurationProperties(prefix = AWS_REGION_PROPERTIES_PREFIX)
+	public AwsRegionProperties awsRegionProperties() {
+		return new AwsRegionProperties();
+	}
 
     static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -41,7 +41,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @Import(ContextRegionProviderAutoConfiguration.Registrar.class)
 public class ContextRegionProviderAutoConfiguration {
 
-    private static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
+    /**
+     * The prefix used for AWS region related properties.
+     */
+    public static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
 
     /**
      * Bind AWS region related properties to a property instance.

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -37,21 +37,22 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @ConditionalOnClass(name = "com.amazonaws.services.s3.AmazonS3Client")
 public class ContextResourceLoaderAutoConfiguration {
 
-    /**
-     * The prefix used for properties related to S3 resource loading via the ResourceLoader.
-     */
-    public static final String AWS_LOADER_PROPERTY_PREFIX = "cloud.aws.loader";
+	/**
+	 * The prefix used for properties related to S3 resource loading via the
+	 * ResourceLoader.
+	 */
+	public static final String AWS_LOADER_PROPERTY_PREFIX = "cloud.aws.loader";
 
-    /**
-     * Bind AWS resource loader related properties to a property instance.
-     *
-     * @return An {@link AwsS3ResourceLoaderProperties} instance
-     */
-    @Bean
-    @ConfigurationProperties(prefix = AWS_LOADER_PROPERTY_PREFIX)
-    public AwsS3ResourceLoaderProperties awsS3ResourceLoaderProperties() {
-        return new AwsS3ResourceLoaderProperties();
-    }
+	/**
+	 * Bind AWS resource loader related properties to a property instance.
+	 *
+	 * @return An {@link AwsS3ResourceLoaderProperties} instance
+	 */
+	@Bean
+	@ConfigurationProperties(prefix = AWS_LOADER_PROPERTY_PREFIX)
+	public AwsS3ResourceLoaderProperties awsS3ResourceLoaderProperties() {
+		return new AwsS3ResourceLoaderProperties();
+	}
 
     public static class Registrar extends ContextResourceLoaderConfiguration.Registrar implements EnvironmentAware {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @ConditionalOnClass(name = "com.amazonaws.services.s3.AmazonS3Client")
 public class ContextResourceLoaderAutoConfiguration {
 
-    private static final String AWS_LOADER_PROPERTY_PREFIX = "cloud.aws.loader";
+    /**
+     * The prefix used for properties related to S3 resource loading via the ResourceLoader.
+     */
+    public static final String AWS_LOADER_PROPERTY_PREFIX = "cloud.aws.loader";
 
     /**
      * Bind AWS resource loader related properties to a property instance.

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -19,8 +19,11 @@ package org.springframework.cloud.aws.autoconfigure.context;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.aws.autoconfigure.context.properties.AwsS3ResourceLoaderProperties;
 import org.springframework.cloud.aws.context.config.annotation.ContextResourceLoaderConfiguration;
 import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
@@ -34,9 +37,21 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @ConditionalOnClass(name = "com.amazonaws.services.s3.AmazonS3Client")
 public class ContextResourceLoaderAutoConfiguration {
 
+    private static final String AWS_LOADER_PROPERTY_PREFIX = "cloud.aws.loader";
+
+    /**
+     * Bind AWS resource loader related properties to a property instance.
+     *
+     * @return An {@link AwsS3ResourceLoaderProperties} instance
+     */
+    @Bean
+    @ConfigurationProperties(prefix = AWS_LOADER_PROPERTY_PREFIX)
+    public AwsS3ResourceLoaderProperties awsS3ResourceLoaderProperties() {
+        return new AwsS3ResourceLoaderProperties();
+    }
+
     public static class Registrar extends ContextResourceLoaderConfiguration.Registrar implements EnvironmentAware {
 
-        private static final String PROPERTY_PREFIX = "cloud.aws.loader";
         private static final String CORE_POOL_SIZE_PROPERTY_NAME = "corePoolSize";
         private static final String MAX_POOL_SIZE_PROPERTY_NAME = "maxPoolSize";
         private static final String QUEUE_CAPACITY_PROPERTY_NAME = "queueCapacity";
@@ -65,11 +80,11 @@ public class ContextResourceLoaderAutoConfiguration {
         }
 
         private boolean containsProperty(String name) {
-            return this.environment.containsProperty(PROPERTY_PREFIX + "." + name);
+            return this.environment.containsProperty(AWS_LOADER_PROPERTY_PREFIX + "." + name);
         }
 
         private String getProperty(String name) {
-            return this.environment.getProperty(PROPERTY_PREFIX + "." + name);
+            return this.environment.getProperty(AWS_LOADER_PROPERTY_PREFIX + "." + name);
         }
 
         private void setPropertyIfConfigured(BeanDefinitionBuilder builder, String name) {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
@@ -26,81 +26,82 @@ import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
  */
 public class AwsCredentialsProperties {
 
-    /**
-     * The access key to be used with a static provider.
-     */
-    private String accessKey;
+	/**
+	 * The access key to be used with a static provider.
+	 */
+	private String accessKey;
 
-    /**
-     * The secret key to be used with a static provider.
-     */
-    private String secretKey;
+	/**
+	 * The secret key to be used with a static provider.
+	 */
+	private String secretKey;
 
-    /**
-     * Configures an instance profile credentials provider with no further configuration.
-     */
-    private boolean instanceProfile = true;
+	/**
+	 * Configures an instance profile credentials provider with no further configuration.
+	 */
+	private boolean instanceProfile = true;
 
-    /**
-     * Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain.
-     */
-    private boolean useDefaultAwsCredentialsChain;
+	/**
+	 * Use the DefaultAWSCredentials Chain instead of configuring a custom credentials
+	 * chain.
+	 */
+	private boolean useDefaultAwsCredentialsChain;
 
-    /**
-     * The AWS profile name.
-     */
-    private String profileName = AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
+	/**
+	 * The AWS profile name.
+	 */
+	private String profileName = AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
 
-    /**
-     * The AWS profile path.
-     */
-    private String profilePath;
+	/**
+	 * The AWS profile path.
+	 */
+	private String profilePath;
 
-    public String getAccessKey() {
-        return this.accessKey;
-    }
+	public String getAccessKey() {
+		return this.accessKey;
+	}
 
-    public void setAccessKey(String accessKey) {
-        this.accessKey = accessKey;
-    }
+	public void setAccessKey(String accessKey) {
+		this.accessKey = accessKey;
+	}
 
-    public String getSecretKey() {
-        return this.secretKey;
-    }
+	public String getSecretKey() {
+		return this.secretKey;
+	}
 
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
-    }
+	public void setSecretKey(String secretKey) {
+		this.secretKey = secretKey;
+	}
 
-    public boolean isInstanceProfile() {
-        return this.instanceProfile;
-    }
+	public boolean isInstanceProfile() {
+		return this.instanceProfile;
+	}
 
-    public void setInstanceProfile(boolean instanceProfile) {
-        this.instanceProfile = instanceProfile;
-    }
+	public void setInstanceProfile(boolean instanceProfile) {
+		this.instanceProfile = instanceProfile;
+	}
 
-    public boolean isUseDefaultAwsCredentialsChain() {
-        return this.useDefaultAwsCredentialsChain;
-    }
+	public boolean isUseDefaultAwsCredentialsChain() {
+		return this.useDefaultAwsCredentialsChain;
+	}
 
-    public void setUseDefaultAwsCredentialsChain(boolean useDefaultAwsCredentialsChain) {
-        this.useDefaultAwsCredentialsChain = useDefaultAwsCredentialsChain;
-    }
+	public void setUseDefaultAwsCredentialsChain(boolean useDefaultAwsCredentialsChain) {
+		this.useDefaultAwsCredentialsChain = useDefaultAwsCredentialsChain;
+	}
 
-    public String getProfileName() {
-        return this.profileName;
-    }
+	public String getProfileName() {
+		return this.profileName;
+	}
 
-    public void setProfileName(String profileName) {
-        this.profileName = profileName;
-    }
+	public void setProfileName(String profileName) {
+		this.profileName = profileName;
+	}
 
-    public String getProfilePath() {
-        return this.profilePath;
-    }
+	public String getProfilePath() {
+		return this.profilePath;
+	}
 
-    public void setProfilePath(String profilePath) {
-        this.profilePath = profilePath;
-    }
+	public void setProfilePath(String profilePath) {
+		this.profilePath = profilePath;
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
+
+/**
+ * Properties related to AWS credentials.
+ *
+ * @author tgianos
+ * @see org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration
+ * @since 2.0.2
+ */
+public class AwsCredentialsProperties {
+
+    /**
+     * The access key to be used with a static provider.
+     */
+    private String accessKey;
+
+    /**
+     * The secret key to be used with a static provider.
+     */
+    private String secretKey;
+
+    /**
+     * Configures an instance profile credentials provider with no further configuration.
+     */
+    private boolean instanceProfile = true;
+
+    /**
+     * Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain.
+     */
+    private boolean useDefaultAwsCredentialsChain;
+
+    /**
+     * The AWS profile name.
+     */
+    private String profileName = AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
+
+    /**
+     * The AWS profile path.
+     */
+    private String profilePath;
+
+    public String getAccessKey() {
+        return this.accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return this.secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public boolean isInstanceProfile() {
+        return this.instanceProfile;
+    }
+
+    public void setInstanceProfile(boolean instanceProfile) {
+        this.instanceProfile = instanceProfile;
+    }
+
+    public boolean isUseDefaultAwsCredentialsChain() {
+        return this.useDefaultAwsCredentialsChain;
+    }
+
+    public void setUseDefaultAwsCredentialsChain(boolean useDefaultAwsCredentialsChain) {
+        this.useDefaultAwsCredentialsChain = useDefaultAwsCredentialsChain;
+    }
+
+    public String getProfileName() {
+        return this.profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
+    public String getProfilePath() {
+        return this.profilePath;
+    }
+
+    public void setProfilePath(String profilePath) {
+        this.profilePath = profilePath;
+    }
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
@@ -24,35 +24,38 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
  */
 public class AwsRegionProperties {
 
-    /**
-     * Enables automatic region detection based on the EC2 meta data service.
-     */
-    private boolean auto = true;
+	/**
+	 * Enables automatic region detection based on the EC2 meta data service.
+	 */
+	private boolean auto = true;
 
-    /**
-     * Configures a static region for the application.
-     * Possible regions are (currently) us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1,
-     * ap-southeast-1, ap-northeast-1, sa-east-1, cn-north-1 and any custom region configured with own region meta data.
-     */
-    private String staticRegion;
+	/**
+	 * Configures a static region for the application. Possible regions are (currently)
+	 * us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1,
+	 * ap-southeast-1, ap-northeast-1, sa-east-1, cn-north-1 and any custom region
+	 * configured with own region meta data.
+	 */
+	private String staticRegion;
 
-    public boolean isAuto() {
-        return this.auto;
-    }
+	public boolean isAuto() {
+		return this.auto;
+	}
 
-    public void setAuto(boolean auto) {
-        this.auto = auto;
-    }
+	public void setAuto(boolean auto) {
+		this.auto = auto;
+	}
 
-    public String getStatic() {
-        return this.staticRegion;
-    }
+	public String getStatic() {
+		return this.staticRegion;
+	}
 
-    public void setStatic(String staticRegion) {
-        // Feels like validation should be done to make sure this is a valid AWS region value. However current
-        // configuration in ContextRegionProviderAutoConfiguration doesn't seem to check property is valid before
-        // creating a bean definition. Leaving for now.
-        // - tgianos 11/26/2018
-        this.staticRegion = staticRegion;
-    }
+	public void setStatic(String staticRegion) {
+		// Feels like validation should be done to make sure this is a valid AWS region
+		// value. However current
+		// configuration in ContextRegionProviderAutoConfiguration doesn't seem to check
+		// property is valid before
+		// creating a bean definition. Leaving for now.
+		// - tgianos 11/26/2018
+		this.staticRegion = staticRegion;
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+/**
+ * Properties related to AWS region configuration.
+ *
+ * @author tgianos
+ * @see org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration
+ * @since 2.0.2
+ */
+public class AwsRegionProperties {
+
+    /**
+     * Enables automatic region detection based on the EC2 meta data service.
+     */
+    private boolean auto = true;
+
+    /**
+     * Configures a static region for the application.
+     * Possible regions are (currently) us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1,
+     * ap-southeast-1, ap-northeast-1, sa-east-1, cn-north-1 and any custom region configured with own region meta data.
+     */
+    private String staticRegion;
+
+    public boolean isAuto() {
+        return this.auto;
+    }
+
+    public void setAuto(boolean auto) {
+        this.auto = auto;
+    }
+
+    public String getStatic() {
+        return this.staticRegion;
+    }
+
+    public void setStatic(String staticRegion) {
+        // Feels like validation should be done to make sure this is a valid AWS region value. However current
+        // configuration in ContextRegionProviderAutoConfiguration doesn't seem to check property is valid before
+        // creating a bean definition. Leaving for now.
+        // - tgianos 11/26/2018
+        this.staticRegion = staticRegion;
+    }
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderProperties.java
@@ -16,7 +16,8 @@
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
 /**
- * Properties related to S3 client behavior within the application {@link org.springframework.core.io.ResourceLoader}.
+ * Properties related to S3 client behavior within the application
+ * {@link org.springframework.core.io.ResourceLoader}.
  *
  * @author tgianos
  * @see org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration
@@ -24,48 +25,48 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
  */
 public class AwsS3ResourceLoaderProperties {
 
-    /**
-     * The core pool size of the Task Executor used for parallel S3 interaction.
-     *
-     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
-     */
-    private int corePoolSize = 1;
+	/**
+	 * The core pool size of the Task Executor used for parallel S3 interaction.
+	 *
+	 * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
+	 */
+	private int corePoolSize = 1;
 
-    /**
-     * The maximum pool size of the Task Executor used for parallel S3 interaction.
-     *
-     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
-     */
-    private int maxPoolSize = Integer.MAX_VALUE;
+	/**
+	 * The maximum pool size of the Task Executor used for parallel S3 interaction.
+	 *
+	 * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
+	 */
+	private int maxPoolSize = Integer.MAX_VALUE;
 
-    /**
-     * The maximum queue capacity for backed up S3 requests.
-     *
-     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
-     */
-    private int queueCapacity = Integer.MAX_VALUE;
+	/**
+	 * The maximum queue capacity for backed up S3 requests.
+	 *
+	 * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
+	 */
+	private int queueCapacity = Integer.MAX_VALUE;
 
-    public int getCorePoolSize() {
-        return this.corePoolSize;
-    }
+	public int getCorePoolSize() {
+		return this.corePoolSize;
+	}
 
-    public void setCorePoolSize(int corePoolSize) {
-        this.corePoolSize = corePoolSize;
-    }
+	public void setCorePoolSize(int corePoolSize) {
+		this.corePoolSize = corePoolSize;
+	}
 
-    public int getMaxPoolSize() {
-        return this.maxPoolSize;
-    }
+	public int getMaxPoolSize() {
+		return this.maxPoolSize;
+	}
 
-    public void setMaxPoolSize(int maxPoolSize) {
-        this.maxPoolSize = maxPoolSize;
-    }
+	public void setMaxPoolSize(int maxPoolSize) {
+		this.maxPoolSize = maxPoolSize;
+	}
 
-    public int getQueueCapacity() {
-        return this.queueCapacity;
-    }
+	public int getQueueCapacity() {
+		return this.queueCapacity;
+	}
 
-    public void setQueueCapacity(int queueCapacity) {
-        this.queueCapacity = queueCapacity;
-    }
+	public void setQueueCapacity(int queueCapacity) {
+		this.queueCapacity = queueCapacity;
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+/**
+ * Properties related to S3 client behavior within the application {@link org.springframework.core.io.ResourceLoader}.
+ *
+ * @author tgianos
+ * @see org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration
+ * @since 2.0.2
+ */
+public class AwsS3ResourceLoaderProperties {
+
+    /**
+     * The core pool size of the Task Executor used for parallel S3 interaction.
+     *
+     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
+     */
+    private int corePoolSize = 1;
+
+    /**
+     * The maximum pool size of the Task Executor used for parallel S3 interaction.
+     *
+     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
+     */
+    private int maxPoolSize = Integer.MAX_VALUE;
+
+    /**
+     * The maximum queue capacity for backed up S3 requests.
+     *
+     * @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
+     */
+    private int queueCapacity = Integer.MAX_VALUE;
+
+    public int getCorePoolSize() {
+        return this.corePoolSize;
+    }
+
+    public void setCorePoolSize(int corePoolSize) {
+        this.corePoolSize = corePoolSize;
+    }
+
+    public int getMaxPoolSize() {
+        return this.maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getQueueCapacity() {
+        return this.queueCapacity;
+    }
+
+    public void setQueueCapacity(int queueCapacity) {
+        this.queueCapacity = queueCapacity;
+    }
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Classes intended to be bound into {@link org.springframework.boot.context.properties.ConfigurationProperties} within
+ * Classes intended to be bound into
+ * {@link org.springframework.boot.context.properties.ConfigurationProperties} within
  * Spring Boot auto configuration.
  *
  * @author tgianos

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/package-info.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes intended to be bound into {@link org.springframework.boot.context.properties.ConfigurationProperties} within
+ * Spring Boot auto configuration.
+ *
+ * @author tgianos
+ * @since 2.0.2
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
-import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
+import java.util.UUID;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.UUID;
+import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
 
 /**
  * Tests for {@link AwsCredentialsProperties}.
@@ -30,62 +31,75 @@ import java.util.UUID;
  */
 public class AwsCredentialsPropertiesTest {
 
-    private AwsCredentialsProperties properties;
+	private AwsCredentialsProperties properties;
 
-    @Before
-    public void setup() {
-        this.properties = new AwsCredentialsProperties();
-    }
+	@Before
+	public void setup() {
+		this.properties = new AwsCredentialsProperties();
+	}
 
-    @Test
-    public void accessKeyCanBeSet() {
-        Assert.assertNull("Access key default value expected to be null", this.properties.getAccessKey());
+	@Test
+	public void accessKeyCanBeSet() {
+		Assert.assertNull("Access key default value expected to be null",
+				this.properties.getAccessKey());
 
-        String newAccessKey = UUID.randomUUID().toString();
-        this.properties.setAccessKey(newAccessKey);
-        Assert.assertEquals("Access key should have been assigned", newAccessKey, this.properties.getAccessKey());
-    }
+		String newAccessKey = UUID.randomUUID().toString();
+		this.properties.setAccessKey(newAccessKey);
+		Assert.assertEquals("Access key should have been assigned", newAccessKey,
+				this.properties.getAccessKey());
+	}
 
-    @Test
-    public void secretKeyCanBeSet() {
-        Assert.assertNull("Secret key default value expected to be null", this.properties.getSecretKey());
+	@Test
+	public void secretKeyCanBeSet() {
+		Assert.assertNull("Secret key default value expected to be null",
+				this.properties.getSecretKey());
 
-        String newSecretKey = UUID.randomUUID().toString();
-        this.properties.setSecretKey(newSecretKey);
-        Assert.assertEquals("Secret key should have been assigned", newSecretKey, this.properties.getSecretKey());
-    }
+		String newSecretKey = UUID.randomUUID().toString();
+		this.properties.setSecretKey(newSecretKey);
+		Assert.assertEquals("Secret key should have been assigned", newSecretKey,
+				this.properties.getSecretKey());
+	}
 
-    @Test
-    public void instanceProfileCanBeSet() {
-        Assert.assertTrue("Instance profile default expected to be true", this.properties.isInstanceProfile());
+	@Test
+	public void instanceProfileCanBeSet() {
+		Assert.assertTrue("Instance profile default expected to be true",
+				this.properties.isInstanceProfile());
 
-        this.properties.setInstanceProfile(false);
-        Assert.assertFalse("Instance profile should have been assigned", this.properties.isInstanceProfile());
-    }
+		this.properties.setInstanceProfile(false);
+		Assert.assertFalse("Instance profile should have been assigned",
+				this.properties.isInstanceProfile());
+	}
 
-    @Test
-    public void useDefaultAwsCredentialsChainCanBeSet() {
-        Assert.assertFalse("useDefaultAwsCredentialsChain default expected to be false", this.properties.isUseDefaultAwsCredentialsChain());
+	@Test
+	public void useDefaultAwsCredentialsChainCanBeSet() {
+		Assert.assertFalse("useDefaultAwsCredentialsChain default expected to be false",
+				this.properties.isUseDefaultAwsCredentialsChain());
 
-        this.properties.setUseDefaultAwsCredentialsChain(true);
-        Assert.assertTrue("useDefaultAwsCredentialsChain should have been assigned", this.properties.isUseDefaultAwsCredentialsChain());
-    }
+		this.properties.setUseDefaultAwsCredentialsChain(true);
+		Assert.assertTrue("useDefaultAwsCredentialsChain should have been assigned",
+				this.properties.isUseDefaultAwsCredentialsChain());
+	}
 
-    @Test
-    public void profileNameCanBeSet() {
-        Assert.assertEquals("Default profile name expected to be set" , AwsProfileNameLoader.DEFAULT_PROFILE_NAME, this.properties.getProfileName());
+	@Test
+	public void profileNameCanBeSet() {
+		Assert.assertEquals("Default profile name expected to be set",
+				AwsProfileNameLoader.DEFAULT_PROFILE_NAME,
+				this.properties.getProfileName());
 
-        String newProfileName = UUID.randomUUID().toString();
-        this.properties.setProfileName(newProfileName);
-        Assert.assertEquals("Profile name should have been assigned", newProfileName, this.properties.getProfileName());
-    }
+		String newProfileName = UUID.randomUUID().toString();
+		this.properties.setProfileName(newProfileName);
+		Assert.assertEquals("Profile name should have been assigned", newProfileName,
+				this.properties.getProfileName());
+	}
 
-    @Test
-    public void profilePathCanBeSet() {
-        Assert.assertNull("Profile path default value expected to be null", this.properties.getProfilePath());
+	@Test
+	public void profilePathCanBeSet() {
+		Assert.assertNull("Profile path default value expected to be null",
+				this.properties.getProfilePath());
 
-        String newProfilePath = UUID.randomUUID().toString();
-        this.properties.setProfilePath(newProfilePath);
-        Assert.assertEquals("Profile path should have been assigned", newProfilePath, this.properties.getProfilePath());
-    }
+		String newProfilePath = UUID.randomUUID().toString();
+		this.properties.setProfilePath(newProfilePath);
+		Assert.assertEquals("Profile path should have been assigned", newProfilePath,
+				this.properties.getProfilePath());
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests for {@link AwsCredentialsProperties}.
+ *
+ * @author tgianos
+ * @since 2.0.2
+ */
+public class AwsCredentialsPropertiesTest {
+
+    private AwsCredentialsProperties properties;
+
+    @Before
+    public void setup() {
+        this.properties = new AwsCredentialsProperties();
+    }
+
+    @Test
+    public void accessKeyCanBeSet() {
+        Assert.assertNull("Access key default value expected to be null", this.properties.getAccessKey());
+
+        String newAccessKey = UUID.randomUUID().toString();
+        this.properties.setAccessKey(newAccessKey);
+        Assert.assertEquals("Access key should have been assigned", newAccessKey, this.properties.getAccessKey());
+    }
+
+    @Test
+    public void secretKeyCanBeSet() {
+        Assert.assertNull("Secret key default value expected to be null", this.properties.getSecretKey());
+
+        String newSecretKey = UUID.randomUUID().toString();
+        this.properties.setSecretKey(newSecretKey);
+        Assert.assertEquals("Secret key should have been assigned", newSecretKey, this.properties.getSecretKey());
+    }
+
+    @Test
+    public void instanceProfileCanBeSet() {
+        Assert.assertTrue("Instance profile default expected to be true", this.properties.isInstanceProfile());
+
+        this.properties.setInstanceProfile(false);
+        Assert.assertFalse("Instance profile should have been assigned", this.properties.isInstanceProfile());
+    }
+
+    @Test
+    public void useDefaultAwsCredentialsChainCanBeSet() {
+        Assert.assertFalse("useDefaultAwsCredentialsChain default expected to be false", this.properties.isUseDefaultAwsCredentialsChain());
+
+        this.properties.setUseDefaultAwsCredentialsChain(true);
+        Assert.assertTrue("useDefaultAwsCredentialsChain should have been assigned", this.properties.isUseDefaultAwsCredentialsChain());
+    }
+
+    @Test
+    public void profileNameCanBeSet() {
+        Assert.assertEquals("Default profile name expected to be set" , AwsProfileNameLoader.DEFAULT_PROFILE_NAME, this.properties.getProfileName());
+
+        String newProfileName = UUID.randomUUID().toString();
+        this.properties.setProfileName(newProfileName);
+        Assert.assertEquals("Profile name should have been assigned", newProfileName, this.properties.getProfileName());
+    }
+
+    @Test
+    public void profilePathCanBeSet() {
+        Assert.assertNull("Profile path default value expected to be null", this.properties.getProfilePath());
+
+        String newProfilePath = UUID.randomUUID().toString();
+        this.properties.setProfilePath(newProfilePath);
+        Assert.assertEquals("Profile path should have been assigned", newProfilePath, this.properties.getProfilePath());
+    }
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
@@ -15,10 +15,11 @@
  */
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
-import com.amazonaws.regions.Regions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.amazonaws.regions.Regions;
 
 /**
  * Tests for {@link AwsRegionProperties}.
@@ -28,30 +29,30 @@ import org.junit.Test;
  */
 public class AwsRegionPropertiesTest {
 
-    private AwsRegionProperties properties;
+	private AwsRegionProperties properties;
 
-    @Before
-    public void setup() {
-        this.properties = new AwsRegionProperties();
-    }
+	@Before
+	public void setup() {
+		this.properties = new AwsRegionProperties();
+	}
 
-    @Test
-    public void autoCanBeSet() {
-        Assert.assertTrue("Default value of auto should be true", this.properties.isAuto());
+	@Test
+	public void autoCanBeSet() {
+		Assert.assertTrue("Default value of auto should be true",
+				this.properties.isAuto());
 
-        this.properties.setAuto(false);
-        Assert.assertFalse("Auto should have been reassigned as false", this.properties.isAuto());
-    }
+		this.properties.setAuto(false);
+		Assert.assertFalse("Auto should have been reassigned as false",
+				this.properties.isAuto());
+	}
 
-    @Test
-    public void staticRegionCanBeSet() {
-        Assert.assertNull("Static region value should have default of null", this.properties.getStatic());
+	@Test
+	public void staticRegionCanBeSet() {
+		Assert.assertNull("Static region value should have default of null",
+				this.properties.getStatic());
 
-        this.properties.setStatic(Regions.US_EAST_1.getName());
-        Assert.assertEquals(
-                "Static region should have been assigned to us-east-1",
-                Regions.US_EAST_1.getName(),
-                this.properties.getStatic()
-        );
-    }
+		this.properties.setStatic(Regions.US_EAST_1.getName());
+		Assert.assertEquals("Static region should have been assigned to us-east-1",
+				Regions.US_EAST_1.getName(), this.properties.getStatic());
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+import com.amazonaws.regions.Regions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AwsRegionProperties}.
+ *
+ * @author tgianos
+ * @since 2.0.2
+ */
+public class AwsRegionPropertiesTest {
+
+    private AwsRegionProperties properties;
+
+    @Before
+    public void setup() {
+        this.properties = new AwsRegionProperties();
+    }
+
+    @Test
+    public void autoCanBeSet() {
+        Assert.assertTrue("Default value of auto should be true", this.properties.isAuto());
+
+        this.properties.setAuto(false);
+        Assert.assertFalse("Auto should have been reassigned as false", this.properties.isAuto());
+    }
+
+    @Test
+    public void staticRegionCanBeSet() {
+        Assert.assertNull("Static region value should have default of null", this.properties.getStatic());
+
+        this.properties.setStatic(Regions.US_EAST_1.getName());
+        Assert.assertEquals(
+                "Static region should have been assigned to us-east-1",
+                Regions.US_EAST_1.getName(),
+                this.properties.getStatic()
+        );
+    }
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderPropertiesTest.java
@@ -27,61 +27,45 @@ import org.junit.Test;
  */
 public class AwsS3ResourceLoaderPropertiesTest {
 
-    private AwsS3ResourceLoaderProperties properties;
+	private AwsS3ResourceLoaderProperties properties;
 
-    @Before
-    public void setup() {
-        this.properties = new AwsS3ResourceLoaderProperties();
-    }
+	@Before
+	public void setup() {
+		this.properties = new AwsS3ResourceLoaderProperties();
+	}
 
-    @Test
-    public void corePoolSizeCanBeSet() {
-        Assert.assertEquals(
-                "Default value of the core size should be one",
-                1,
-                this.properties.getCorePoolSize()
-        );
+	@Test
+	public void corePoolSizeCanBeSet() {
+		Assert.assertEquals("Default value of the core size should be one", 1,
+				this.properties.getCorePoolSize());
 
-        int newSize = 138;
-        this.properties.setCorePoolSize(newSize);
-        Assert.assertEquals(
-                "Core size should have been reset",
-                newSize,
-                this.properties.getCorePoolSize()
-        );
-    }
+		int newSize = 138;
+		this.properties.setCorePoolSize(newSize);
+		Assert.assertEquals("Core size should have been reset", newSize,
+				this.properties.getCorePoolSize());
+	}
 
-    @Test
-    public void maxPoolSizeCanBeSet() {
-        Assert.assertEquals(
-                "Default value of the max pool size should be integer max value",
-                Integer.MAX_VALUE,
-                this.properties.getMaxPoolSize()
-        );
+	@Test
+	public void maxPoolSizeCanBeSet() {
+		Assert.assertEquals(
+				"Default value of the max pool size should be integer max value",
+				Integer.MAX_VALUE, this.properties.getMaxPoolSize());
 
-        int newSize = 11;
-        this.properties.setMaxPoolSize(newSize);
-        Assert.assertEquals(
-                "Max pool size should have been reset",
-                newSize,
-                this.properties.getMaxPoolSize()
-        );
-    }
+		int newSize = 11;
+		this.properties.setMaxPoolSize(newSize);
+		Assert.assertEquals("Max pool size should have been reset", newSize,
+				this.properties.getMaxPoolSize());
+	}
 
-    @Test
-    public void queueCapacityCanBeSet() {
-        Assert.assertEquals(
-                "Default value of the queue capacity size should be integer max value",
-                Integer.MAX_VALUE,
-                this.properties.getQueueCapacity()
-        );
+	@Test
+	public void queueCapacityCanBeSet() {
+		Assert.assertEquals(
+				"Default value of the queue capacity size should be integer max value",
+				Integer.MAX_VALUE, this.properties.getQueueCapacity());
 
-        int newSize = 11;
-        this.properties.setQueueCapacity(newSize);
-        Assert.assertEquals(
-                "Queue capacity should have been reset",
-                newSize,
-                this.properties.getQueueCapacity()
-        );
-    }
+		int newSize = 11;
+		this.properties.setQueueCapacity(newSize);
+		Assert.assertEquals("Queue capacity should have been reset", newSize,
+				this.properties.getQueueCapacity());
+	}
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsS3ResourceLoaderPropertiesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.aws.autoconfigure.context.properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AwsS3ResourceLoaderProperties}.
+ *
+ * @author tgianos
+ * @since 2.0.2
+ */
+public class AwsS3ResourceLoaderPropertiesTest {
+
+    private AwsS3ResourceLoaderProperties properties;
+
+    @Before
+    public void setup() {
+        this.properties = new AwsS3ResourceLoaderProperties();
+    }
+
+    @Test
+    public void corePoolSizeCanBeSet() {
+        Assert.assertEquals(
+                "Default value of the core size should be one",
+                1,
+                this.properties.getCorePoolSize()
+        );
+
+        int newSize = 138;
+        this.properties.setCorePoolSize(newSize);
+        Assert.assertEquals(
+                "Core size should have been reset",
+                newSize,
+                this.properties.getCorePoolSize()
+        );
+    }
+
+    @Test
+    public void maxPoolSizeCanBeSet() {
+        Assert.assertEquals(
+                "Default value of the max pool size should be integer max value",
+                Integer.MAX_VALUE,
+                this.properties.getMaxPoolSize()
+        );
+
+        int newSize = 11;
+        this.properties.setMaxPoolSize(newSize);
+        Assert.assertEquals(
+                "Max pool size should have been reset",
+                newSize,
+                this.properties.getMaxPoolSize()
+        );
+    }
+
+    @Test
+    public void queueCapacityCanBeSet() {
+        Assert.assertEquals(
+                "Default value of the queue capacity size should be integer max value",
+                Integer.MAX_VALUE,
+                this.properties.getQueueCapacity()
+        );
+
+        int newSize = 11;
+        this.properties.setQueueCapacity(newSize);
+        Assert.assertEquals(
+                "Queue capacity should have been reset",
+                newSize,
+                this.properties.getQueueCapacity()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds POJOs intended to bind `cloud.aws.credentials`, `cloud.aws.region` and `cloud.aws.loader` property prefixes into type safe `ConfgurationProperties` instances within the Spring application context.

Some of these properties are loosely documented within the documentation so some digging had to be done to find suitable defaults.

The `ConfigurationProperties` beans are added within the respective auto configuration classes but aren't used by existing spring-cloud-aws configuration for fear of trickle.