### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -40,6 +40,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -51,8 +51,8 @@ variable `GEM_HOME`to the ruby gem folder. For example:
 
 = Using IntelliJ IDEA
 Spring Cloud AWS development is done with
-http://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
-http://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
+https://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
+https://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
 import the file within idea as a maven project.
 
 _Note:_ Please make sure to revert all changes in the .idea config file
@@ -144,11 +144,11 @@ Spring Cloud Team on https://twitter.com/springcentral[Twitter]
 
 Individual team members can be found on different social media channels
 
-* Agim Emruli (http://twitter.com/aemruli[Twitter] /
-http://de.linkedin.com/in/agimemruli[LinkedIn])
-* Alain Sahli (http://twitter.com/sahlialain[Twitter] /
-http://ch.linkedin.com/in/asahli[LinkedIn])
-* Christian Stettler (http://twitter.com/chrisstettler[Twitter])
+* Agim Emruli (https://twitter.com/aemruli[Twitter] /
+https://de.linkedin.com/in/agimemruli[LinkedIn])
+* Alain Sahli (https://twitter.com/sahlialain[Twitter] /
+https://ch.linkedin.com/in/asahli[LinkedIn])
+* Christian Stettler (https://twitter.com/chrisstettler[Twitter])
 
 == Contributing
 
@@ -182,7 +182,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -195,7 +195,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -266,7 +266,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -45,8 +45,8 @@ variable `GEM_HOME`to the ruby gem folder. For example:
 
 = Using IntelliJ IDEA
 Spring Cloud AWS development is done with
-http://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
-http://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
+https://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
+https://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
 import the file within idea as a maven project.
 
 _Note:_ Please make sure to revert all changes in the .idea config file
@@ -138,11 +138,11 @@ Spring Cloud Team on https://twitter.com/springcentral[Twitter]
 
 Individual team members can be found on different social media channels
 
-* Agim Emruli (http://twitter.com/aemruli[Twitter] /
-http://de.linkedin.com/in/agimemruli[LinkedIn])
-* Alain Sahli (http://twitter.com/sahlialain[Twitter] /
-http://ch.linkedin.com/in/asahli[LinkedIn])
-* Christian Stettler (http://twitter.com/chrisstettler[Twitter])
+* Agim Emruli (https://twitter.com/aemruli[Twitter] /
+https://de.linkedin.com/in/agimemruli[LinkedIn])
+* Alain Sahli (https://twitter.com/sahlialain[Twitter] /
+https://ch.linkedin.com/in/asahli[LinkedIn])
+* Christian Stettler (https://twitter.com/chrisstettler[Twitter])
 
 == Contributing
 

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -16,8 +16,8 @@ include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/maste
 
 == Using Amazon Web Services
 
-Amazon provides a http://aws.amazon.com/sdk-for-java/[Java SDK] to issue requests for the all services provided by the
-http://aws.amazon.com[Amazon Web Service] platform. Using the SDK, application developers still have to integrate the
+Amazon provides a https://aws.amazon.com/sdk-for-java/[Java SDK] to issue requests for the all services provided by the
+https://aws.amazon.com[Amazon Web Service] platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -28,16 +28,16 @@ image::overview.png[Overview]
 
 * *Spring Cloud AWS Core* is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based http://aws.amazon.com/ec2/[EC2]
-metadata and the overall application stack specific http://aws.amazon.com/cloudformation/[CloudFormation] metadata.
-* *Spring Cloud AWS Context* delivers access to the http://aws.amazon.com/s3/[Simple Storage Service] via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the http://aws.amazon.com/ses/[Simple E-Mail Service]
+cloud based environment configurations providing direct access to the instance based https://aws.amazon.com/ec2/[EC2]
+metadata and the overall application stack specific https://aws.amazon.com/cloudformation/[CloudFormation] metadata.
+* *Spring Cloud AWS Context* delivers access to the https://aws.amazon.com/s3/[Simple Storage Service] via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the https://aws.amazon.com/ses/[Simple E-Mail Service]
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the http://aws.amazon.com/elasticache/[ElastiCache] caching service.
-* *Spring Cloud AWS JDBC* provides automatic datasource lookup and configuration for the http://aws.amazon.com/rds/[Relational Database Service]
+and the https://aws.amazon.com/elasticache/[ElastiCache] caching service.
+* *Spring Cloud AWS JDBC* provides automatic datasource lookup and configuration for the https://aws.amazon.com/rds/[Relational Database Service]
 which can be used with JDBC or any other support data access technology by Spring.
-* *Spring Cloud AWS Messaging* enables developers to receive and send messages with the http://aws.amazon.com/sqs/[Simple Queueing Service] for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the http://aws.amazon.com/sns/[Simple Notification Service].
+* *Spring Cloud AWS Messaging* enables developers to receive and send messages with the https://aws.amazon.com/sqs/[Simple Queueing Service] for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the https://aws.amazon.com/sns/[Simple Notification Service].
 * *Spring Cloud AWS Parameter Store Configuration* enables Spring Cloud applications to use the https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html[AWS Parameter Store]
 as a Bootstrap Property Source, comparable to the support provided for the Spring Cloud Config Server or Consul's key-value store.
 * *Spring Cloud AWS Secrets Manager Configuration* enables Spring Cloud applications to use the https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html[AWS Secrets Manager]
@@ -49,7 +49,7 @@ Before using the Spring Cloud AWS module developers have to pick the dependencie
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.
 
 === Spring Cloud AWS maven dependency management
-Spring Cloud AWS module dependencies can be used directly in http://maven.apache.org[Maven] with a direct configuration
+Spring Cloud AWS module dependencies can be used directly in https://maven.apache.org[Maven] with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:
 
@@ -108,9 +108,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
            <aws-context:context-region region="..."/>
 </beans>
@@ -158,7 +158,7 @@ and not be checked in into the source management system.
 ====
 
 ===== Instance profile configuration
-An http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html[instance profile configuration] allows to assign
+An https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html[instance profile configuration] allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:
@@ -197,13 +197,13 @@ errors if the properties are not configured at all.
 The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default `AWSSimpleSystemsManagement`
 client, which uses a `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` and `com.amazonaws.regions.DefaultAwsRegionProviderChain`.
 If you want to override this, then you need to
-http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
+https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration[define your own Spring Cloud bootstrap configuration class]
 with a bean of type `AWSSimpleSystemsManagement` that's configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can't simply override the bean
 in a regular `@Configuration` class.
 
 ==== Region configuration
-Amazon Web services are available in different http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[regions]. Based
+Amazon Web services are available in different https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[regions]. Based
 on the custom requirements, the user can host the application on different Amazon regions. The `spring-cloud-aws-context`
 module provides a way to define the region for the entire application context.
 
@@ -226,7 +226,7 @@ be reconfigured with property files or system properties.
 
 ===== Automatic region configuration
 If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata] and therefore must
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata] and therefore must
 not be configured statically. The configuration will look like this:
 
 [source,xml,indent=0]
@@ -336,7 +336,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.
 
 === Retrieving instance metadata
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] are available inside an
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.
@@ -416,7 +416,7 @@ directly into Java fields. The next example demonstrates the use of instance met
 
 [NOTE]
 ====
-Every instance metadata can be accessed by the key available in the http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata service]
+Every instance metadata can be accessed by the key available in the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata service]
 Nested properties can be accessed by separating the properties with a slash ('/').
 ====
 
@@ -425,7 +425,7 @@ Besides the default instance metadata it is also possible to configure user data
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format `<key>:<value>;<key>:<value>` inside the user data so that it can parse the string and extract the key value pairs.
 
-The user data can be configured using either the management console shown below or a http://aws.amazon.com/cloudformation/aws-cloudformation-templates/[CloudFormation template].
+The user data can be configured using either the management console shown below or a https://aws.amazon.com/cloudformation/aws-cloudformation-templates/[CloudFormation template].
 
 image::cloud-environment-user-data.png[User data in the management console]
 
@@ -473,7 +473,7 @@ the instance.
 
 [TIP]
 ====
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html[User data] can also be used to execute scripts
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html[User data] can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.
 ====
@@ -741,7 +741,7 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 
 == Managing cloud environments
 Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a http://aws.amazon.com/cloudformation/[CloudFormation]
+complexity of the infrastructure. Amazon Web services offers a https://aws.amazon.com/cloudformation/[CloudFormation]
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -788,7 +788,7 @@ the database.
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
   <aws-context:context-credentials>
   	...
@@ -919,7 +919,7 @@ with a special setup. The client itself can be configured using the `amazon-clou
 ----
 
 == Messaging
-Spring Cloud AWS provides http://aws.amazon.com/sqs/[Amazon SQS] and http://aws.amazon.com/sqs/[Amazon SNS] integration
+Spring Cloud AWS provides https://aws.amazon.com/sqs/[Amazon SQS] and https://aws.amazon.com/sqs/[Amazon SNS] integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.
@@ -996,9 +996,9 @@ With the messaging namespace a `QueueMessagingTemplate` can be defined in an XML
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging">
 
@@ -1084,7 +1084,7 @@ In addition to the payload, headers can be injected in the listener methods with
 annotations. `@Header` is used to inject a specific header value while `@Headers` injects a `Map<String, String>`
 containing all headers.
 
-Only the link:http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
+Only the link:https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
 message attributes] sent with an SQS message are supported. Custom attributes are currently not supported.
 
 In addition to the provided argument resolvers, custom ones can be registered on the
@@ -1355,10 +1355,10 @@ Reducing database round trips can significantly reduce the requirements for the 
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.
 
-Spring Cloud AWS integrates the http://aws.amazon.com/elasticache/[Amazon ElastiCache] service into the Spring unified
+Spring Cloud AWS integrates the https://aws.amazon.com/elasticache/[Amazon ElastiCache] service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-http://projects.spring.io/spring-data-redis/[Spring Data Redis] for Redis caches.
+https://projects.spring.io/spring-data-redis/[Spring Data Redis] for Redis caches.
 
 === Configuring dependencies for Redis caches
 Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1396,9 +1396,9 @@ configuration to enable declarative, annotation-based caching.
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<aws-context:context-credentials>
 		...
@@ -1413,7 +1413,7 @@ configuration to enable declarative, annotation-based caching.
 ----
 
 The configuration above configures a `cache-manager` with one cache with the name `CacheCluster` that represents an
-http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html[ElasticCache cluster].
+https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html[ElasticCache cluster].
 
 ==== Mixing caches
 Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1513,7 +1513,7 @@ public class ExpensiveService {
 There are different memcached client implementations available for Java, the most prominent ones are
 https://github.com/couchbase/spymemcached[Spymemcached] and https://github.com/killme2008/xmemcached[XMemcached].
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html[auto-discovery] of new nodes based on
+https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html[auto-discovery] of new nodes based on
 a central configuration endpoint.
 
 Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.
@@ -1556,7 +1556,7 @@ without any configuration change inside the application.
 
 Spring has a broad support of data access technologies built on top of JDBC like `JdbcTemplate` and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-http://aws.amazon.com/rds/[Amazon Relational Database Service] with a declarative configuration. The main support provided by Spring
+https://aws.amazon.com/rds/[Amazon Relational Database Service] with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:
 
  * Automatic data source configuration and setup based on the Amazon RDS database instance.
@@ -1592,7 +1592,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
 
  <aws-context:context-credentials>
   ...
@@ -1612,7 +1612,7 @@ that points to a valid Amazon RDS database instance. The master user password fo
 user to be used (which is recommended) then the `username` attribute can be set.
 
 With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC pool] with the default properties. The data source
+https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC pool] with the default properties. The data source
 can be later injected into any Spring Bean as shown below:
 
 [source,java,indent=0]
@@ -1659,7 +1659,7 @@ with custom pool properties.
 </beans>
 ----
 
-A full list of all configuration attributes with their value is available http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[here].
+A full list of all configuration attributes with their value is available https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[here].
 
 === Configuring data source with Java config
 Spring Cloud AWS also supports the configuration of the data source within an `@Configuration` class. The
@@ -1749,7 +1749,7 @@ outlines all properties for a data source using `test` as the instance identifie
 
 
 === Read-replica configuration
-Amazon RDS allows to use http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[MySQL read-replica]
+Amazon RDS allows to use https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[MySQL read-replica]
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.
 
@@ -1759,7 +1759,7 @@ for write operations.
 
 [CAUTION]
 ====
-Using read-replica instances does not guarantee strict http://en.wikipedia.org/wiki/ACID[ACID] semantics for the database
+Using read-replica instances does not guarantee strict https://en.wikipedia.org/wiki/ACID[ACID] semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.
@@ -1806,7 +1806,7 @@ public class SimpleDatabaseService {
 ----
 
 === Failover support
-Amazon RDS supports a http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html[Multi-AZ] fail-over if
+Amazon RDS supports a https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html[Multi-AZ] fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.
@@ -1938,9 +1938,9 @@ database is configured using CloudFormation.
 ====
 
 == Sending mails
-Spring has a built-in support to send e-mails based on the http://www.oracle.com/technetwork/java/javamail/index.html[Java Mail API]
+Spring has a built-in support to send e-mails based on the https://www.oracle.com/technetwork/java/javamail/index.html[Java Mail API]
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the http://aws.amazon.com/de/ses/[Amazon SES] as an implementation of the Spring Mail abstraction.
+Spring Cloud AWS supports the https://aws.amazon.com/de/ses/[Amazon SES] as an implementation of the Spring Mail abstraction.
 
 As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.
@@ -1962,7 +1962,7 @@ attachments as simple mail messages. A configuration with the necessary elements
 ----
 <beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<aws-context:context-credentials>
 	  ..
@@ -2028,7 +2028,7 @@ which is shown below.
 [NOTE]
 ====
 Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html[SMTP setup] required
+messages. There is no https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html[SMTP setup] required
 on the Amazon AWS side.
 ====
 
@@ -2065,7 +2065,7 @@ public class MailSendingService {
 ----
 
 === Configuring regions
-Amazon SES is not available in all http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html[regions] of the
+Amazon SES is not available in all https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html[regions] of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -2083,15 +2083,15 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 
 === Authenticating e-mails
 To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html[verify] each
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html[verify] each
 e-mail receiver otherwise the mail sender will throw a `com.amazonaws.services.simpleemail.model.MessageRejectedException`.
 
-http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html[Production access] can be requested
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html[Production access] can be requested
 and will disable the need for mail address verification.
 
 == Resource handling
 The Spring Framework provides a `org.springframework.core.io.ResourceLoader` abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the http://aws.amazon.com/s3/[Amazon S3] service
+servlet context and the classpath. Spring Cloud AWS adds support for the https://aws.amazon.com/s3/[Amazon S3] service
 to load and write resources with the resource loader and the `s3` protocol.
 
 The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
@@ -2106,7 +2106,7 @@ The configuration consists of one element for the whole application context that
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
     		...
@@ -2164,7 +2164,7 @@ public class SimpleResourceLoadingBean {
 ----
 
 ==== Uploading multi-part files
-Amazon S3 supports http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html[multi-part uploads] to
+Amazon S3 supports https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html[multi-part uploads] to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom `org.springframework.core.task.TaskExecutor`
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="cache-manager">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="cache-manager">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
@@ -22,9 +22,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:element name="context-credentials">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
@@ -22,9 +22,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:element name="context-credentials">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="mail-sender">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="mail-sender">
 		<xsd:annotation>

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
  * bound to an account if the resource is scoped ot an account.
  * <p>
  * More information on resources are available on
- * <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">the
+ * <a href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">the
  * Amazon Webservice Manual</a>
  * </p>
  *
@@ -148,7 +148,7 @@ public final class AmazonResourceName {
 	 * Returns the service name for this particular AmazonResourceName. The service name
 	 * is a plain string which will be one of the service from the namespace defined at
 	 * <a href=
-	 * "http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces">user
+	 * "https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces">user
 	 * manual</a>
 	 * @return - the service as a string - never be null
 	 */

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
@@ -59,7 +59,7 @@ public class AmazonS3ClientFactoryTest {
 		this.expectedException.expectMessage("AmazonS3 must not be null");
 
 		// Act
-		amazonS3ClientFactory.createClientForEndpointUrl(null, "http://s3.amazonaws.com");
+		amazonS3ClientFactory.createClientForEndpointUrl(null, "https://s3.amazonaws.com");
 
 		// Prepare
 
@@ -74,7 +74,7 @@ public class AmazonS3ClientFactoryTest {
 
 		// Act
 		AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
-				"http://s3.amazonaws.com");
+				"https://s3.amazonaws.com");
 
 		// Prepare
 		assertThat(newClient.getRegionName()).isEqualTo(Regions.DEFAULT_REGION.getName());

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
@@ -29,7 +29,7 @@ import static org.springframework.cloud.aws.core.naming.AmazonResourceName.fromS
 /**
  * Test for {@link AmazonResourceName} class. The examples are taken from the aws
  * documentation at
- * http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+ * https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
  *
  * @author Agim Emruli
  * @since 1.0

--- a/spring-cloud-aws-integration-test/src/test/resources/IntegrationTestStack.yaml
+++ b/spring-cloud-aws-integration-test/src/test/resources/IntegrationTestStack.yaml
@@ -148,7 +148,7 @@ Resources:
 		Type: AWS::SNS::Topic
 		Properties:
 			Subscription:
-				- Endpoint: http://build.elasticspring.org
+				- Endpoint: https://build.elasticspring.org
 				  Protocol: http
 	CacheCluster:
 		Type: AWS::ElastiCache::CacheCluster

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
@@ -31,7 +31,7 @@ import javax.sql.DataSource;
  * <p>
  * <b>Note:</b> This interface does not assume what kind of datasource is returned. It is
  * strongly recommended to use an already existing and pooled datasource like
- * <a href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC
+ * <a href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC
  * datasource</a> for real life production applications.
  * </p>
  *

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
@@ -23,9 +23,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="data-source">
 		<xsd:annotation>

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
@@ -23,9 +23,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="data-source">
 		<xsd:annotation>

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -89,7 +89,7 @@ public class SimpleMessageListenerContainerFactory {
 	 * arrive if the are currently no messages on the queue. Higher values will reduce
 	 * poll request to the system significantly. The value should be between 1 and 20. For
 	 * more information read the <a href=
-	 * "http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+	 * "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
 	 * @param waitTimeOut - the wait time out in seconds
 	 */
 	public void setWaitTimeOut(Integer waitTimeOut) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
@@ -69,7 +69,7 @@ public class NotificationMessagingTemplate
 	 * Convenience method that sends a notification with the given {@literal message} and
 	 * {@literal subject} to the {@literal destination}. The {@literal subject} is sent as
 	 * header as defined in the
-	 * <a href="http://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message
+	 * <a href="https://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message
 	 * JSON formats</a>.
 	 * @param destinationName The logical name of the destination
 	 * @param message The message to send
@@ -84,7 +84,7 @@ public class NotificationMessagingTemplate
 	 * Convenience method that sends a notification with the given {@literal message} and
 	 * {@literal subject} to the {@literal destination}. The {@literal subject} is sent as
 	 * header as defined in the
-	 * <a href="http://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message
+	 * <a href="https://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message
 	 * JSON formats</a>. The configured default destination will be used.
 	 * @param message The message to send
 	 * @param subject The subject to send

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
@@ -93,7 +93,7 @@ abstract class AbstractMessageListenerContainer
 	/**
 	 * By default sets the maximum value for long polling in SQS. For more information
 	 * read the <a href=
-	 * "http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>
+	 * "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>
 	 */
 	private Integer waitTimeOut = DEFAULT_WAIT_TIME_IN_SECONDS;
 

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
@@ -24,11 +24,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="annotation-driven-queue-listener">
 		<xsd:annotation>
@@ -147,7 +147,7 @@
 						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
 						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
 						be between 1 and 20. For more information read the
-						<a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
 
 	<xsd:element name="annotation-driven-queue-listener">
 		<xsd:annotation>
@@ -146,7 +146,7 @@
 						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
 						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
 						be between 1 and 20. For more information read the
-						<a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -77,7 +77,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com");
+				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
@@ -94,7 +94,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com");
+				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
@@ -138,7 +138,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(ReceiveMessageRequest.class);
 		verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com");
+				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
@@ -153,7 +153,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(ReceiveMessageRequest.class);
 		verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com");
+				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -273,7 +273,7 @@ public class QueueMessagingTemplateTest {
 		AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
 
 		GetQueueUrlResult queueUrl = new GetQueueUrlResult();
-		queueUrl.setQueueUrl("http://queue-url.com");
+		queueUrl.setQueueUrl("https://queue-url.com");
 		when(amazonSqs.getQueueUrl(any(GetQueueUrlRequest.class))).thenReturn(queueUrl);
 
 		ReceiveMessageResult receiveMessageResult = new ReceiveMessageResult();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
@@ -268,7 +268,7 @@ public class MessageListenerContainerTest {
 						.withQueueUrl("http://testQueue.amazonaws.com"));
 		when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("anotherTestQueue")))
 				.thenReturn(new GetQueueUrlResult()
-						.withQueueUrl("http://anotherTestQueue.amazonaws.com"));
+						.withQueueUrl("https://anotherTestQueue.amazonaws.com"));
 		when(mock.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 				.thenReturn(new GetQueueAttributesResult());
 
@@ -286,7 +286,7 @@ public class MessageListenerContainerTest {
 		assertThat(registeredQueues.get("testQueue").getReceiveMessageRequest()
 				.getWaitTimeSeconds().longValue()).isEqualTo(33L);
 		assertThat(registeredQueues.get("anotherTestQueue").getReceiveMessageRequest()
-				.getQueueUrl()).isEqualTo("http://anotherTestQueue.amazonaws.com");
+				.getQueueUrl()).isEqualTo("https://anotherTestQueue.amazonaws.com");
 		assertThat(registeredQueues.get("anotherTestQueue").getReceiveMessageRequest()
 				.getMaxNumberOfMessages().longValue()).isEqualTo(11L);
 		assertThat(registeredQueues.get("anotherTestQueue").getReceiveMessageRequest()
@@ -441,7 +441,7 @@ public class MessageListenerContainerTest {
 						destinationResolutionExceptionMessage));
 		when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("anotherTestQueue")))
 				.thenReturn(new GetQueueUrlResult()
-						.withQueueUrl("http://anotherTestQueue.amazonaws.com"));
+						.withQueueUrl("https://anotherTestQueue.amazonaws.com"));
 		when(mock.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 				.thenReturn(new GetQueueAttributesResult());
 
@@ -460,7 +460,7 @@ public class MessageListenerContainerTest {
 				.isEqualTo("Ignoring queue with name 'testQueue': "
 						+ destinationResolutionExceptionMessage);
 		assertThat(registeredQueues.get("anotherTestQueue").getReceiveMessageRequest()
-				.getQueueUrl()).isEqualTo("http://anotherTestQueue.amazonaws.com");
+				.getQueueUrl()).isEqualTo("https://anotherTestQueue.amazonaws.com");
 	}
 
 	private static class StubAbstractMessageListenerContainer

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -334,27 +334,27 @@ public class SimpleMessageListenerContainerTest {
 				AnotherTestMessageListener.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
 		mockGetQueueUrl(sqs, "anotherTestQueue",
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com")
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
 						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20)))
 								.thenReturn(new ReceiveMessageResult().withMessages(
 										new Message().withBody("messageContent")))
 								.thenReturn(new ReceiveMessageResult());
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com")
+				"https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
 						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20)))
 								.thenReturn(new ReceiveMessageResult().withMessages(
@@ -400,16 +400,16 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListener.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
+				"https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
+				"https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com")
+				"https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
 						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20)))
 								.thenReturn(new ReceiveMessageResult().withMessages(
@@ -497,9 +497,9 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListener.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
+				"https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
+				"https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
@@ -507,7 +507,7 @@ public class SimpleMessageListenerContainerTest {
 
 		MimeType mimeType = new MimeType("text", "plain", Charset.forName("UTF-8"));
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com")
+				"https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
 						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20))).thenReturn(
 								new ReceiveMessageResult().withMessages(new Message()
@@ -576,16 +576,16 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListener.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
+				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
+				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
 		mockReceiveMessage(sqs,
-				"http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com",
+				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com",
 				"messageContent", "ReceiptHandle");
 
 		// Act
@@ -595,7 +595,7 @@ public class SimpleMessageListenerContainerTest {
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com",
+				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com",
 				"ReceiptHandle")));
 	}
 
@@ -625,10 +625,10 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListenerThatThrowsAnExceptionWithAllDeletionPolicy.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
@@ -636,7 +636,7 @@ public class SimpleMessageListenerContainerTest {
 		container.afterPropertiesSet();
 
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com")
 								.withAttributeNames("All").withMaxNumberOfMessages(10)
 								.withWaitTimeSeconds(20)
@@ -657,7 +657,7 @@ public class SimpleMessageListenerContainerTest {
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com",
 				"ReceiptHandle")));
 	}
@@ -688,10 +688,10 @@ public class SimpleMessageListenerContainerTest {
 		applicationContext.registerSingleton("testMessageListener", clazz);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
 		mockGetQueueAttributesWithRedrivePolicy(sqs,
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
@@ -699,7 +699,7 @@ public class SimpleMessageListenerContainerTest {
 		container.afterPropertiesSet();
 
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com")
 								.withAttributeNames("All").withMaxNumberOfMessages(10)
 								.withWaitTimeSeconds(20)
@@ -720,7 +720,7 @@ public class SimpleMessageListenerContainerTest {
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://executeMessage_executionThrowsExceptionAnd"
+				"https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com",
 				"ReceiptHandle")));
 	}
@@ -768,7 +768,7 @@ public class SimpleMessageListenerContainerTest {
 		messageHandler.setApplicationContext(applicationContext);
 
 		mockGetQueueUrl(amazonSqs, "testQueue",
-				"http://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com");
+				"https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com");
 		messageHandler.afterPropertiesSet();
 
 		when(amazonSqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
@@ -816,17 +816,17 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListenerWithManualDeletionPolicy.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
-		mockReceiveMessage(sqs, "http://receiveMessage_withMessageListenerMethodAnd"
+		mockReceiveMessage(sqs, "https://receiveMessage_withMessageListenerMethodAnd"
 				+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com",
 				"messageContent", "ReceiptHandle");
 
@@ -836,7 +836,7 @@ public class SimpleMessageListenerContainerTest {
 		// Assert
 		countDownLatch.await(1L, TimeUnit.SECONDS);
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com",
 				"ReceiptHandle")));
 		TestMessageListenerWithManualDeletionPolicy testMessageListenerWithManualDeletionPolicy = applicationContext
@@ -845,7 +845,7 @@ public class SimpleMessageListenerContainerTest {
 				TimeUnit.SECONDS);
 		testMessageListenerWithManualDeletionPolicy.acknowledge();
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com",
 				"ReceiptHandle")));
 		container.stop();
@@ -877,17 +877,17 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListenerWithVisibilityProlong.class);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://receiveMessage_withMessageListenerMethodAnd"
+				"https://receiveMessage_withMessageListenerMethodAnd"
 						+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
-		mockReceiveMessage(sqs, "http://receiveMessage_withMessageListenerMethodAnd"
+		mockReceiveMessage(sqs, "https://receiveMessage_withMessageListenerMethodAnd"
 				+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com",
 				"messageContent", "ReceiptHandle");
 
@@ -905,7 +905,7 @@ public class SimpleMessageListenerContainerTest {
 		testMessageListenerWithVisibilityProlong.extend(5);
 		verify(sqs, times(1))
 				.changeMessageVisibilityAsync(eq(new ChangeMessageVisibilityRequest(
-						"http://receiveMessage_withMessageListenerMethodAnd"
+						"https://receiveMessage_withMessageListenerMethodAnd"
 								+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com",
 						"ReceiptHandle", 5)));
 		container.stop();
@@ -928,44 +928,44 @@ public class SimpleMessageListenerContainerTest {
 		applicationContext.registerSingleton("testListener",
 				TestMessageListenerWithAllPossibleDeletionPolicies.class);
 
-		mockGetQueueUrl(sqs, "alwaysSuccess", "http://alwaysSuccess.amazonaws.com");
-		mockGetQueueAttributesWithEmptyResult(sqs, "http://alwaysSuccess.amazonaws.com");
-		mockGetQueueUrl(sqs, "alwaysError", "http://alwaysError.amazonaws.com");
-		mockGetQueueAttributesWithEmptyResult(sqs, "http://alwaysError.amazonaws.com");
-		mockGetQueueUrl(sqs, "onSuccessSuccess", "http://onSuccessSuccess.amazonaws.com");
+		mockGetQueueUrl(sqs, "alwaysSuccess", "https://alwaysSuccess.amazonaws.com");
+		mockGetQueueAttributesWithEmptyResult(sqs, "https://alwaysSuccess.amazonaws.com");
+		mockGetQueueUrl(sqs, "alwaysError", "https://alwaysError.amazonaws.com");
+		mockGetQueueAttributesWithEmptyResult(sqs, "https://alwaysError.amazonaws.com");
+		mockGetQueueUrl(sqs, "onSuccessSuccess", "https://onSuccessSuccess.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://onSuccessSuccess.amazonaws.com");
-		mockGetQueueUrl(sqs, "onSuccessError", "http://onSuccessError.amazonaws.com");
-		mockGetQueueAttributesWithEmptyResult(sqs, "http://onSuccessError.amazonaws.com");
-		mockGetQueueUrl(sqs, "noRedriveSuccess", "http://noRedriveSuccess.amazonaws.com");
+				"https://onSuccessSuccess.amazonaws.com");
+		mockGetQueueUrl(sqs, "onSuccessError", "https://onSuccessError.amazonaws.com");
+		mockGetQueueAttributesWithEmptyResult(sqs, "https://onSuccessError.amazonaws.com");
+		mockGetQueueUrl(sqs, "noRedriveSuccess", "https://noRedriveSuccess.amazonaws.com");
 		mockGetQueueAttributesWithRedrivePolicy(sqs,
-				"http://noRedriveSuccess.amazonaws.com");
-		mockGetQueueUrl(sqs, "noRedriveError", "http://noRedriveError.amazonaws.com");
+				"https://noRedriveSuccess.amazonaws.com");
+		mockGetQueueUrl(sqs, "noRedriveError", "https://noRedriveError.amazonaws.com");
 		mockGetQueueAttributesWithRedrivePolicy(sqs,
-				"http://noRedriveError.amazonaws.com");
-		mockGetQueueUrl(sqs, "neverSuccess", "http://neverSuccess.amazonaws.com");
-		mockGetQueueAttributesWithEmptyResult(sqs, "http://neverSuccess.amazonaws.com");
-		mockGetQueueUrl(sqs, "neverError", "http://neverError.amazonaws.com");
-		mockGetQueueAttributesWithEmptyResult(sqs, "http://neverError.amazonaws.com");
+				"https://noRedriveError.amazonaws.com");
+		mockGetQueueUrl(sqs, "neverSuccess", "https://neverSuccess.amazonaws.com");
+		mockGetQueueAttributesWithEmptyResult(sqs, "https://neverSuccess.amazonaws.com");
+		mockGetQueueUrl(sqs, "neverError", "https://neverError.amazonaws.com");
+		mockGetQueueAttributesWithEmptyResult(sqs, "https://neverError.amazonaws.com");
 
 		messageHandler.setApplicationContext(applicationContext);
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
 
-		mockReceiveMessage(sqs, "http://alwaysSuccess.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://alwaysSuccess.amazonaws.com", "foo",
 				"alwaysSuccess");
-		mockReceiveMessage(sqs, "http://alwaysError.amazonaws.com", "foo", "alwaysError");
-		mockReceiveMessage(sqs, "http://onSuccessSuccess.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://alwaysError.amazonaws.com", "foo", "alwaysError");
+		mockReceiveMessage(sqs, "https://onSuccessSuccess.amazonaws.com", "foo",
 				"onSuccessSuccess");
-		mockReceiveMessage(sqs, "http://onSuccessError.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://onSuccessError.amazonaws.com", "foo",
 				"onSuccessError");
-		mockReceiveMessage(sqs, "http://noRedriveSuccess.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://noRedriveSuccess.amazonaws.com", "foo",
 				"noRedriveSuccess");
-		mockReceiveMessage(sqs, "http://noRedriveError.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://noRedriveError.amazonaws.com", "foo",
 				"noRedriveError");
-		mockReceiveMessage(sqs, "http://neverSuccess.amazonaws.com", "foo",
+		mockReceiveMessage(sqs, "https://neverSuccess.amazonaws.com", "foo",
 				"neverSuccess");
-		mockReceiveMessage(sqs, "http://neverError.amazonaws.com", "foo", "neverError");
+		mockReceiveMessage(sqs, "https://neverError.amazonaws.com", "foo", "neverError");
 
 		// Act
 		container.start();
@@ -976,21 +976,21 @@ public class SimpleMessageListenerContainerTest {
 		assertThat(bean.getCountdownLatch().await(1L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://alwaysSuccess.amazonaws.com", "alwaysSuccess")));
+				"https://alwaysSuccess.amazonaws.com", "alwaysSuccess")));
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://alwaysError.amazonaws.com", "alwaysError")));
+				"https://alwaysError.amazonaws.com", "alwaysError")));
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://onSuccessSuccess.amazonaws.com", "onSuccessSuccess")));
+				"https://onSuccessSuccess.amazonaws.com", "onSuccessSuccess")));
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://onSuccessError.amazonaws.com", "onSuccessError")));
+				"https://onSuccessError.amazonaws.com", "onSuccessError")));
 		verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://noRedriveSuccess.amazonaws.com", "noRedriveSuccess")));
+				"https://noRedriveSuccess.amazonaws.com", "noRedriveSuccess")));
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://noRedriveError.amazonaws.com", "noRedriveError")));
+				"https://noRedriveError.amazonaws.com", "noRedriveError")));
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://neverSuccess.amazonaws.com", "neverSuccess")));
+				"https://neverSuccess.amazonaws.com", "neverSuccess")));
 		verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest(
-				"http://neverError.amazonaws.com", "neverError")));
+				"https://neverError.amazonaws.com", "neverError")));
 
 		setLogLevel(previous);
 	}
@@ -1015,13 +1015,13 @@ public class SimpleMessageListenerContainerTest {
 		container.setMessageHandler(messageHandler);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
+				"https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
+				"https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
 		mockGetQueueUrl(sqs, "anotherTestQueue",
-				"http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
+				"https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
+				"https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
 
 		when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
 				.thenReturn(new ReceiveMessageResult());
@@ -1146,9 +1146,9 @@ public class SimpleMessageListenerContainerTest {
 		container.setMessageHandler(messageHandler);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+				"https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+				"https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
@@ -1183,9 +1183,9 @@ public class SimpleMessageListenerContainerTest {
 		container.setMessageHandler(messageHandler);
 
 		mockGetQueueUrl(sqs, "testQueue",
-				"http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+				"https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+				"https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 
 		messageHandler.afterPropertiesSet();
 		container.afterPropertiesSet();
@@ -1220,11 +1220,11 @@ public class SimpleMessageListenerContainerTest {
 		container.setMessageHandler(messageHandler);
 
 		mockGetQueueUrl(sqs, "longRunningQueueMessage",
-				"http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
+				"https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
+				"https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
 		mockReceiveMessage(sqs,
-				"http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com",
+				"https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com",
 				"Hello", "ReceiptHandle");
 
 		messageHandler.afterPropertiesSet();
@@ -1290,10 +1290,10 @@ public class SimpleMessageListenerContainerTest {
 		container.setMessageHandler(messageHandler);
 
 		mockGetQueueUrl(sqs, "testQueue", "http://testQueue.amazonaws.com");
-		mockGetQueueUrl(sqs, "anotherTestQueue", "http://anotherTestQueue.amazonaws.com");
+		mockGetQueueUrl(sqs, "anotherTestQueue", "https://anotherTestQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs, "http://testQueue.amazonaws.com");
 		mockGetQueueAttributesWithEmptyResult(sqs,
-				"http://anotherTestQueue.amazonaws.com");
+				"https://anotherTestQueue.amazonaws.com");
 
 		when(sqs.receiveMessage(
 				new ReceiveMessageRequest("http://testQueue.amazonaws.com")
@@ -1306,7 +1306,7 @@ public class SimpleMessageListenerContainerTest {
 								});
 
 		when(sqs.receiveMessage(
-				new ReceiveMessageRequest("http://anotherTestQueue.amazonaws.com")
+				new ReceiveMessageRequest("https://anotherTestQueue.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
 						.withMaxNumberOfMessages(10)))
 								.thenAnswer((Answer<ReceiveMessageResult>) invocation -> {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
@@ -38,7 +38,7 @@ public class DynamicQueueUrlDestinationResolverTest {
 	@Test
 	public void testAutoCreate() throws Exception {
 		AmazonSQS amazonSqs = mock(AmazonSQS.class);
-		String queueUrl = "http://foo/bar";
+		String queueUrl = "https://foo/bar";
 		when(amazonSqs.createQueue(new CreateQueueRequest("foo")))
 				.thenReturn(new CreateQueueResult().withQueueUrl(queueUrl));
 
@@ -54,7 +54,7 @@ public class DynamicQueueUrlDestinationResolverTest {
 		AmazonSQS amazonSqs = mock(AmazonSQS.class);
 		DynamicQueueUrlDestinationResolver dynamicQueueDestinationResolver = new DynamicQueueUrlDestinationResolver(
 				amazonSqs);
-		String destination = "http://sqs-amazon.aws.com/123123123/myQueue";
+		String destination = "https://sqs-amazon.aws.com/123123123/myQueue";
 		assertThat(dynamicQueueDestinationResolver.resolveDestination(destination))
 				.isEqualTo(destination);
 	}
@@ -62,7 +62,7 @@ public class DynamicQueueUrlDestinationResolverTest {
 	@Test
 	public void testNoAutoCreate() throws Exception {
 		AmazonSQS amazonSqs = mock(AmazonSQS.class);
-		String queueUrl = "http://foo/bar";
+		String queueUrl = "https://foo/bar";
 		when(amazonSqs.getQueueUrl(new GetQueueUrlRequest("foo")))
 				.thenReturn(new GetQueueUrlResult().withQueueUrl(queueUrl));
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://queue.com (200) with 4 occurrences could not be migrated:  
   ([https](https://queue.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ch.linkedin.com/in/asahli (IllegalArgumentException) with 2 occurrences migrated to:  
  https://ch.linkedin.com/in/asahli ([https](https://ch.linkedin.com/in/asahli) result IllegalArgumentException).
* [ ] http://de.linkedin.com/in/agimemruli (IllegalArgumentException) with 2 occurrences migrated to:  
  https://de.linkedin.com/in/agimemruli ([https](https://de.linkedin.com/in/agimemruli) result IllegalArgumentException).
* [ ] http://alwaysError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://alwaysError.amazonaws.com ([https](https://alwaysError.amazonaws.com) result UnknownHostException).
* [ ] http://alwaysSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://alwaysSuccess.amazonaws.com ([https](https://alwaysSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://anotherTestQueue.amazonaws.com (UnknownHostException) with 7 occurrences migrated to:  
  https://anotherTestQueue.amazonaws.com ([https](https://anotherTestQueue.amazonaws.com) result UnknownHostException).
* [ ] http://build.elasticspring.org (UnknownHostException) with 1 occurrences migrated to:  
  https://build.elasticspring.org ([https](https://build.elasticspring.org) result UnknownHostException).
* [ ] http://executeMessage_executionThrowsExceptionAnd (UnknownHostException) with 8 occurrences migrated to:  
  https://executeMessage_executionThrowsExceptionAnd ([https](https://executeMessage_executionThrowsExceptionAnd) result UnknownHostException).
* [ ] http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com ([https](https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com) result UnknownHostException).
* [ ] http://foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/bar ([https](https://foo/bar) result UnknownHostException).
* [ ] http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com ([https](https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com) result UnknownHostException).
* [ ] http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com ([https](https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com) result UnknownHostException).
* [ ] http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com ([https](https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com) result UnknownHostException).
* [ ] http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com ([https](https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com) result UnknownHostException).
* [ ] http://neverError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://neverError.amazonaws.com ([https](https://neverError.amazonaws.com) result UnknownHostException).
* [ ] http://neverSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://neverSuccess.amazonaws.com ([https](https://neverSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://noRedriveError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://noRedriveError.amazonaws.com ([https](https://noRedriveError.amazonaws.com) result UnknownHostException).
* [ ] http://noRedriveSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://noRedriveSuccess.amazonaws.com ([https](https://noRedriveSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://onSuccessError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://onSuccessError.amazonaws.com ([https](https://onSuccessError.amazonaws.com) result UnknownHostException).
* [ ] http://onSuccessSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://onSuccessSuccess.amazonaws.com ([https](https://onSuccessSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://queue-url.com (UnknownHostException) with 5 occurrences migrated to:  
  https://queue-url.com ([https](https://queue-url.com) result UnknownHostException).
* [ ] http://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com (UnknownHostException) with 1 occurrences migrated to:  
  https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com ([https](https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com) result UnknownHostException).
* [ ] http://receiveMessage_withMessageListenerMethodAnd (UnknownHostException) with 9 occurrences migrated to:  
  https://receiveMessage_withMessageListenerMethodAnd ([https](https://receiveMessage_withMessageListenerMethodAnd) result UnknownHostException).
* [ ] http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com ([https](https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com) result UnknownHostException).
* [ ] http://sqs-amazon.aws.com/123123123/myQueue (UnknownHostException) with 1 occurrences migrated to:  
  https://sqs-amazon.aws.com/123123123/myQueue ([https](https://sqs-amazon.aws.com/123123123/myQueue) result UnknownHostException).
* [ ] http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com ([https](https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com ([https](https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com ([https](https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com ([https](https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://EditorConfig.org with 1 occurrences migrated to:  
  https://EditorConfig.org ([https](https://EditorConfig.org) result 200).
* [ ] http://aws.amazon.com with 1 occurrences migrated to:  
  https://aws.amazon.com ([https](https://aws.amazon.com) result 200).
* [ ] http://aws.amazon.com/cloudformation/ with 2 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/ ([https](https://aws.amazon.com/cloudformation/) result 200).
* [ ] http://aws.amazon.com/cloudformation/aws-cloudformation-templates/ with 1 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/aws-cloudformation-templates/ ([https](https://aws.amazon.com/cloudformation/aws-cloudformation-templates/) result 200).
* [ ] http://aws.amazon.com/de/ses/ with 1 occurrences migrated to:  
  https://aws.amazon.com/de/ses/ ([https](https://aws.amazon.com/de/ses/) result 200).
* [ ] http://aws.amazon.com/ec2/ with 1 occurrences migrated to:  
  https://aws.amazon.com/ec2/ ([https](https://aws.amazon.com/ec2/) result 200).
* [ ] http://aws.amazon.com/elasticache/ with 2 occurrences migrated to:  
  https://aws.amazon.com/elasticache/ ([https](https://aws.amazon.com/elasticache/) result 200).
* [ ] http://aws.amazon.com/rds/ with 2 occurrences migrated to:  
  https://aws.amazon.com/rds/ ([https](https://aws.amazon.com/rds/) result 200).
* [ ] http://aws.amazon.com/s3/ with 2 occurrences migrated to:  
  https://aws.amazon.com/s3/ ([https](https://aws.amazon.com/s3/) result 200).
* [ ] http://aws.amazon.com/sdk-for-java/ with 1 occurrences migrated to:  
  https://aws.amazon.com/sdk-for-java/ ([https](https://aws.amazon.com/sdk-for-java/) result 200).
* [ ] http://aws.amazon.com/ses/ with 1 occurrences migrated to:  
  https://aws.amazon.com/ses/ ([https](https://aws.amazon.com/ses/) result 200).
* [ ] http://aws.amazon.com/sns/ with 1 occurrences migrated to:  
  https://aws.amazon.com/sns/ ([https](https://aws.amazon.com/sns/) result 200).
* [ ] http://aws.amazon.com/sqs/ with 3 occurrences migrated to:  
  https://aws.amazon.com/sqs/ ([https](https://aws.amazon.com/sqs/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html ([https](https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html with 3 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html with 4 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html ([https](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html) result 200).
* [ ] http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html with 3 occurrences migrated to:  
  https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html ([https](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html) result 200).
* [ ] http://en.wikipedia.org/wiki/ACID with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ACID ([https](https://en.wikipedia.org/wiki/ACID) result 200).
* [ ] http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://projects.spring.io/spring-data-redis/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-redis/ ([https](https://projects.spring.io/spring-data-redis/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html with 3 occurrences migrated to:  
  https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html ([https](https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html) result 200).
* [ ] http://twitter.com/aemruli with 2 occurrences migrated to:  
  https://twitter.com/aemruli ([https](https://twitter.com/aemruli) result 200).
* [ ] http://twitter.com/chrisstettler with 2 occurrences migrated to:  
  https://twitter.com/chrisstettler ([https](https://twitter.com/chrisstettler) result 200).
* [ ] http://twitter.com/sahlialain with 2 occurrences migrated to:  
  https://twitter.com/sahlialain ([https](https://twitter.com/sahlialain) result 200).
* [ ] http://www.jetbrains.com/idea/ with 4 occurrences migrated to:  
  https://www.jetbrains.com/idea/ ([https](https://www.jetbrains.com/idea/) result 200).
* [ ] http://www.oracle.com/technetwork/java/javamail/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javamail/index.html ([https](https://www.oracle.com/technetwork/java/javamail/index.html) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool.xsd ([https](https://www.springframework.org/schema/tool/spring-tool.xsd) result 200).
* [ ] http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html ([https](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 301).
* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd) result 301).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd with 12 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd) result 301).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd) result 301).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd) result 301).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) result 302).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html) result 302).
* [ ] http://docs.aws.amazon.com/sns/latest/dg/json-formats.html with 2 occurrences migrated to:  
  https://docs.aws.amazon.com/sns/latest/dg/json-formats.html ([https](https://docs.aws.amazon.com/sns/latest/dg/json-formats.html) result 302).
* [ ] http://s3.amazonaws.com with 2 occurrences migrated to:  
  https://s3.amazonaws.com ([https](https://s3.amazonaws.com) result 307).

# Ignored
These URLs were intentionally ignored.

* http://testContainerDoesNotProcessMessageAfterBeingStopped.amazonaws.com with 2 occurrences
* http://testQueue with 39 occurrences
* http://testQueue.amazonaws.com with 13 occurrences
* http://testSimpleReceiveMessage.amazonaws.com with 3 occurrences
* http://www.springframework.org/schema/beans with 17 occurrences
* http://www.springframework.org/schema/cache with 2 occurrences
* http://www.springframework.org/schema/cloud/aws/cache with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/context with 28 occurrences
* http://www.springframework.org/schema/cloud/aws/jdbc with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/mail with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging with 1 occurrences
* http://www.springframework.org/schema/tool with 20 occurrences
* http://www.w3.org/2001/XMLSchema with 10 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 5 occurrences