### PR TITLE
URL Cleanup

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -23,7 +23,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -31,7 +31,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -39,7 +39,7 @@
 				<repository>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
+					<url>https://repo.spring.io/release</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -47,14 +47,14 @@
 				<repository>
 					<id>maven2-central</id>
 					<name>Maven2 Mirror</name>
-					<url>http://repo1.maven.org/maven2</url>
+					<url>https://repo1.maven.org/maven2</url>
 				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -62,7 +62,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
 	   		http://www.springframework.org/schema/cloud/aws/cache
-	   		http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+	   		https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" expiration="1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
@@ -20,9 +20,9 @@
 	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
            	http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-ref ref="memc" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
@@ -19,9 +19,9 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
 	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
@@ -19,9 +19,9 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
 	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" region="eu-west-1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
@@ -19,9 +19,9 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
            	http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="testMemcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
@@ -19,9 +19,9 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
 	   		http://www.springframework.org/schema/cloud/aws/cache
-           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+           	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" amazon-elasti-cache="customClient" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans 
-	   http://www.springframework.org/schema/beans/spring-beans.xsd 
+	   https://www.springframework.org/schema/beans/spring-beans.xsd 
 	   http://www.springframework.org/schema/cloud/aws/cache
-	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+	   https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<aws-cache:cache-manager id="cacheManager">
 		<aws-cache:cache-cluster name="memcached" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
@@ -19,9 +19,9 @@
 	   xmlns:cache="http://www.springframework.org/schema/cloud/aws/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
 			     	   	   http://www.springframework.org/schema/cloud/aws/cache
-			     	   	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+			     	   	   https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
 
 	<cache:cache-manager>
 		<cache:cache-cluster name="test" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:profile-credentials profileName="test" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
@@ -20,11 +20,11 @@
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/context
-	   					   http://www.springframework.org/schema/context/spring-context.xsd">
+	   					   https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:profile-credentials profileName="customProfile" profilePath="${profilePath}" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key=" " secret-key="staticSecretKey" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="staticAccessKey" secret-key=" " />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
@@ -20,10 +20,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
-	   					   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="#{configuration['accessKey']}"

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -20,7 +20,7 @@
 	   xmlns:spc="http://www.springframework.org/schema/context"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="${accessKey}" secret-key="${secretKey}" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-instance-data />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-instance-data attribute-separator="/" value-separator="=" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-instance-data user-tags-map="myUserTags" amazon-ec2="amazonEC2Client" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-instance-data user-tags-map="myUserTags" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
@@ -18,9 +18,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-region region="sa-east-1" />
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
@@ -18,9 +18,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-region auto-detect="true" />
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
@@ -18,9 +18,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<!--suppress UnparsedCustomBeanInspection -->
 	<context:context-region auto-detect="true" region="sa-east-1" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
@@ -18,9 +18,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-region region-provider="myRegionProvider" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
@@ -18,9 +18,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<!--suppress UnparsedCustomBeanInspection -->
 	<context:context-region />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
@@ -18,9 +18,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-region region="sa-east-1" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
@@ -19,11 +19,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/util
-	   					   http://www.springframework.org/schema/util/spring-util.xsd">
+	   					   https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:context-region region="#{configuration['region']}" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -20,13 +20,13 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/util
-	   					   http://www.springframework.org/schema/util/spring-util.xsd
+	   					   https://www.springframework.org/schema/util/spring-util.xsd
 	   					   http://www.springframework.org/schema/context
-	   					   http://www.springframework.org/schema/context/spring-context.xsd">
+	   					   https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<aws-context:context-region region="${region}" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
@@ -19,11 +19,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns:task="http://www.springframework.org/schema/task" xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/task
-	   					   http://www.springframework.org/schema/task/spring-task.xsd">
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="first" secret-key="first" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
@@ -19,9 +19,9 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
 			     	   	   http://www.springframework.org/schema/cloud/aws/context
-			     	   	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+			     	   	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="staticAccessKey" secret-key="staticSecretKey" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
@@ -18,9 +18,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-       					   http://www.springframework.org/schema/beans/spring-beans.xsd
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   	   				   http://www.springframework.org/schema/cloud/aws/context
-	   	   				   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   	   				   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:stack-configuration />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
@@ -18,9 +18,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-       					   http://www.springframework.org/schema/beans/spring-beans.xsd
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:stack-configuration stack-name="IntegrationTestStack" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:stack-configuration amazon-cloud-formation="customCloudFormationClient" stack-name="test"
 									 user-tags-map="customStackTags" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
@@ -19,9 +19,9 @@
 	   xmlns:mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-			     	   	   http://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
 			     	   	   http://www.springframework.org/schema/cloud/aws/mail
-			     	   	   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+			     	   	   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<mail:mail-sender id="mailSender" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/mail
-	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<aws-mail:mail-sender id="test" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/mail
-	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<aws-mail:mail-sender id="test" region="eu-west-1" />
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/mail
-	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<bean id="myRegionProvider" class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
 		<constructor-arg name="configuredRegion" value="ap-southeast-2" />

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/mail
-	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<aws-mail:mail-sender id="test" amazon-ses="emailServiceClient" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context.xsd
+                           https://www.springframework.org/schema/context/spring-context.xsd
                            http://www.springframework.org/schema/cloud/aws/context
-                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+                           https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="${cloud.aws.credentials.accessKey}" secret-key="${cloud.aws.credentials.secretKey}" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/cache/XmlElastiCacheAwsTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-       					   http://www.springframework.org/schema/beans/spring-beans.xsd
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
        					   http://www.springframework.org/schema/cloud/aws/cache
-       					   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+       					   https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
        					   http://www.springframework.org/schema/cache
-       					   http://www.springframework.org/schema/cache/spring-cache.xsd">
+       					   https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
@@ -19,11 +19,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns:task="http://www.springframework.org/schema/task" xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/task
-	   					   http://www.springframework.org/schema/task/spring-task.xsd">
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/context/support/io/XmlResourceLoaderAwsTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/task
-	   					   http://www.springframework.org/schema/task/spring-task.xsd">
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/cloud/aws/context
-                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+                           https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/cloud/aws/context
-                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+                           https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/StackResourceUserTagsAwsTest-context.xml
@@ -17,7 +17,7 @@
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns="http://www.springframework.org/schema/beans"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/core/env/stack/XmlStackConfigurationAwsTest-context.xml
@@ -16,7 +16,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
@@ -22,13 +22,13 @@
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/tx
-	   					   http://www.springframework.org/schema/tx/spring-tx.xsd
+	   					   https://www.springframework.org/schema/tx/spring-tx.xsd
 	   					   http://www.springframework.org/schema/aop
-	   					   http://www.springframework.org/schema/aop/spring-aop.xsd">
+	   					   https://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/mail/XmlMailSenderAwsTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util.xsd
+                           https://www.springframework.org/schema/util/spring-util.xsd
                            http://www.springframework.org/schema/cloud/aws/mail
-                           http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+                           https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 
 	<import resource="classpath:Integration-test-context.xml" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlMessageListenerContainerAwsTest-context.xml
@@ -21,10 +21,10 @@
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
-	   					   http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueListenerTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 	<aws-context:stack-configuration stack-name="IntegrationTestStack" />

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<import resource="classpath:Integration-test-context.xml" />
 

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
@@ -20,9 +20,9 @@
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
 
 	<jdbc:data-source db-instance-identifier="test" password="password" />
 

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
@@ -21,11 +21,11 @@
 	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/jdbc
-	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
 		<context:simple-credentials access-key="foo" secret-key="bar" />

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
@@ -20,9 +20,9 @@
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 			   			   http://www.springframework.org/schema/cloud/aws/jdbc
-			   			   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+			   			   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
 
 	<jdbc:data-source db-instance-identifier="test" password="password" region="eu-west-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener back-off-time="5000" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-region region="ap-southeast-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<bean id="myClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 
 	<aws-messaging:annotation-driven-queue-listener>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener destination-resolver="destinationResolver" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener auto-startup="false" max-number-of-messages="9"
 													visibility-timeout="6"

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<bean id="provider" class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
 		<constructor-arg value="ap-southeast-2" />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener region="eu-west-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 
 	<aws-messaging:annotation-driven-queue-listener>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<bean id="executor" class="org.springframework.core.task.SimpleAsyncTaskExecutor" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-messaging:annotation-driven-queue-listener send-to-message-template="messageTemplate" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
@@ -19,9 +19,9 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:queue-messaging-template id="queueMessagingTemplate" region="sa-east-1" />
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials />

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
@@ -21,13 +21,13 @@
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
 	   					   http://www.springframework.org/schema/task
-	   					   http://www.springframework.org/schema/task/spring-task.xsd">
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
@@ -20,11 +20,11 @@
 	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/context
-	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 
 	<aws-context:context-credentials>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
@@ -20,11 +20,11 @@
 	   xmlns:mvc="http://www.springframework.org/schema/mvc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   					   http://www.springframework.org/schema/mvc
-	   					   http://www.springframework.org/schema/mvc/spring-mvc.xsd
+	   					   https://www.springframework.org/schema/mvc/spring-mvc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
@@ -20,10 +20,10 @@
 	   xmlns:mvc="http://www.springframework.org/schema/mvc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   					   http://www.springframework.org/schema/beans/spring-beans.xsd
-	   					   http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
 	   					   http://www.springframework.org/schema/cloud/aws/messaging
-	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+	   					   https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd (404) with 9 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd (404) with 91 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd (404) with 19 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd (404) with 6 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd (404) with 40 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd ([https](https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/aop/spring-aop.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 112 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/mvc/spring-mvc.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* [ ] http://www.springframework.org/schema/task/spring-task.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* [ ] http://www.springframework.org/schema/tx/spring-tx.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://repo.spring.io/libs-milestone-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* [ ] http://repo.spring.io/libs-snapshot-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* [ ] http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* [ ] http://repo1.maven.org/maven2 with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 34 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/beans with 224 occurrences
* http://www.springframework.org/schema/cache with 2 occurrences
* http://www.springframework.org/schema/cloud/aws/cache with 18 occurrences
* http://www.springframework.org/schema/cloud/aws/context with 182 occurrences
* http://www.springframework.org/schema/cloud/aws/jdbc with 38 occurrences
* http://www.springframework.org/schema/cloud/aws/mail with 12 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging with 80 occurrences
* http://www.springframework.org/schema/context with 8 occurrences
* http://www.springframework.org/schema/mvc with 4 occurrences
* http://www.springframework.org/schema/task with 10 occurrences
* http://www.springframework.org/schema/tx with 2 occurrences
* http://www.springframework.org/schema/util with 10 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 129 occurrences