### PR TITLE
Issue 463: can change AWS Secret Manager default separator

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -726,6 +726,10 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 |`_`
 |String that separates an appended profile from the context name.
 
+|`aws.secretsmanager.prefixSeparator`
+|`/`
+|String that separates an appended prefix from the context name.
+
 |`aws.secretsmanager.failFast`
 |`true`
 |Indicates if an error while retrieving the secrets should fail starting the application.

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -54,6 +54,10 @@ public class AwsSecretsManagerProperties {
 	@Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
 	private String profileSeparator = "_";
 
+	@NotNull
+	@Pattern(regexp = "[a-zA-Z0-9.\\-_/]+")
+	private String prefixSeparator = "/";
+
 	/** Throw exceptions during config lookup if true, otherwise, log warnings. */
 	private boolean failFast = true;
 
@@ -114,4 +118,11 @@ public class AwsSecretsManagerProperties {
 		this.enabled = enabled;
 	}
 
+	public String getPrefixSeparator() {
+		return prefixSeparator;
+	}
+
+	public void setPrefixSeparator(String prefixSeparator) {
+		this.prefixSeparator = prefixSeparator;
+	}
 }

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -31,6 +31,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Builds a {@link CompositePropertySource} with various
@@ -78,14 +79,24 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
 
 		String prefix = this.properties.getPrefix();
+		String prefixSeparator = this.properties.getPrefixSeparator();
 
-		String defaultContext = prefix + "/" + this.properties.getDefaultContext();
-		this.contexts.add(defaultContext);
-		addProfiles(this.contexts, defaultContext, profiles);
+		String defaultContext = StringUtils.isEmpty(prefix) ? this.properties.getDefaultContext() : prefix + prefixSeparator + this.properties.getDefaultContext();
+		// Prevent to add an empty context if there is no prefix, and an empty properties.getDefaultContext()
+		if (!StringUtils.isEmpty(defaultContext)) {
+			this.contexts.add(defaultContext);
+			addProfiles(this.contexts, defaultContext, profiles);
+		}
 
-		String baseContext = prefix + "/" + appName;
-		this.contexts.add(baseContext);
-		addProfiles(this.contexts, baseContext, profiles);
+		// appName can be null or empty
+		if (!StringUtils.isEmpty(appName)) {
+			String baseContext = StringUtils.isEmpty(prefix) ? appName : prefix + prefixSeparator + appName;
+			// Prevent to add an empty context if there is no prefix, and an empty appName
+			if (!StringUtils.isEmpty(baseContext)) {
+				this.contexts.add(baseContext);
+				addProfiles(this.contexts, baseContext, profiles);
+			}
+		}
 
 		Collections.reverse(this.contexts);
 

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import org.junit.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AwsSecretsManagerPropertySourceLocatorTest {
+
+	private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
+
+	private Environment environment = mock(ConfigurableEnvironment.class);
+
+	@Test
+	public void shouldIgnoreSeparatorIfPrefixIsEmpty() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setPrefix("");
+
+		when(environment.getActiveProfiles()).thenReturn(new String[]{"dev"});
+
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+			.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator propertySourceLocator = new AwsSecretsManagerPropertySourceLocator(
+			smClient, properties);
+
+		propertySourceLocator.locate(environment);
+		List<String> contexts = propertySourceLocator.getContexts();
+
+		assertThat(contexts.size()).isEqualTo(2);
+		assertThat(contexts).contains("application");
+		assertThat(contexts).contains("application_dev");
+	}
+
+	@Test
+	public void shouldUseThePropertiesPrefixSeparator() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setPrefix("prefix");
+		properties.setPrefixSeparator("-");
+
+		when(environment.getActiveProfiles()).thenReturn(new String[]{"dev"});
+
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+			.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator propertySourceLocator = new AwsSecretsManagerPropertySourceLocator(
+			smClient, properties);
+
+		propertySourceLocator.locate(environment);
+		List<String> contexts = propertySourceLocator.getContexts();
+
+		assertThat(contexts.size()).isEqualTo(2);
+		assertThat(contexts).contains("prefix-application");
+		assertThat(contexts).contains("prefix-application_dev");
+	}
+
+}


### PR DESCRIPTION
Fixes gh-463

- The default prefix separator can now be changed `/` is the default
- The prefix can now be empty. If it is empty, the prefix separator is not appended to the context name 