### PR TITLE
URL Cleanup

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -15,7 +15,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -23,7 +23,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone-local</url>
+			<url>https://repo.spring.io/libs-milestone-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -31,7 +31,7 @@
 		<repository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -41,7 +41,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -49,7 +49,7 @@
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone-local</url>
+			<url>https://repo.spring.io/libs-milestone-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -15,9 +15,9 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<artifactId>spring-cloud-aws</artifactId>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-autoconfigure/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-autoconfigure/src/test/resources/log4j.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-context/pom.xml
+++ b/spring-cloud-aws-context/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-context/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-context/src/test/resources/log4j.xml
@@ -17,7 +17,7 @@
   -->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-	   		http://www.springframework.org/schema/cloud/aws/cache
-	   		http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/cloud/aws/cache
+	   		https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
       <aws-cache:cache-cluster name="memcached" expiration="1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
@@ -16,13 +16,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-           	http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+           	https://www.springframework.org/schema/cloud/aws/cache
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-ref ref="memc" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
@@ -16,12 +16,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/cloud/aws/cache
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
@@ -16,12 +16,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/cloud/aws/cache
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
       <aws-cache:cache-cluster name="memcached" region="eu-west-1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
@@ -16,12 +16,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-           	http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+           	https://www.springframework.org/schema/cloud/aws/cache
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="testMemcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
@@ -16,12 +16,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
-	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/cloud/aws/cache
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" amazon-elasti-cache="customClient" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans 
-	   http://www.springframework.org/schema/beans/spring-beans.xsd 
-	   http://www.springframework.org/schema/cloud/aws/cache
-	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans 
+	   https://www.springframework.org/schema/beans/spring-beans.xsd 
+	   https://www.springframework.org/schema/cloud/aws/cache
+	   https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
       <aws-cache:cache-cluster name="memcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:cache="http://www.springframework.org/schema/cloud/aws/cache"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
-			     	   	   http://www.springframework.org/schema/cloud/aws/cache
-			     	   	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cache="https://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/cloud/aws/cache
+			     	   	   https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<cache:cache-manager>
 		<cache:cache-cluster name="test" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:profile-credentials profileName="test" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans" xmlns:context="https://www.springframework.org/schema/context"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:profile-credentials profileName="customProfile" profilePath="${profilePath}" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key=" " secret-key="staticSecretKey" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="staticAccessKey" secret-key=" " />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd   https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="#{configuration['accessKey']}"

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:spc="http://www.springframework.org/schema/context"
-	   xmlns:util="http://www.springframework.org/schema/util" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:spc="https://www.springframework.org/schema/context"
+	   xmlns:util="https://www.springframework.org/schema/util" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="${accessKey}" secret-key="${secretKey}" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <context:context-instance-data />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-instance-data attribute-separator="/" value-separator="=" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <context:context-instance-data user-tags-map="myUserTags" amazon-ec2="amazonEC2Client" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <context:context-instance-data user-tags-map="myUserTags" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <context:context-region region="sa-east-1" />
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-region auto-detect="true" />
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<!--suppress UnparsedCustomBeanInspection -->
   <context:context-region auto-detect="true" region="sa-east-1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-region region-provider="myRegionProvider" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<!--suppress UnparsedCustomBeanInspection -->
 	<context:context-region />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <context:context-region region="sa-east-1" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
@@ -14,11 +14,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-region region="#{configuration['region']}" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -14,12 +14,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns:context="https://www.springframework.org/schema/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<aws-context:context-region region="${region}" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:task="http://www.springframework.org/schema/task" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="https://www.springframework.org/schema/task" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
-			     	   	   http://www.springframework.org/schema/cloud/aws/context
-			     	   	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/cloud/aws/context
+			     	   	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="staticAccessKey" secret-key="staticSecretKey" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
@@ -14,11 +14,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-       xmlns="http://www.springframework.org/schema/beans"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	   				   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+       xmlns="https://www.springframework.org/schema/beans"
+       xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	   				   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:stack-configuration />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
@@ -14,11 +14,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-       xmlns="http://www.springframework.org/schema/beans"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+       xmlns="https://www.springframework.org/schema/beans"
+       xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:stack-configuration stack-name="IntegrationTestStack" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:stack-configuration amazon-cloud-formation="customCloudFormationClient" stack-name="test"
 									 user-tags-map="customStackTags" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
-			     	   	   http://www.springframework.org/schema/cloud/aws/mail
-			     	   	   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/cloud/aws/mail
+			     	   	   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<mail:mail-sender id="mailSender" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/mail http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/mail https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
 
 	<aws-mail:mail-sender id="test" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/mail http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/mail https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
 
   <aws-mail:mail-sender id="test" region="eu-west-1" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/mail http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/mail https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
 
 	<bean id="myRegionProvider" class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
       <constructor-arg name="configuredRegion" value="ap-southeast-2" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/mail http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/mail https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
 
 	<aws-mail:mail-sender id="test" amazon-ses="emailServiceClient" />
 

--- a/spring-cloud-aws-core/pom.xml
+++ b/spring-cloud-aws-core/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-core/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-core/src/test/resources/log4j.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-integration-test/pom.xml
+++ b/spring-cloud-aws-integration-test/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-                           http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:context="https://www.springframework.org/schema/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                           https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+                           https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="${cloud.aws.credentials.accessKey}" secret-key="${cloud.aws.credentials.secretKey}" />

--- a/spring-cloud-aws-integration-test/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/log4j.xml
@@ -17,7 +17,7 @@
   -->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
@@ -15,12 +15,12 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
-       xmlns:cache="http://www.springframework.org/schema/cache"
-       xmlns="http://www.springframework.org/schema/beans"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/cloud/aws/cache http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aws-cache="https://www.springframework.org/schema/cloud/aws/cache"
+       xmlns:cache="https://www.springframework.org/schema/cache"
+       xmlns="https://www.springframework.org/schema/beans"
+       xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd https://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:task="http://www.springframework.org/schema/task" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="https://www.springframework.org/schema/task" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:task="http://www.springframework.org/schema/task" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="https://www.springframework.org/schema/task" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                           https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                           https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
@@ -15,9 +15,9 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:Integration-test-context.xml"/>
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
@@ -14,9 +14,9 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
@@ -16,15 +16,15 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
-	   xmlns:tx="http://www.springframework.org/schema/tx"
-	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd
-	   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-	   http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:tx="https://www.springframework.org/schema/tx"
+	   xmlns:aop="https://www.springframework.org/schema/aop"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd
+	   https://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd
+	   https://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-                           http://www.springframework.org/schema/cloud/aws/mail http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-mail="https://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                           https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+                           https://www.springframework.org/schema/cloud/aws/mail https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
@@ -16,15 +16,15 @@
   -->
 
 <!--suppress UnparsedCustomBeanInspection -->
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:task="http://www.springframework.org/schema/task"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   					   http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:task="https://www.springframework.org/schema/task"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   					   https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 	<aws-context:stack-configuration stack-name="IntegrationTestStack" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-jdbc/pom.xml
+++ b/spring-cloud-aws-jdbc/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-jdbc/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/log4j.xml
@@ -17,7 +17,7 @@
   -->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
@@ -16,10 +16,10 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd">
 
   <jdbc:data-source db-instance-identifier="test" password="password" />
 

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
@@ -16,11 +16,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/jdbc http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc" xmlns:context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/jdbc https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
@@ -16,13 +16,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-			   			   http://www.springframework.org/schema/cloud/aws/jdbc
-			   			   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="https://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+			   			   https://www.springframework.org/schema/cloud/aws/jdbc
+			   			   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
 
 	<jdbc:data-source db-instance-identifier="test" password="password" region="eu-west-1" />
 

--- a/spring-cloud-aws-messaging/pom.xml
+++ b/spring-cloud-aws-messaging/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-aws-messaging/src/test/resources/log4j.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/log4j.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out" />
 		<layout class="org.apache.log4j.PatternLayout">

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener back-off-time="5000" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <aws-context:context-region region="ap-southeast-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<bean id="myClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 
 	<aws-messaging:annotation-driven-queue-listener>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener destination-resolver="destinationResolver" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener auto-startup="false" max-number-of-messages="9"
 													visibility-timeout="6"

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<bean id="provider" class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
       <constructor-arg value="ap-southeast-2" />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <aws-messaging:annotation-driven-queue-listener region="eu-west-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 
 	<aws-messaging:annotation-driven-queue-listener>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<bean id="executor" class="org.springframework.core.task.SimpleAsyncTaskExecutor" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-delete-message-on-exception-false.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-delete-message-on-exception-false.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
   <aws-messaging:annotation-driven-queue-listener delete-message-on-exception="false" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
-	   http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd
+	   https://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener send-to-message-template="messageTemplate" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
@@ -15,13 +15,13 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:queue-messaging-template id="queueMessagingTemplate" region="sa-east-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
@@ -15,17 +15,17 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:task="http://www.springframework.org/schema/task"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:task="https://www.springframework.org/schema/task"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
@@ -15,16 +15,16 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
-	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="https://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
   -->
 
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xmlns:mvc="http://www.springframework.org/schema/mvc" xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
+<beans xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:mvc="https://www.springframework.org/schema/mvc" xmlns="https://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd https://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://maven.apache.org/POM/4.0.0 (404) with 18 occurrences migrated to:  
  https://maven.apache.org/POM/4.0.0 ([https](https://maven.apache.org/POM/4.0.0) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/cache (404) with 18 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache ([https](https://www.springframework.org/schema/cloud/aws/cache) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context (404) with 184 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context ([https](https://www.springframework.org/schema/cloud/aws/context) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd (404) with 91 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc (404) with 38 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc ([https](https://www.springframework.org/schema/cloud/aws/jdbc) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd (404) with 18 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail (404) with 12 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail ([https](https://www.springframework.org/schema/cloud/aws/mail) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd (404) with 5 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging (404) with 80 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging ([https](https://www.springframework.org/schema/cloud/aws/messaging) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd (404) with 39 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd ([https](https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd ([https](https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/aop/spring-aop.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 112 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/mvc/spring-mvc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* [ ] http://www.springframework.org/schema/task/spring-task.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* [ ] http://www.springframework.org/schema/tx/spring-tx.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 121 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://jakarta.apache.org/log4j/ with 6 occurrences migrated to:  
  https://jakarta.apache.org/log4j/ ([https](https://jakarta.apache.org/log4j/) result 301).
* [ ] http://www.springframework.org/schema/aop with 2 occurrences migrated to:  
  https://www.springframework.org/schema/aop ([https](https://www.springframework.org/schema/aop) result 301).
* [ ] http://www.springframework.org/schema/beans with 224 occurrences migrated to:  
  https://www.springframework.org/schema/beans ([https](https://www.springframework.org/schema/beans) result 301).
* [ ] http://www.springframework.org/schema/cache with 2 occurrences migrated to:  
  https://www.springframework.org/schema/cache ([https](https://www.springframework.org/schema/cache) result 301).
* [ ] http://www.springframework.org/schema/context with 8 occurrences migrated to:  
  https://www.springframework.org/schema/context ([https](https://www.springframework.org/schema/context) result 301).
* [ ] http://www.springframework.org/schema/mvc with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc ([https](https://www.springframework.org/schema/mvc) result 301).
* [ ] http://www.springframework.org/schema/task with 10 occurrences migrated to:  
  https://www.springframework.org/schema/task ([https](https://www.springframework.org/schema/task) result 301).
* [ ] http://www.springframework.org/schema/tx with 2 occurrences migrated to:  
  https://www.springframework.org/schema/tx ([https](https://www.springframework.org/schema/tx) result 301).
* [ ] http://www.springframework.org/schema/util with 10 occurrences migrated to:  
  https://www.springframework.org/schema/util ([https](https://www.springframework.org/schema/util) result 301).
* [ ] http://repo.spring.io/libs-milestone-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* [ ] http://repo.spring.io/libs-snapshot-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* [ ] http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).