### PR TITLE
Issue 262 - determine 'content-type' from location

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
+import java.net.URLConnection;
+
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Utility class that provides utility method to work with s3 storage resources.
@@ -105,6 +108,14 @@ final class SimpleStorageNameUtils {
 		}
 
 		return location.substring(++objectNameEndIndex, location.length());
+	}
+
+	static String getContentTypeFromLocation(String location) {
+		String objectName = getObjectNameFromLocation(location);
+		if (!StringUtils.isEmpty(objectName)) {
+			return URLConnection.guessContentTypeFromName(objectName);
+		}
+		return null;
 	}
 
 	static String getLocationForBucketAndObject(String bucketName, String objectName) {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
@@ -65,7 +65,8 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 					SimpleStorageNameUtils.getBucketNameFromLocation(location),
 					SimpleStorageNameUtils.getObjectNameFromLocation(location),
 					this.taskExecutor,
-					SimpleStorageNameUtils.getVersionIdFromLocation(location));
+					SimpleStorageNameUtils.getVersionIdFromLocation(location),
+					SimpleStorageNameUtils.getContentTypeFromLocation(location));
 		}
 		else {
 			return null;

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getBucketNameFromLocation;
+import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getContentTypeFromLocation;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObject;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObjectAndVersionId;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getObjectNameFromLocation;
@@ -125,6 +126,17 @@ public class SimpleStorageNameUtilsTest {
 				.isEqualTo("versionIdValue");
 		assertThat(getVersionIdFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue"))
 				.isEqualTo("versionIdValue");
+	}
+
+	@Test
+	public void testGetContentTypeFromLocation() {
+		assertThat(getContentTypeFromLocation("s3://foo/bar")).isEqualTo(null);
+		assertThat(getContentTypeFromLocation("s3://foo/bar^versionIdValue"))
+				.isEqualTo(null);
+		assertThat(getContentTypeFromLocation("s3://foo/bar/baz/boo.txt"))
+				.isEqualTo("text/plain");
+		assertThat(getContentTypeFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue"))
+				.isEqualTo("text/plain");
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -23,11 +23,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.Date;
+import java.util.Random;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.Region;
@@ -285,6 +288,8 @@ public class SimpleStorageResourceTest {
 							assertThat(((InputStream) invocation.getArguments()[2])
 									.read(content)).isEqualTo(content.length);
 							assertThat(new String(content)).isEqualTo(messageContext);
+							assertThat(((ObjectMetadata) invocation.getArgument(3))
+									.getContentType()).isEqualTo(null);
 							return new PutObjectResult();
 						});
 		OutputStream outputStream = simpleStorageResource.getOutputStream();
@@ -293,6 +298,68 @@ public class SimpleStorageResourceTest {
 		outputStream.write(messageContext.getBytes());
 		outputStream.flush();
 		outputStream.close();
+
+		// Assert
+	}
+
+	@Test
+	public void writeFile_simpleUpload_setsContentType() throws Exception {
+		// Arrange
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3,
+				"bucketName", "objectName", new SyncTaskExecutor(), null, "text/plain");
+		String messageContext = "myFileContent";
+		when(amazonS3.putObject(eq("bucketName"), eq("objectName"),
+				any(InputStream.class), any(ObjectMetadata.class)))
+						.thenAnswer((Answer<PutObjectResult>) invocation -> {
+							assertThat(invocation.getArguments()[0])
+									.isEqualTo("bucketName");
+							assertThat(invocation.getArguments()[1])
+									.isEqualTo("objectName");
+							byte[] content = new byte[messageContext.length()];
+							assertThat(((InputStream) invocation.getArguments()[2])
+									.read(content)).isEqualTo(content.length);
+							assertThat(new String(content)).isEqualTo(messageContext);
+							assertThat(((ObjectMetadata) invocation.getArgument(3))
+									.getContentType()).isEqualTo("text/plain");
+							return new PutObjectResult();
+						});
+		OutputStream outputStream = simpleStorageResource.getOutputStream();
+
+		// Act
+		outputStream.write(messageContext.getBytes());
+		outputStream.flush();
+		outputStream.close();
+
+		// Assert
+	}
+
+	@Test
+	public void writeFile_multipartUpload_setsContentType() throws Exception {
+		// Arrange
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3,
+				"bucketName", "objectName", new SyncTaskExecutor(), null, "text/plain");
+
+		byte[] messageContext = new byte[(1024 * 1024 * 5) + 1];
+		new Random().nextBytes(messageContext);
+
+		when(amazonS3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+				.thenAnswer((Answer<InitiateMultipartUploadResult>) invocation -> {
+					assertThat(((InitiateMultipartUploadRequest) invocation
+							.getArguments()[0]).getBucketName()).isEqualTo("bucketName");
+					assertThat(((InitiateMultipartUploadRequest) invocation
+							.getArguments()[0]).getKey()).isEqualTo("objectName");
+					assertThat(((InitiateMultipartUploadRequest) invocation
+							.getArguments()[0]).getObjectMetadata().getContentType())
+									.isEqualTo("text/plain");
+					return new InitiateMultipartUploadResult();
+				});
+		OutputStream outputStream = simpleStorageResource.getOutputStream();
+
+		// Act
+		outputStream.write(messageContext);
+		outputStream.flush();
 
 		// Assert
 	}


### PR DESCRIPTION
If possible, determine the content-type from the file extension part of the Resource's location.

When content is uploaded via `getOutputStream` the resource's content-type is used to set the content-type on the s3 object's metadata.

Fixes gh-#262