### PR TITLE
Documentation update for Amazon RDS read replicas

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -1749,7 +1749,8 @@ outlines all properties for a data source using `test` as the instance identifie
 
 
 === Read-replica configuration
-Amazon RDS allows to use MariaDB, MySQL, Oracle, and PostgreSQL https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[read-replica]
+Amazon RDS allows to use MySQL, MariaDB, Oracle, PostgreSQL and
+Microsoft SQL Server https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[read-replica]
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.
 

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -1749,7 +1749,7 @@ outlines all properties for a data source using `test` as the instance identifie
 
 
 === Read-replica configuration
-Amazon RDS allows to use https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[MySQL read-replica]
+Amazon RDS allows to use MariaDB, MySQL, Oracle, and PostgreSQL https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html[read-replica]
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.
 


### PR DESCRIPTION
This PR updates part of documentation about Amazon RDS read replicas. AWS added support for replication functionality of more DB engines by now.

Section from [AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html):
> Amazon RDS uses the MariaDB, MySQL, Oracle, and PostgreSQL DB engines' built-in replication functionality to create a special type of DB instance called a Read Replica from a source DB instance.


Edit: Travis build is failing probably due to the latest code on master branch where the same thing is happening.