### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,8 +47,8 @@ variable `GEM_HOME`to the ruby gem folder. For example:
 
 = Using IntelliJ IDEA
 Spring Cloud AWS development is done with
-http://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
-http://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
+https://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
+https://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
 import the file within idea as a maven project.
 
 _Note:_ Please make sure to revert all changes in the .idea config file
@@ -140,11 +140,11 @@ Spring Cloud Team on https://twitter.com/springcentral[Twitter]
 
 Individual team members can be found on different social media channels
 
-* Agim Emruli (http://twitter.com/aemruli[Twitter] /
-http://de.linkedin.com/in/agimemruli[LinkedIn])
-* Alain Sahli (http://twitter.com/sahlialain[Twitter] /
-http://ch.linkedin.com/in/asahli[LinkedIn])
-* Christian Stettler (http://twitter.com/chrisstettler[Twitter])
+* Agim Emruli (https://twitter.com/aemruli[Twitter] /
+https://de.linkedin.com/in/agimemruli[LinkedIn])
+* Alain Sahli (https://twitter.com/sahlialain[Twitter] /
+https://ch.linkedin.com/in/asahli[LinkedIn])
+* Christian Stettler (https://twitter.com/chrisstettler[Twitter])
 
 == Contributing
 
@@ -176,7 +176,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -189,6 +189,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -45,8 +45,8 @@ variable `GEM_HOME`to the ruby gem folder. For example:
 
 = Using IntelliJ IDEA
 Spring Cloud AWS development is done with
-http://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
-http://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
+https://www.jetbrains.com/idea/[IntelliJ IDEA]. In order to create all
+https://www.jetbrains.com/idea/[IntelliJ IDEA] project files, you have to
 import the file within idea as a maven project.
 
 _Note:_ Please make sure to revert all changes in the .idea config file
@@ -138,11 +138,11 @@ Spring Cloud Team on https://twitter.com/springcentral[Twitter]
 
 Individual team members can be found on different social media channels
 
-* Agim Emruli (http://twitter.com/aemruli[Twitter] /
-http://de.linkedin.com/in/agimemruli[LinkedIn])
-* Alain Sahli (http://twitter.com/sahlialain[Twitter] /
-http://ch.linkedin.com/in/asahli[LinkedIn])
-* Christian Stettler (http://twitter.com/chrisstettler[Twitter])
+* Agim Emruli (https://twitter.com/aemruli[Twitter] /
+https://de.linkedin.com/in/agimemruli[LinkedIn])
+* Alain Sahli (https://twitter.com/sahlialain[Twitter] /
+https://ch.linkedin.com/in/asahli[LinkedIn])
+* Christian Stettler (https://twitter.com/chrisstettler[Twitter])
 
 == Contributing
 

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -16,8 +16,8 @@ include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/maste
 
 == Using Amazon Web Services
 
-Amazon provides a http://aws.amazon.com/sdk-for-java/[Java SDK] to issue requests for the all services provided by the
-http://aws.amazon.com[Amazon Web Service] platform. Using the SDK, application developers still have to integrate the
+Amazon provides a https://aws.amazon.com/sdk-for-java/[Java SDK] to issue requests for the all services provided by the
+https://aws.amazon.com[Amazon Web Service] platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -28,23 +28,23 @@ image::overview.png[Overview]
 
 * *Spring Cloud AWS Core* is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based http://aws.amazon.com/ec2/[EC2]
-metadata and the overall application stack specific http://aws.amazon.com/cloudformation/[CloudFormation] metadata.
-* *Spring Cloud AWS Context* delivers access to the http://aws.amazon.com/s3/[Simple Storage Service] via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the http://aws.amazon.com/ses/[Simple E-Mail Service]
+cloud based environment configurations providing direct access to the instance based https://aws.amazon.com/ec2/[EC2]
+metadata and the overall application stack specific https://aws.amazon.com/cloudformation/[CloudFormation] metadata.
+* *Spring Cloud AWS Context* delivers access to the https://aws.amazon.com/s3/[Simple Storage Service] via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the https://aws.amazon.com/ses/[Simple E-Mail Service]
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the http://aws.amazon.com/elasticache/[ElastiCache] caching service.
-* *Spring Cloud AWS JDBC* provides automatic datasource lookup and configuration for the http://aws.amazon.com/rds/[Relational Database Service]
+and the https://aws.amazon.com/elasticache/[ElastiCache] caching service.
+* *Spring Cloud AWS JDBC* provides automatic datasource lookup and configuration for the https://aws.amazon.com/rds/[Relational Database Service]
 which can be used with JDBC or any other support data access technology by Spring.
-* *Spring Cloud AWS Messaging* enables developers to receive and send messages with the http://aws.amazon.com/sqs/[Simple Queueing Service] for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the http://aws.amazon.com/sns/[Simple Notification Service].
+* *Spring Cloud AWS Messaging* enables developers to receive and send messages with the https://aws.amazon.com/sqs/[Simple Queueing Service] for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the https://aws.amazon.com/sns/[Simple Notification Service].
 
 == Basic setup
 Before using the Spring Cloud AWS module developers have to pick the dependencies and configure the Spring Cloud AWS module.
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.
 
 === Spring Cloud AWS maven dependency management
-Spring Cloud AWS module dependencies can be used directly in http://maven.apache.org[Maven] with a direct configuration
+Spring Cloud AWS module dependencies can be used directly in https://maven.apache.org[Maven] with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:
 
@@ -71,7 +71,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <repositories>
     <repository>
         <id>io.spring.repo.maven.release</id>
-        <url>http://repo.spring.io/release/</url>
+        <url>https://repo.spring.io/release/</url>
         <snapshots><enabled>false</enabled></snapshots>
     </repository>
 </repositories>
@@ -84,7 +84,7 @@ For milestones:
 <repositories>
     <repository>
         <id>io.spring.repo.maven.milestone</id>
-        <url>http://repo.spring.io/milestone/</url>
+        <url>https://repo.spring.io/milestone/</url>
         <snapshots><enabled>false</enabled></snapshots>
     </repository>
 </repositories>
@@ -103,9 +103,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
            <aws-context:context-region region="..."/>
 </beans>
@@ -152,7 +152,7 @@ and not be checked in into the source management system.
 ====
 
 ===== Instance profile configuration
-An http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html[instance profile configuration] allows to assign
+An https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html[instance profile configuration] allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:
@@ -188,7 +188,7 @@ errors if the properties are not configured at all.
 ====
 
 ==== Region configuration
-Amazon Web services are available in different http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[regions]. Based
+Amazon Web services are available in different https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[regions]. Based
 on the custom requirements, the user can host the application on different Amazon regions. The `spring-cloud-aws-context`
 module provides a way to define the region for the entire application context.
 
@@ -211,7 +211,7 @@ be reconfigured with property files or system properties.
 
 ===== Automatic region configuration
 If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata] and therefore must
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata] and therefore must
 not be configured statically. The configuration will look like this:
 
 [source,xml,indent=0]
@@ -317,7 +317,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.
 
 === Retrieving instance metadata
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] are available inside an
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata] are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.
@@ -397,7 +397,7 @@ directly into Java fields. The next example demonstrates the use of instance met
 
 [NOTE]
 ====
-Every instance metadata can be accessed by the key available in the http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata service]
+Every instance metadata can be accessed by the key available in the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[instance metadata service]
 Nested properties can be accessed by separating the properties with a slash ('/').
 ====
 
@@ -406,7 +406,7 @@ Besides the default instance metadata it is also possible to configure user data
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format `<key>:<value>;<key>:<value>` inside the user data so that it can parse the string and extract the key value pairs.
 
-The user data can be configured using either the management console shown below or a http://aws.amazon.com/cloudformation/aws-cloudformation-templates/[CloudFormation template].
+The user data can be configured using either the management console shown below or a https://aws.amazon.com/cloudformation/aws-cloudformation-templates/[CloudFormation template].
 
 image::cloud-environment-user-data.png[User data in the management console]
 
@@ -454,7 +454,7 @@ the instance.
 
 [TIP]
 ====
-http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html[User data] can also be used to execute scripts
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html[User data] can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.
 ====
@@ -571,7 +571,7 @@ public class ApplicationService {
 
 == Managing cloud environments
 Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a http://aws.amazon.com/cloudformation/[CloudFormation]
+complexity of the infrastructure. Amazon Web services offers a https://aws.amazon.com/cloudformation/[CloudFormation]
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -618,7 +618,7 @@ the database.
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
   <aws-context:context-credentials>
   	...
@@ -749,7 +749,7 @@ with a special setup. The client itself can be configured using the `amazon-clou
 ----
 
 == Messaging
-Spring Cloud AWS provides http://aws.amazon.com/sqs/[Amazon SQS] and http://aws.amazon.com/sqs/[Amazon SNS] integration
+Spring Cloud AWS provides https://aws.amazon.com/sqs/[Amazon SQS] and https://aws.amazon.com/sqs/[Amazon SNS] integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.
@@ -826,9 +826,9 @@ With the messaging namespace a `QueueMessagingTemplate` can be defined in an XML
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging">
 
@@ -932,7 +932,7 @@ this.queueMessagingTemplate.convertAndSend("queueName", new Person("John, "Doe")
 
 In this example a `QueueMessagingTemplate` is created using the messaging namespace. The `convertAndSend` method
 converts the payload `Person` using the configured `MessageConverter` and sends the message.
-Only the link:http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
+Only the link:https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
 message attributes] sent with an SQS message are supported. Custom attributes are currently not supported.
 
 In addition to the provided argument resolvers, custom ones can be registered on the
@@ -1203,10 +1203,10 @@ Reducing database round trips can significantly reduce the requirements for the 
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.
 
-Spring Cloud AWS integrates the http://aws.amazon.com/elasticache/[Amazon ElastiCache] service into the Spring unified
+Spring Cloud AWS integrates the https://aws.amazon.com/elasticache/[Amazon ElastiCache] service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-http://projects.spring.io/spring-data-redis/[Spring Data Redis] for Redis caches.
+https://projects.spring.io/spring-data-redis/[Spring Data Redis] for Redis caches.
 
 === Configuring dependencies for Redis caches
 Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1244,9 +1244,9 @@ configuration to enable declarative, annotation-based caching.
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<aws-context:context-credentials>
 		...
@@ -1261,7 +1261,7 @@ configuration to enable declarative, annotation-based caching.
 ----
 
 The configuration above configures a `cache-manager` with one cache with the name `CacheCluster` that represents an
-http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html[ElasticCache cluster].
+https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html[ElasticCache cluster].
 
 ==== Mixing caches
 Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1361,7 +1361,7 @@ public class ExpensiveService {
 There are different memcached client implementations available for Java, the most prominent ones are
 https://github.com/couchbase/spymemcached[Spymemcached] and https://github.com/killme2008/xmemcached[XMemcached].
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html[auto-discovery] of new nodes based on
+https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html[auto-discovery] of new nodes based on
 a central configuration endpoint.
 
 Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.
@@ -1404,7 +1404,7 @@ without any configuration change inside the application.
 
 Spring has a broad support of data access technologies built on top of JDBC like `JdbcTemplate` and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-http://aws.amazon.com/rds/[Amazon Relational Database Service] with a declarative configuration. The main support provided by Spring
+https://aws.amazon.com/rds/[Amazon Relational Database Service] with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:
 
  * Automatic data source configuration and setup based on the Amazon RDS database instance.
@@ -1440,7 +1440,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
 
  <aws-context:context-credentials>
   ...
@@ -1460,7 +1460,7 @@ that points to a valid Amazon RDS database instance. The master user password fo
 user to be used (which is recommended) then the `username` attribute can be set.
 
 With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC pool] with the default properties. The data source
+https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC pool] with the default properties. The data source
 can be later injected into any Spring Bean as shown below:
 
 [source,java,indent=0]
@@ -1507,7 +1507,7 @@ with custom pool properties.
 </beans>
 ----
 
-A full list of all configuration attributes with their value is available http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[here].
+A full list of all configuration attributes with their value is available https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[here].
 
 === Configuring data source with Java config
 Spring Cloud AWS also supports the configuration of the data source within an `@Configuration` class. The
@@ -1597,7 +1597,7 @@ outlines all properties for a data source using `test` as the instance identifie
 
 
 === Read-replica configuration
-Amazon RDS allows to use http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[MySQL read-replica]
+Amazon RDS allows to use https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[MySQL read-replica]
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.
 
@@ -1607,7 +1607,7 @@ for write operations.
 
 [CAUTION]
 ====
-Using read-replica instances does not guarantee strict http://en.wikipedia.org/wiki/ACID[ACID] semantics for the database
+Using read-replica instances does not guarantee strict https://en.wikipedia.org/wiki/ACID[ACID] semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.
@@ -1654,7 +1654,7 @@ public class SimpleDatabaseService {
 ----
 
 === Failover support
-Amazon RDS supports a http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html[Multi-AZ] fail-over if
+Amazon RDS supports a https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html[Multi-AZ] fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.
@@ -1786,9 +1786,9 @@ database is configured using CloudFormation.
 ====
 
 == Sending mails
-Spring has a built-in support to send e-mails based on the http://www.oracle.com/technetwork/java/javamail/index.html[Java Mail API]
+Spring has a built-in support to send e-mails based on the https://www.oracle.com/technetwork/java/javamail/index.html[Java Mail API]
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the http://aws.amazon.com/de/ses/[Amazon SES] as an implementation of the Spring Mail abstraction.
+Spring Cloud AWS supports the https://aws.amazon.com/de/ses/[Amazon SES] as an implementation of the Spring Mail abstraction.
 
 As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.
@@ -1810,7 +1810,7 @@ attachments as simple mail messages. A configuration with the necessary elements
 ----
 <beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
 
 	<aws-context:context-credentials>
 	  ..
@@ -1876,7 +1876,7 @@ which is shown below.
 [NOTE]
 ====
 Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html[SMTP setup] required
+messages. There is no https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html[SMTP setup] required
 on the Amazon AWS side.
 ====
 
@@ -1913,7 +1913,7 @@ public class MailSendingService {
 ----
 
 === Configuring regions
-Amazon SES is not available in all http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html[regions] of the
+Amazon SES is not available in all https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html[regions] of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1931,15 +1931,15 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 
 === Authenticating e-mails
 To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html[verify] each
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html[verify] each
 e-mail receiver otherwise the mail sender will throw a `com.amazonaws.services.simpleemail.model.MessageRejectedException`.
 
-http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html[Production access] can be requested
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html[Production access] can be requested
 and will disable the need for mail address verification.
 
 == Resource handling
 The Spring Framework provides a `org.springframework.core.io.ResourceLoader` abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the http://aws.amazon.com/s3/[Amazon S3] service
+servlet context and the classpath. Spring Cloud AWS adds support for the https://aws.amazon.com/s3/[Amazon S3] service
 to load and write resources with the resource loader and the `s3` protocol.
 
 The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
@@ -1954,7 +1954,7 @@ The configuration consists of one element for the whole application context that
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<aws-context:context-credentials>
     		...
@@ -2012,7 +2012,7 @@ public class SimpleResourceLoadingBean {
 ----
 
 ==== Uploading multi-part files
-Amazon S3 supports http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html[multi-part uploads] to
+Amazon S3 supports https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html[multi-part uploads] to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom `org.springframework.core.task.TaskExecutor`
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="cache-manager">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="cache-manager">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
@@ -22,9 +22,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 
 	<xsd:element name="context-credentials">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
@@ -22,9 +22,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 
 	<xsd:element name="context-credentials">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="mail-sender">
 		<xsd:annotation>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="mail-sender">
 		<xsd:annotation>

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
  * to an account if the resource is scoped ot an account.
  * <p>
  * More information on resources are available on
- * <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">the Amazon Webservice Manual</a>
+ * <a href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">the Amazon Webservice Manual</a>
  * </p>
  *
  * @author Agim Emruli
@@ -67,7 +67,7 @@ public class AmazonResourceName {
 
     /**
      * Returns the service name for this particular AmazonResourceName. The service name is a plain string which will be
-     * one of the service from the namespace defined at <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces">user
+     * one of the service from the namespace defined at <a href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces">user
      * manual</a>
      *
      * @return - the service as a string - never be null

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
@@ -57,7 +57,7 @@ public class AmazonS3ClientFactoryTest {
         this.expectedException.expectMessage("AmazonS3 must not be null");
 
         // Act
-        amazonS3ClientFactory.createClientForEndpointUrl(null, "http://s3.amazonaws.com");
+        amazonS3ClientFactory.createClientForEndpointUrl(null, "https://s3.amazonaws.com");
 
         // Prepare
 
@@ -70,7 +70,7 @@ public class AmazonS3ClientFactoryTest {
         AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_CENTRAL_1).build();
 
         // Act
-        AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3, "http://s3.amazonaws.com");
+        AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3, "https://s3.amazonaws.com");
 
         // Prepare
         Assert.assertEquals(Regions.DEFAULT_REGION.getName(), newClient.getRegionName());

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
@@ -29,7 +29,7 @@ import static org.springframework.cloud.aws.core.naming.AmazonResourceName.fromS
 
 /**
  * Test for {@link AmazonResourceName} class. The examples are taken from the aws documentation at
- * http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+ * https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
  *
  * @author Agim Emruli
  * @since 1.0

--- a/spring-cloud-aws-integration-test/src/test/resources/IntegrationTestStack.yaml
+++ b/spring-cloud-aws-integration-test/src/test/resources/IntegrationTestStack.yaml
@@ -148,7 +148,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       Subscription:
-      - Endpoint: http://build.elasticspring.org
+      - Endpoint: https://build.elasticspring.org
         Protocol: http
   CacheCluster:
     Type: AWS::ElastiCache::CacheCluster

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/datasource/DataSourceFactory.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
  * while destroying the application itself.
  * <p>
  * <b>Note:</b> This interface does not assume what kind of datasource is returned. It is strongly recommended to use
- * an already existing and pooled datasource like <a href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat
+ * an already existing and pooled datasource like <a href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat
  * JDBC datasource</a> for real life production applications.
  * </p>
  *

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
@@ -23,9 +23,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="data-source">
 		<xsd:annotation>

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
@@ -23,9 +23,9 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="data-source">
 		<xsd:annotation>

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -91,7 +91,7 @@ public class SimpleMessageListenerContainerFactory {
     /**
      * Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
      * messages on the queue. Higher values will reduce poll request to the system significantly. The value should
-     * be between 1 and 20. For more information read the <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+     * be between 1 and 20. For more information read the <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
      *
      * @param waitTimeOut
      *         - the wait time out in seconds

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
@@ -88,7 +88,7 @@ public class NotificationMessagingTemplate extends AbstractMessageChannelMessagi
 
     /**
      * Convenience method that sends a notification with the given {@literal message} and {@literal subject} to the {@literal destination}.
-     * The {@literal subject} is sent as header as defined in the <a href="http://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message JSON formats</a>.
+     * The {@literal subject} is sent as header as defined in the <a href="https://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message JSON formats</a>.
      *
      * @param destinationName
      *         The logical name of the destination
@@ -103,7 +103,7 @@ public class NotificationMessagingTemplate extends AbstractMessageChannelMessagi
 
     /**
      * Convenience method that sends a notification with the given {@literal message} and {@literal subject} to the {@literal destination}.
-     * The {@literal subject} is sent as header as defined in the <a href="http://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message JSON formats</a>.
+     * The {@literal subject} is sent as header as defined in the <a href="https://docs.aws.amazon.com/sns/latest/dg/json-formats.html">SNS message JSON formats</a>.
      * The configured default destination will be used.
      *
      * @param message

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
@@ -24,11 +24,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="annotation-driven-queue-listener">
 		<xsd:annotation>
@@ -131,7 +131,7 @@
 						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
 						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
 						be between 1 and 20. For more information read the
-						<a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
@@ -23,11 +23,11 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
-				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd" />
 
 	<xsd:element name="annotation-driven-queue-listener">
 		<xsd:annotation>
@@ -130,7 +130,7 @@
 						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
 						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
 						be between 1 and 20. For more information read the
-						<a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -65,7 +65,7 @@ public class QueueMessagingTemplateTest {
 
         ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
         verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-        assertEquals("http://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
+        assertEquals("https://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class QueueMessagingTemplateTest {
 
         ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
         verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-        assertEquals("http://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
+        assertEquals("https://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
     }
 
 
@@ -119,7 +119,7 @@ public class QueueMessagingTemplateTest {
 
         ArgumentCaptor<ReceiveMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
         verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
-        assertEquals("http://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
+        assertEquals("https://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class QueueMessagingTemplateTest {
 
         ArgumentCaptor<ReceiveMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor.forClass(ReceiveMessageRequest.class);
         verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
-        assertEquals("http://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
+        assertEquals("https://queue-url.com", sendMessageRequestArgumentCaptor.getValue().getQueueUrl());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -180,7 +180,7 @@ public class QueueMessagingTemplateTest {
         AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
 
         GetQueueUrlResult queueUrl = new GetQueueUrlResult();
-        queueUrl.setQueueUrl("http://queue-url.com");
+        queueUrl.setQueueUrl("https://queue-url.com");
         when(amazonSqs.getQueueUrl(any(GetQueueUrlRequest.class))).thenReturn(queueUrl);
 
         ReceiveMessageResult receiveMessageResult = new ReceiveMessageResult();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
@@ -259,7 +259,7 @@ public class MessageListenerContainerTest {
         when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("testQueue"))).
                 thenReturn(new GetQueueUrlResult().withQueueUrl("http://testQueue.amazonaws.com"));
         when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("anotherTestQueue"))).
-                thenReturn(new GetQueueUrlResult().withQueueUrl("http://anotherTestQueue.amazonaws.com"));
+                thenReturn(new GetQueueUrlResult().withQueueUrl("https://anotherTestQueue.amazonaws.com"));
         when(mock.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(new GetQueueAttributesResult());
 
         messageHandler.afterPropertiesSet();
@@ -271,7 +271,7 @@ public class MessageListenerContainerTest {
         assertEquals(11L, registeredQueues.get("testQueue").getReceiveMessageRequest().getMaxNumberOfMessages().longValue());
         assertEquals(22L, registeredQueues.get("testQueue").getReceiveMessageRequest().getVisibilityTimeout().longValue());
         assertEquals(33L, registeredQueues.get("testQueue").getReceiveMessageRequest().getWaitTimeSeconds().longValue());
-        assertEquals("http://anotherTestQueue.amazonaws.com", registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getQueueUrl());
+        assertEquals("https://anotherTestQueue.amazonaws.com", registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getQueueUrl());
         assertEquals(11L, registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getMaxNumberOfMessages().longValue());
         assertEquals(22L, registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getVisibilityTimeout().longValue());
         assertEquals(33L, registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getWaitTimeSeconds().longValue());
@@ -418,7 +418,7 @@ public class MessageListenerContainerTest {
         when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("testQueue"))).
                 thenThrow(new DestinationResolutionException("Queue not found"));
         when(mock.getQueueUrl(new GetQueueUrlRequest().withQueueName("anotherTestQueue"))).
-                thenReturn(new GetQueueUrlResult().withQueueUrl("http://anotherTestQueue.amazonaws.com"));
+                thenReturn(new GetQueueUrlResult().withQueueUrl("https://anotherTestQueue.amazonaws.com"));
         when(mock.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(new GetQueueAttributesResult());
 
         messageHandler.afterPropertiesSet();
@@ -433,7 +433,7 @@ public class MessageListenerContainerTest {
         Map<String, QueueAttributes> registeredQueues = container.getRegisteredQueues();
         assertFalse(registeredQueues.containsKey("testQueue"));
         assertEquals("Ignoring queue with name 'testQueue' as it does not exist.", logMsgArgCaptor.getValue());
-        assertEquals("http://anotherTestQueue.amazonaws.com", registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getQueueUrl());
+        assertEquals("https://anotherTestQueue.amazonaws.com", registeredQueues.get("anotherTestQueue").getReceiveMessageRequest().getQueueUrl());
     }
 
     private static class StubAbstractMessageListenerContainer extends AbstractMessageListenerContainer {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -236,21 +236,21 @@ public class SimpleMessageListenerContainerTest {
         applicationContext.registerSingleton("testMessageListener", TestMessageListener.class);
         applicationContext.registerSingleton("anotherTestMessageListener", AnotherTestMessageListener.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
-        mockGetQueueUrl(sqs, "anotherTestQueue", "http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com");
+        mockGetQueueUrl(sqs, "anotherTestQueue", "https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
                 .withMaxNumberOfMessages(10)))
                 .thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("messageContent")))
                 .thenReturn(new ReceiveMessageResult());
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
                 .withMaxNumberOfMessages(10)))
                 .thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("anotherMessageContent")))
@@ -287,14 +287,14 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testMessageListener", TestMessageListener.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
                 .withMaxNumberOfMessages(10)))
                 .thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("messageContent").withAttributes(Collections.singletonMap("SenderId", "ID"))))
@@ -370,15 +370,15 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testMessageListener", TestMessageListener.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
         MimeType mimeType = new MimeType("text", "plain", Charset.forName("UTF-8"));
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
                 .withMaxNumberOfMessages(10)))
                 .thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("messageContent")
@@ -432,14 +432,14 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testMessageListener", TestMessageListener.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        mockReceiveMessage(sqs, "http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com", "messageContent", "ReceiptHandle");
+        mockReceiveMessage(sqs, "https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com", "messageContent", "ReceiptHandle");
 
         // Act
         container.start();
@@ -447,7 +447,7 @@ public class SimpleMessageListenerContainerTest {
         // Assert
         assertTrue(countDownLatch.await(2L, TimeUnit.SECONDS));
         container.stop();
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
     }
 
     @Test
@@ -472,14 +472,14 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testMessageListener", TestMessageListenerThatThrowsAnExceptionWithAllDeletionPolicy.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com").withAttributeNames("All").withMaxNumberOfMessages(10).withMessageAttributeNames("All"))).
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com").withAttributeNames("All").withMaxNumberOfMessages(10).withMessageAttributeNames("All"))).
                 thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("messageContent").withReceiptHandle("ReceiptHandle")),
                         new ReceiveMessageResult());
 
@@ -489,7 +489,7 @@ public class SimpleMessageListenerContainerTest {
         // Assert
         assertTrue(countDownLatch.await(2L, TimeUnit.SECONDS));
         container.stop();
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
     }
 
     @Test
@@ -514,14 +514,14 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testMessageListener", TestMessageListenerThatThrowsAnExceptionWithAllExceptOnRedriveDeletionPolicy.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
-        mockGetQueueAttributesWithRedrivePolicy(sqs, "http://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
+        mockGetQueueAttributesWithRedrivePolicy(sqs, "https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com").withAttributeNames("All")
                 .withMaxNumberOfMessages(10)
                 .withMessageAttributeNames("All")))
                 .thenReturn(new ReceiveMessageResult().withMessages(new Message().withBody("messageContent").withReceiptHandle("ReceiptHandle")),
@@ -533,7 +533,7 @@ public class SimpleMessageListenerContainerTest {
         // Assert
         assertTrue(countDownLatch.await(2L, TimeUnit.SECONDS));
         container.stop();
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com", "ReceiptHandle")));
     }
 
     @Test
@@ -574,7 +574,7 @@ public class SimpleMessageListenerContainerTest {
         applicationContext.registerSingleton("testMessageListener", TestMessageListener.class);
         messageHandler.setApplicationContext(applicationContext);
 
-        mockGetQueueUrl(amazonSqs, "testQueue", "http://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com");
+        mockGetQueueUrl(amazonSqs, "testQueue", "https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com");
         messageHandler.afterPropertiesSet();
 
         when(amazonSqs.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(new GetQueueAttributesResult());
@@ -617,25 +617,25 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testListener", TestMessageListenerWithManualDeletionPolicy.class);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        mockReceiveMessage(sqs, "http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "messageContent", "ReceiptHandle");
+        mockReceiveMessage(sqs, "https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "messageContent", "ReceiptHandle");
 
         // Act
         container.start();
 
         // Assert
         countDownLatch.await(1L, TimeUnit.SECONDS);
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "ReceiptHandle")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "ReceiptHandle")));
         TestMessageListenerWithManualDeletionPolicy testMessageListenerWithManualDeletionPolicy = applicationContext.getBean(TestMessageListenerWithManualDeletionPolicy.class);
         testMessageListenerWithManualDeletionPolicy.getCountDownLatch().await(1L, TimeUnit.SECONDS);
         testMessageListenerWithManualDeletionPolicy.acknowledge();
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "ReceiptHandle")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com", "ReceiptHandle")));
         container.stop();
     }
 
@@ -654,35 +654,35 @@ public class SimpleMessageListenerContainerTest {
         StaticApplicationContext applicationContext = new StaticApplicationContext();
         applicationContext.registerSingleton("testListener", TestMessageListenerWithAllPossibleDeletionPolicies.class);
 
-        mockGetQueueUrl(sqs, "alwaysSuccess", "http://alwaysSuccess.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://alwaysSuccess.amazonaws.com");
-        mockGetQueueUrl(sqs, "alwaysError", "http://alwaysError.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://alwaysError.amazonaws.com");
-        mockGetQueueUrl(sqs, "onSuccessSuccess", "http://onSuccessSuccess.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://onSuccessSuccess.amazonaws.com");
-        mockGetQueueUrl(sqs, "onSuccessError", "http://onSuccessError.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://onSuccessError.amazonaws.com");
-        mockGetQueueUrl(sqs, "noRedriveSuccess", "http://noRedriveSuccess.amazonaws.com");
-        mockGetQueueAttributesWithRedrivePolicy(sqs, "http://noRedriveSuccess.amazonaws.com");
-        mockGetQueueUrl(sqs, "noRedriveError", "http://noRedriveError.amazonaws.com");
-        mockGetQueueAttributesWithRedrivePolicy(sqs, "http://noRedriveError.amazonaws.com");
-        mockGetQueueUrl(sqs, "neverSuccess", "http://neverSuccess.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://neverSuccess.amazonaws.com");
-        mockGetQueueUrl(sqs, "neverError", "http://neverError.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://neverError.amazonaws.com");
+        mockGetQueueUrl(sqs, "alwaysSuccess", "https://alwaysSuccess.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://alwaysSuccess.amazonaws.com");
+        mockGetQueueUrl(sqs, "alwaysError", "https://alwaysError.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://alwaysError.amazonaws.com");
+        mockGetQueueUrl(sqs, "onSuccessSuccess", "https://onSuccessSuccess.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://onSuccessSuccess.amazonaws.com");
+        mockGetQueueUrl(sqs, "onSuccessError", "https://onSuccessError.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://onSuccessError.amazonaws.com");
+        mockGetQueueUrl(sqs, "noRedriveSuccess", "https://noRedriveSuccess.amazonaws.com");
+        mockGetQueueAttributesWithRedrivePolicy(sqs, "https://noRedriveSuccess.amazonaws.com");
+        mockGetQueueUrl(sqs, "noRedriveError", "https://noRedriveError.amazonaws.com");
+        mockGetQueueAttributesWithRedrivePolicy(sqs, "https://noRedriveError.amazonaws.com");
+        mockGetQueueUrl(sqs, "neverSuccess", "https://neverSuccess.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://neverSuccess.amazonaws.com");
+        mockGetQueueUrl(sqs, "neverError", "https://neverError.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://neverError.amazonaws.com");
 
         messageHandler.setApplicationContext(applicationContext);
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
 
-        mockReceiveMessage(sqs, "http://alwaysSuccess.amazonaws.com", "foo", "alwaysSuccess");
-        mockReceiveMessage(sqs, "http://alwaysError.amazonaws.com", "foo", "alwaysError");
-        mockReceiveMessage(sqs, "http://onSuccessSuccess.amazonaws.com", "foo", "onSuccessSuccess");
-        mockReceiveMessage(sqs, "http://onSuccessError.amazonaws.com", "foo", "onSuccessError");
-        mockReceiveMessage(sqs, "http://noRedriveSuccess.amazonaws.com", "foo", "noRedriveSuccess");
-        mockReceiveMessage(sqs, "http://noRedriveError.amazonaws.com", "foo", "noRedriveError");
-        mockReceiveMessage(sqs, "http://neverSuccess.amazonaws.com", "foo", "neverSuccess");
-        mockReceiveMessage(sqs, "http://neverError.amazonaws.com", "foo", "neverError");
+        mockReceiveMessage(sqs, "https://alwaysSuccess.amazonaws.com", "foo", "alwaysSuccess");
+        mockReceiveMessage(sqs, "https://alwaysError.amazonaws.com", "foo", "alwaysError");
+        mockReceiveMessage(sqs, "https://onSuccessSuccess.amazonaws.com", "foo", "onSuccessSuccess");
+        mockReceiveMessage(sqs, "https://onSuccessError.amazonaws.com", "foo", "onSuccessError");
+        mockReceiveMessage(sqs, "https://noRedriveSuccess.amazonaws.com", "foo", "noRedriveSuccess");
+        mockReceiveMessage(sqs, "https://noRedriveError.amazonaws.com", "foo", "noRedriveError");
+        mockReceiveMessage(sqs, "https://neverSuccess.amazonaws.com", "foo", "neverSuccess");
+        mockReceiveMessage(sqs, "https://neverError.amazonaws.com", "foo", "neverError");
 
         // Act
         container.start();
@@ -691,14 +691,14 @@ public class SimpleMessageListenerContainerTest {
         TestMessageListenerWithAllPossibleDeletionPolicies bean = applicationContext.getBean(TestMessageListenerWithAllPossibleDeletionPolicies.class);
         assertTrue(bean.getCountdownLatch().await(1L, TimeUnit.SECONDS));
         container.stop();
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://alwaysSuccess.amazonaws.com", "alwaysSuccess")));
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://alwaysError.amazonaws.com", "alwaysError")));
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://onSuccessSuccess.amazonaws.com", "onSuccessSuccess")));
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://onSuccessError.amazonaws.com", "onSuccessError")));
-        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("http://noRedriveSuccess.amazonaws.com", "noRedriveSuccess")));
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://noRedriveError.amazonaws.com", "noRedriveError")));
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://neverSuccess.amazonaws.com", "neverSuccess")));
-        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("http://neverError.amazonaws.com", "neverError")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://alwaysSuccess.amazonaws.com", "alwaysSuccess")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://alwaysError.amazonaws.com", "alwaysError")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://onSuccessSuccess.amazonaws.com", "onSuccessSuccess")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://onSuccessError.amazonaws.com", "onSuccessError")));
+        verify(sqs, times(1)).deleteMessageAsync(eq(new DeleteMessageRequest("https://noRedriveSuccess.amazonaws.com", "noRedriveSuccess")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://noRedriveError.amazonaws.com", "noRedriveError")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://neverSuccess.amazonaws.com", "neverSuccess")));
+        verify(sqs, never()).deleteMessageAsync(eq(new DeleteMessageRequest("https://neverError.amazonaws.com", "neverError")));
 
         setLogLevel(previous);
     }
@@ -729,10 +729,10 @@ public class SimpleMessageListenerContainerTest {
         messageHandler.setApplicationContext(applicationContext);
         container.setMessageHandler(messageHandler);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
-        mockGetQueueUrl(sqs, "anotherTestQueue", "http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com");
+        mockGetQueueUrl(sqs, "anotherTestQueue", "https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com");
 
         when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(new ReceiveMessageResult());
 
@@ -848,8 +848,8 @@ public class SimpleMessageListenerContainerTest {
         messageHandler.setApplicationContext(applicationContext);
         container.setMessageHandler(messageHandler);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
@@ -881,8 +881,8 @@ public class SimpleMessageListenerContainerTest {
         messageHandler.setApplicationContext(applicationContext);
         container.setMessageHandler(messageHandler);
 
-        mockGetQueueUrl(sqs, "testQueue", "http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+        mockGetQueueUrl(sqs, "testQueue", "https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com");
 
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
@@ -914,9 +914,9 @@ public class SimpleMessageListenerContainerTest {
         messageHandler.setApplicationContext(applicationContext);
         container.setMessageHandler(messageHandler);
 
-        mockGetQueueUrl(sqs, "longRunningQueueMessage", "http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
-        mockReceiveMessage(sqs, "http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com", "Hello", "ReceiptHandle");
+        mockGetQueueUrl(sqs, "longRunningQueueMessage", "https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com");
+        mockReceiveMessage(sqs, "https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com", "Hello", "ReceiptHandle");
 
         messageHandler.afterPropertiesSet();
         container.afterPropertiesSet();
@@ -971,9 +971,9 @@ public class SimpleMessageListenerContainerTest {
         container.setMessageHandler(messageHandler);
 
         mockGetQueueUrl(sqs, "testQueue", "http://testQueue.amazonaws.com");
-        mockGetQueueUrl(sqs, "anotherTestQueue", "http://anotherTestQueue.amazonaws.com");
+        mockGetQueueUrl(sqs, "anotherTestQueue", "https://anotherTestQueue.amazonaws.com");
         mockGetQueueAttributesWithEmptyResult(sqs, "http://testQueue.amazonaws.com");
-        mockGetQueueAttributesWithEmptyResult(sqs, "http://anotherTestQueue.amazonaws.com");
+        mockGetQueueAttributesWithEmptyResult(sqs, "https://anotherTestQueue.amazonaws.com");
 
         when(sqs.receiveMessage(new ReceiveMessageRequest("http://testQueue.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
@@ -988,7 +988,7 @@ public class SimpleMessageListenerContainerTest {
                     }
                 });
 
-        when(sqs.receiveMessage(new ReceiveMessageRequest("http://anotherTestQueue.amazonaws.com").withAttributeNames("All")
+        when(sqs.receiveMessage(new ReceiveMessageRequest("https://anotherTestQueue.amazonaws.com").withAttributeNames("All")
                 .withMessageAttributeNames("All")
                 .withMaxNumberOfMessages(10)))
                 .thenAnswer(new Answer<ReceiveMessageResult>() {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/support/destination/DynamicQueueUrlDestinationResolverTest.java
@@ -50,7 +50,7 @@ public class DynamicQueueUrlDestinationResolverTest {
     public void testAbsoluteUrl() throws Exception {
         AmazonSQS amazonSqs = mock(AmazonSQS.class);
         DynamicQueueUrlDestinationResolver dynamicQueueDestinationResolver = new DynamicQueueUrlDestinationResolver(amazonSqs);
-        String destination = "http://sqs-amazon.aws.com/123123123/myQueue";
+        String destination = "https://sqs-amazon.aws.com/123123123/myQueue";
         assertEquals(destination, dynamicQueueDestinationResolver.resolveDestination(destination));
     }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://queue.com (200) with 2 occurrences could not be migrated:  
   ([https](https://queue.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ch.linkedin.com/in/asahli (IllegalArgumentException) with 2 occurrences migrated to:  
  https://ch.linkedin.com/in/asahli ([https](https://ch.linkedin.com/in/asahli) result IllegalArgumentException).
* [ ] http://de.linkedin.com/in/agimemruli (IllegalArgumentException) with 2 occurrences migrated to:  
  https://de.linkedin.com/in/agimemruli ([https](https://de.linkedin.com/in/agimemruli) result IllegalArgumentException).
* [ ] http://alwaysError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://alwaysError.amazonaws.com ([https](https://alwaysError.amazonaws.com) result UnknownHostException).
* [ ] http://alwaysSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://alwaysSuccess.amazonaws.com ([https](https://alwaysSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://anotherTestQueue.amazonaws.com (UnknownHostException) with 7 occurrences migrated to:  
  https://anotherTestQueue.amazonaws.com ([https](https://anotherTestQueue.amazonaws.com) result UnknownHostException).
* [ ] http://build.elasticspring.org (UnknownHostException) with 1 occurrences migrated to:  
  https://build.elasticspring.org ([https](https://build.elasticspring.org) result UnknownHostException).
* [ ] http://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com ([https](https://executeMessage_executionThrowsExceptionAndQueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com) result UnknownHostException).
* [ ] http://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com ([https](https://executeMessage_executionThrowsExceptionAndQueueHasRedrivePolicy_shouldNotRemoveMessageFromQueue.amazonaws.com) result UnknownHostException).
* [ ] http://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com ([https](https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com) result UnknownHostException).
* [ ] http://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com ([https](https://listener_withMultipleMessageHandlers_shouldBeCalled.amazonaws.com) result UnknownHostException).
* [ ] http://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com ([https](https://listener_withMultipleMessageHandlers_shouldBeCalled.another.amazonaws.com) result UnknownHostException).
* [ ] http://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com ([https](https://messageExecutor_messageWithMimeTypeMessageAttribute_shouldSetItAsHeader.amazonaws.com) result UnknownHostException).
* [ ] http://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com ([https](https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com) result UnknownHostException).
* [ ] http://neverError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://neverError.amazonaws.com ([https](https://neverError.amazonaws.com) result UnknownHostException).
* [ ] http://neverSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://neverSuccess.amazonaws.com ([https](https://neverSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://noRedriveError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://noRedriveError.amazonaws.com ([https](https://noRedriveError.amazonaws.com) result UnknownHostException).
* [ ] http://noRedriveSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://noRedriveSuccess.amazonaws.com ([https](https://noRedriveSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://onSuccessError.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://onSuccessError.amazonaws.com ([https](https://onSuccessError.amazonaws.com) result UnknownHostException).
* [ ] http://onSuccessSuccess.amazonaws.com (UnknownHostException) with 4 occurrences migrated to:  
  https://onSuccessSuccess.amazonaws.com ([https](https://onSuccessSuccess.amazonaws.com) result UnknownHostException).
* [ ] http://queue-url.com (UnknownHostException) with 5 occurrences migrated to:  
  https://queue-url.com ([https](https://queue-url.com) result UnknownHostException).
* [ ] http://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com (UnknownHostException) with 1 occurrences migrated to:  
  https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com ([https](https://receiveMessage_throwsAnException_operationShouldBeRetried.amazonaws.com) result UnknownHostException).
* [ ] http://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com (UnknownHostException) with 5 occurrences migrated to:  
  https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com ([https](https://receiveMessage_withMessageListenerMethodAndNeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com) result UnknownHostException).
* [ ] http://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com (UnknownHostException) with 3 occurrences migrated to:  
  https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com ([https](https://setQueueStopTimeout_withNotDefaultTimeout_mustBeUsedWhenStoppingAQueue.amazonaws.com) result UnknownHostException).
* [ ] http://sqs-amazon.aws.com/123123123/myQueue (UnknownHostException) with 1 occurrences migrated to:  
  https://sqs-amazon.aws.com/123123123/myQueue ([https](https://sqs-amazon.aws.com/123123123/myQueue) result UnknownHostException).
* [ ] http://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com ([https](https://start_withAQueueNameThatIsAlreadyRunning_shouldNotStartTheQueueAgainAndIgnoreTheCall.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com ([https](https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com ([https](https://stop_withALogicalQueueName_mustStopOnlyTheSpecifiedQueue.another.amazonaws.com) result UnknownHostException).
* [ ] http://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com (UnknownHostException) with 2 occurrences migrated to:  
  https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com ([https](https://stop_withAQueueNameThatIsNotRunning_shouldNotStopTheQueueAgainAndIgnoreTheCall.amazonaws.com) result UnknownHostException).
* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd (404) with 12 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://aws.amazon.com with 1 occurrences migrated to:  
  https://aws.amazon.com ([https](https://aws.amazon.com) result 200).
* [ ] http://aws.amazon.com/cloudformation/ with 2 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/ ([https](https://aws.amazon.com/cloudformation/) result 200).
* [ ] http://aws.amazon.com/cloudformation/aws-cloudformation-templates/ with 1 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/aws-cloudformation-templates/ ([https](https://aws.amazon.com/cloudformation/aws-cloudformation-templates/) result 200).
* [ ] http://aws.amazon.com/de/ses/ with 1 occurrences migrated to:  
  https://aws.amazon.com/de/ses/ ([https](https://aws.amazon.com/de/ses/) result 200).
* [ ] http://aws.amazon.com/ec2/ with 1 occurrences migrated to:  
  https://aws.amazon.com/ec2/ ([https](https://aws.amazon.com/ec2/) result 200).
* [ ] http://aws.amazon.com/elasticache/ with 2 occurrences migrated to:  
  https://aws.amazon.com/elasticache/ ([https](https://aws.amazon.com/elasticache/) result 200).
* [ ] http://aws.amazon.com/rds/ with 2 occurrences migrated to:  
  https://aws.amazon.com/rds/ ([https](https://aws.amazon.com/rds/) result 200).
* [ ] http://aws.amazon.com/s3/ with 2 occurrences migrated to:  
  https://aws.amazon.com/s3/ ([https](https://aws.amazon.com/s3/) result 200).
* [ ] http://aws.amazon.com/sdk-for-java/ with 1 occurrences migrated to:  
  https://aws.amazon.com/sdk-for-java/ ([https](https://aws.amazon.com/sdk-for-java/) result 200).
* [ ] http://aws.amazon.com/ses/ with 1 occurrences migrated to:  
  https://aws.amazon.com/ses/ ([https](https://aws.amazon.com/ses/) result 200).
* [ ] http://aws.amazon.com/sns/ with 1 occurrences migrated to:  
  https://aws.amazon.com/sns/ ([https](https://aws.amazon.com/sns/) result 200).
* [ ] http://aws.amazon.com/sqs/ with 3 occurrences migrated to:  
  https://aws.amazon.com/sqs/ ([https](https://aws.amazon.com/sqs/) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html with 3 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html with 3 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html ([https](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html) result 200).
* [ ] http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html with 3 occurrences migrated to:  
  https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html ([https](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html) result 200).
* [ ] http://en.wikipedia.org/wiki/ACID with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ACID ([https](https://en.wikipedia.org/wiki/ACID) result 200).
* [ ] http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://projects.spring.io/spring-data-redis/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-redis/ ([https](https://projects.spring.io/spring-data-redis/) result 200).
* [ ] http://repo.spring.io/milestone/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/ ([https](https://repo.spring.io/milestone/) result 200).
* [ ] http://repo.spring.io/release/ with 1 occurrences migrated to:  
  https://repo.spring.io/release/ ([https](https://repo.spring.io/release/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html with 3 occurrences migrated to:  
  https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html ([https](https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html) result 200).
* [ ] http://twitter.com/aemruli with 2 occurrences migrated to:  
  https://twitter.com/aemruli ([https](https://twitter.com/aemruli) result 200).
* [ ] http://twitter.com/chrisstettler with 2 occurrences migrated to:  
  https://twitter.com/chrisstettler ([https](https://twitter.com/chrisstettler) result 200).
* [ ] http://twitter.com/sahlialain with 2 occurrences migrated to:  
  https://twitter.com/sahlialain ([https](https://twitter.com/sahlialain) result 200).
* [ ] http://www.jetbrains.com/idea/ with 4 occurrences migrated to:  
  https://www.jetbrains.com/idea/ ([https](https://www.jetbrains.com/idea/) result 200).
* [ ] http://www.oracle.com/technetwork/java/javamail/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javamail/index.html ([https](https://www.oracle.com/technetwork/java/javamail/index.html) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool.xsd ([https](https://www.springframework.org/schema/tool/spring-tool.xsd) result 200).
* [ ] http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html ([https](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) result 302).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html) result 302).
* [ ] http://docs.aws.amazon.com/sns/latest/dg/json-formats.html with 2 occurrences migrated to:  
  https://docs.aws.amazon.com/sns/latest/dg/json-formats.html ([https](https://docs.aws.amazon.com/sns/latest/dg/json-formats.html) result 302).
* [ ] http://s3.amazonaws.com with 2 occurrences migrated to:  
  https://s3.amazonaws.com ([https](https://s3.amazonaws.com) result 307).

# Ignored
These URLs were intentionally ignored.

* http://foo/bar with 2 occurrences
* http://testContainerDoesNotProcessMessageAfterBeingStopped.amazonaws.com with 2 occurrences
* http://testQueue with 39 occurrences
* http://testQueue.amazonaws.com with 13 occurrences
* http://testSimpleReceiveMessage.amazonaws.com with 3 occurrences
* http://www.springframework.org/schema/beans with 17 occurrences
* http://www.springframework.org/schema/cache with 2 occurrences
* http://www.springframework.org/schema/cloud/aws/cache with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/context with 28 occurrences
* http://www.springframework.org/schema/cloud/aws/jdbc with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/mail with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging with 6 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging with 1 occurrences
* http://www.springframework.org/schema/tool with 20 occurrences
* http://www.w3.org/2001/XMLSchema with 10 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 5 occurrences