### PR TITLE
Fix duplicate error logging

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -52,6 +52,7 @@ import org.springframework.messaging.handler.invocation.AbstractExceptionHandler
 import org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.HandlerMethodReturnValueHandler;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.comparator.ComparableComparator;
 import org.springframework.validation.Errors;
@@ -233,7 +234,11 @@ public class QueueMessageHandler
 	@Override
 	protected void processHandlerMethodException(HandlerMethod handlerMethod,
 			Exception ex, Message<?> message) {
-		super.processHandlerMethodException(handlerMethod, ex, message);
+		InvocableHandlerMethod exceptionHandlerMethod = getExceptionHandlerMethod(
+				handlerMethod, ex);
+		if (exceptionHandlerMethod != null) {
+			super.processHandlerMethodException(handlerMethod, ex, message);
+		}
 		throw new MessagingException(
 				"An exception occurred while invoking the handler method", ex);
 	}


### PR DESCRIPTION
During the processing of an exception thrown by a queue message handler method, the AbstractMethodMessageHandler always logs the error [when there is no existing handler method for that exception](https://github.com/spring-projects/spring-framework/blob/f273fa990c5231684b0dedf4895d9e6bd8f66235/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/AbstractMethodMessageHandler.java#L592). On the other hand, the SimpleMessageListenerContainer logs the same exception again [when the message deletion policy is set to ON_SUCCESS](https://github.com/spring-cloud/spring-cloud-aws/blob/8d456c9428c930fe44f2d00c6144a1be6354770e/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java#L440). This results in duplicated error logging.

This commit fixes this issue by delegating exception processing to AbstractMethodMessageHandler only when there is a configured exception handler.