### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/TestMemcacheServer.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/TestMemcacheServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaDataServer.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaDataServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-autoconfigure/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-autoconfigure/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/AbstractCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/AbstractCacheFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/CacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/CacheFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/ElastiCacheFactoryBean.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/ElastiCacheFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/CacheClusterConfig.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/CacheClusterConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCacheConfigurer.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCacheConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/EnableElastiCache.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/EnableElastiCache.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/SimpleSpringMemcached.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/SimpleSpringMemcached.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnAwsCloudEnvironment.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnAwsCloudEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnClass.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnMissingAmazonClient.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnMissingAmazonClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnAwsCloudEnvironmentCondition.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnAwsCloudEnvironmentCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnClassCondition.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnClassCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientCondition.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/AmazonEc2InstanceDataPropertySourcePostProcessor.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/AmazonEc2InstanceDataPropertySourcePostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextDefaultConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextDefaultConfigurationRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextInstanceData.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextInstanceData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextResourceLoader.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableStackConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableStackConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/GlobalBeanDefinitionUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/GlobalBeanDefinitionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderBeanPostProcessor.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/MailNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/MailNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceJavaMailSender.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceJavaMailSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceMailSender.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceMailSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-context/src/main/resources/META-INF/spring.handlers
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-context/src/main/resources/META-INF/spring.schemas
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/ElastiCacheFactoryBeanTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/ElastiCacheFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/TestMemcacheServer.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/TestMemcacheServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactoryTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/memcached/SimpleSpringMemcachedTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/memcached/SimpleSpringMemcachedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactoryTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/MetaDataServer.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/MetaDataServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientConditionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientConditionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/AmazonEc2InstanceDataPropertySourcePostProcessorTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/AmazonEc2InstanceDataPropertySourcePostProcessorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/GlobalBeanDefinitionUtilsTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/GlobalBeanDefinitionUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderTestBeanPostProcessorTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderTestBeanPostProcessorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceJavaMailSenderTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceJavaMailSenderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceMailSenderTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/simplemail/SimpleEmailServiceMailSenderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-context/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ResourceIdResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ResourceIdResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/StackResourceRegistryDetectingResourceIdResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/StackResourceRegistryDetectingResourceIdResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/InstanceIdProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/InstanceIdProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/ListableStackResourceFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/ListableStackResourceFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/StackResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/StackResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/StackResourceRegistry.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/StackResourceRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/AutoDetectingStackNameProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/AutoDetectingStackNameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackNameProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackNameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StaticStackNameProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StaticStackNameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/RegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/RegionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/support/documentation/RuntimeUse.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/support/documentation/RuntimeUse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/task/ShutdownSuppressingExecutorServiceAdapter.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/task/ShutdownSuppressingExecutorServiceAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/main/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.properties
+++ b/spring-cloud-aws-core/src/main/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClient.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/StackResourceRegistryDetectingResourceIdResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/StackResourceRegistryDetectingResourceIdResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceLoaderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProviderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/StaticRegionProviderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/StaticRegionProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-core/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-core/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/BootElastiCacheAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/BootElastiCacheAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/CachingService.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/CachingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/ElastiCacheAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/ElastiCacheAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/JavaElastiCacheAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/JavaElastiCacheAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/BootPathMatchingResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/BootPathMatchingResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/BootResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/BootResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/JavaPathMatchingResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/JavaPathMatchingResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/PathMatchingResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/PathMatchingResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/ResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProviderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProviderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/JavaAmazonEc2InstanceDataPropertySourceAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/JavaAmazonEc2InstanceDataPropertySourceAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/SimpleConfigurationBean.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/SimpleConfigurationBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/BootStackConfigurationAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/BootStackConfigurationAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/JavaStackConfigurationAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/JavaStackConfigurationAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/StackConfigurationAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/StackConfigurationAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/BootDataSourceFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/BootDataSourceFactoryBeanAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/DataSourceFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/DataSourceFactoryBeanAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/DatabaseService.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/DatabaseService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/JavaDataSourceFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/JavaDataSourceFactoryBeanAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/SimpleDatabaseService.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/SimpleDatabaseService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/BootMailSenderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/BootMailSenderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/MailSenderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/MailSenderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/AbstractContainerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/AbstractContainerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootMessageListenerContainerAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootMessageListenerContainerAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootNotificationMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaMessageListenerContainerAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaMessageListenerContainerAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaNotificationMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/MessageListenerContainerAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/MessageListenerContainerAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/NotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/NotificationMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlQueueListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/TestStackEnvironment.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/TestStackEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/TestStackInstanceIdService.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/TestStackInstanceIdService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/AmazonWebserviceProfileValueSource.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/AmazonWebserviceProfileValueSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/IfAmazonWebserviceEnvironment.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/IfAmazonWebserviceEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-config.properties
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-config.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/EnableRdsInstance.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/EnableRdsInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/RdsInstanceConfigurer.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/RdsInstanceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcNamespaceHandler.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceInformation.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/ReadOnlyRoutingDataSource.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/ReadOnlyRoutingDataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/TomcatJdbcDataSourceFactory.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/TomcatJdbcDataSourceFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/DatabasePlatformSupport.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/DatabasePlatformSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/DatabaseType.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/DatabaseType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/MapBasedDatabasePlatformSupport.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/MapBasedDatabasePlatformSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/StaticDatabasePlatformSupport.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/support/StaticDatabasePlatformSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceFactoryBean.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceUserTagsFactoryBean.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceUserTagsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBean.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/DatabaseInstanceStatusRetryPolicy.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/DatabaseInstanceStatusRetryPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/InstanceStatus.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/InstanceStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/JdbcRetryException.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/JdbcRetryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/RdbmsRetryOperationsInterceptor.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/RdbmsRetryOperationsInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/SqlRetryPolicy.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/retry/SqlRetryPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.handlers
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.schemas
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/ReadOnlyRoutingDataSourceTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/ReadOnlyRoutingDataSourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/TomcatJdbcDataSourceFactoryTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/TomcatJdbcDataSourceFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/support/MapBasedDatabasePlatformSupportTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/datasource/support/MapBasedDatabasePlatformSupportTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceFactoryBeanTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsDataSourceUserTagsFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBeanTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/DatabaseInstanceStatusRetryPolicyTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/DatabaseInstanceStatusRetryPolicyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/RdbmsRetryOperationsInterceptorTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/RdbmsRetryOperationsInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/SqlRetryPolicyTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/retry/SqlRetryPolicyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSns.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSns.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/NotificationMessage.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/NotificationMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/NotificationSubject.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/NotificationSubject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsWebConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsWebConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/MessagingNamespaceHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/MessagingNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/MessageAttributeDataTypes.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/MessageAttributeDataTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/AbstractNotificationMessageHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/AbstractNotificationMessageHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatus.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationSubjectHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationSubjectHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationMessageMapping.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationMessageMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationSubscriptionMapping.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationSubscriptionMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationUnsubscribeConfirmationMapping.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/annotation/NotificationUnsubscribeConfirmationMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBean.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SendToHandlerMethodReturnValueHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SendToHandlerMethodReturnValueHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/NotificationMessageArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/NotificationMessageArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/NotificationSubjectArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/NotificationSubjectArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/converter/NotificationRequestConverter.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/converter/NotificationRequestConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/converter/ObjectMessageConverter.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/converter/ObjectMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicTopicDestinationResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/destination/DynamicTopicDestinationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.handlers
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.schemas
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/AbstractNotificationMessageHandlerMethodArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/AbstractNotificationMessageHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationSubjectHandlerMethodArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationSubjectHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationTestController.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationTestController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBeanTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SendToHandlerMethodReturnValueHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SendToHandlerMethodReturnValueHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/NotificationMessageArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/NotificationMessageArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/NotificationSubjectArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/NotificationSubjectArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/converter/NotificationRequestConverterTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/converter/NotificationRequestConverterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/converter/ObjectMessageConverterTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/converter/ObjectMessageConverterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicTopicDestinationResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicTopicDestinationResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/log4j.xml
@@ -7,7 +7,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-delete-message-on-exception-false.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-delete-message-on-exception-false.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 429 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).