### PR TITLE
Improve warning when SQS queue resolving fails no access GetQueueUrl

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
@@ -322,12 +322,11 @@ abstract class AbstractMessageListenerContainer
 		catch (DestinationResolutionException e) {
 			if (getLogger().isDebugEnabled()) {
 				getLogger().debug(
-						"Ignoring queue with name '" + queue + "' as it does not exist.",
-						e);
+						"Ignoring queue with name '" + queue + "': " + e.getMessage(), e);
 			}
 			else {
 				getLogger().warn(
-						"Ignoring queue with name '" + queue + "' as it does not exist.");
+						"Ignoring queue with name '" + queue + "': " + e.getMessage());
 			}
 			return null;
 		}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
@@ -95,8 +95,20 @@ public class DynamicQueueUrlDestinationResolver implements DestinationResolver<S
 				return getQueueUrlResult.getQueueUrl();
 			}
 			catch (QueueDoesNotExistException e) {
-				throw new DestinationResolutionException(e.getMessage(), e);
+				throw toDestinationResolutionException(e);
 			}
+		}
+	}
+
+	private DestinationResolutionException toDestinationResolutionException(
+			QueueDoesNotExistException e) {
+		if (e.getMessage() != null && e.getMessage().contains("access")) {
+			return new DestinationResolutionException(
+					"The queue does not exist or no access to perform action sqs:GetQueueUrl.",
+					e);
+		}
+		else {
+			return new DestinationResolutionException("The queue does not exist.", e);
 		}
 	}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
@@ -435,8 +435,10 @@ public class MessageListenerContainerTest {
 		applicationContext.registerSingleton("anotherMessageListener",
 				AnotherMessageListener.class);
 
+		String destinationResolutionExceptionMessage = "Queue not found";
 		when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("testQueue")))
-				.thenThrow(new DestinationResolutionException("Queue not found"));
+				.thenThrow(new DestinationResolutionException(
+						destinationResolutionExceptionMessage));
 		when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("anotherTestQueue")))
 				.thenReturn(new GetQueueUrlResult()
 						.withQueueUrl("http://anotherTestQueue.amazonaws.com"));
@@ -455,7 +457,8 @@ public class MessageListenerContainerTest {
 		Map<String, QueueAttributes> registeredQueues = container.getRegisteredQueues();
 		assertThat(registeredQueues.containsKey("testQueue")).isFalse();
 		assertThat(logMsgArgCaptor.getValue())
-				.isEqualTo("Ignoring queue with name 'testQueue' as it does not exist.");
+				.isEqualTo("Ignoring queue with name 'testQueue': "
+						+ destinationResolutionExceptionMessage);
 		assertThat(registeredQueues.get("anotherTestQueue").getReceiveMessageRequest()
 				.getQueueUrl()).isEqualTo("http://anotherTestQueue.amazonaws.com");
 	}


### PR DESCRIPTION
Before this commit the following message is provided "Ignoring queue with name 'queue name' as it does not exist.". This can be misleading when the queue does exist, but there is no permission provided to perform "sqs:GetQueueUrl".  The AWS SDK's QueueDoesNotExistException message is different when the potentially there is no access to perform GetQueueUrl: "The specified queue does not exist or you do not have access to it.". To make it clear exactly what is failing (GetQueueUrl) a custom message is provided.