### PR TITLE
Customizable aws client configuration for cloudwatch

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.metrics;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient;
@@ -70,8 +71,20 @@ public class CloudWatchExportAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingAmazonClient(AmazonCloudWatchAsync.class)
-	public AmazonWebserviceClientFactoryBean<AmazonCloudWatchAsyncClient> amazonCloudWatchAsync(AWSCredentialsProvider credentialsProvider) {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonCloudWatchAsyncClient.class, credentialsProvider, this.regionProvider);
+	public AmazonWebserviceClientFactoryBean<AmazonCloudWatchAsyncClient> amazonCloudWatchAsync(
+			AWSCredentialsProvider credentialsProvider,
+			ClientConfiguration clientConfiguration
+	) {
+		return new AmazonWebserviceClientFactoryBean<>(AmazonCloudWatchAsyncClient.class,
+				credentialsProvider,
+				this.regionProvider,
+				clientConfiguration);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ClientConfiguration defaultClientConfiguration() {
+		return new ClientConfiguration();
 	}
 
 	@Bean

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.core.config;
 
 import com.amazonaws.AmazonWebServiceClient;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsAsyncClientBuilder;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -48,6 +49,7 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
     private RegionProvider regionProvider;
     private Region customRegion;
     private ExecutorService executor;
+    private ClientConfiguration clientConfiguration;
 
     public AmazonWebserviceClientFactoryBean(Class<T> clientClass,
                                              AWSCredentialsProvider credentialsProvider) {
@@ -58,6 +60,14 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
     public AmazonWebserviceClientFactoryBean(Class<T> clientClass, AWSCredentialsProvider credentialsProvider, RegionProvider regionProvider) {
         this(clientClass, credentialsProvider);
         setRegionProvider(regionProvider);
+    }
+
+    public AmazonWebserviceClientFactoryBean(Class<T> clientClass,
+                                             AWSCredentialsProvider credentialsProvider,
+                                             RegionProvider regionProvider,
+                                             ClientConfiguration clientConfiguration) {
+        this(clientClass, credentialsProvider, regionProvider);
+        setClientConfiguration(clientConfiguration);
     }
 
     @Override
@@ -86,6 +96,10 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
             builder.withCredentials(this.credentialsProvider);
         }
 
+        if (this.clientConfiguration != null) {
+            builder.withClientConfiguration(this.clientConfiguration);
+        }
+
         if (this.customRegion != null) {
             builder.withRegion(this.customRegion.getName());
         } else if (this.regionProvider != null) {
@@ -102,6 +116,10 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 
     public void setCustomRegion(String customRegionName) {
         this.customRegion = RegionUtils.getRegion(customRegionName);
+    }
+
+    public void setClientConfiguration(ClientConfiguration clientConfiguration) {
+        this.clientConfiguration = clientConfiguration;
     }
 
     public void setExecutor(ExecutorService executor) {


### PR DESCRIPTION
AWSClient for sending metrics to cloudwatch has default configuration. For example default thread pool size in AWSClient is 50, which in my case it is only used to send metrics. I think it is reasonable to have an option to customize this configuration.

I've only updated configuration for cloudwatch. There is similar MailSenderAutoConfiguration.