### PR TITLE
Support String Array SNS messageAttributeDataType

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/MessageAttributeDataTypes.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/MessageAttributeDataTypes.java
@@ -37,6 +37,11 @@ public final class MessageAttributeDataTypes {
 	 */
 	public static final String STRING = "String";
 
+	/**
+	 * String.Array message attribute data type.
+	 */
+	public static final String STRING_ARRAY = "String.Array";
+
 	private MessageAttributeDataTypes() {
 		// Avoid instantiation
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannel.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.aws.messaging.core;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.MessageAttributeValue;
@@ -34,6 +36,7 @@ import org.springframework.util.NumberUtils;
 /**
  * @author Agim Emruli
  * @author Alain Sahli
+ * @author Gyozo Papp
  * @since 1.0
  */
 public class TopicMessageChannel extends AbstractMessageChannel {
@@ -99,6 +102,10 @@ public class TopicMessageChannel extends AbstractMessageChannel {
 				messageAttributes.put(messageHeaderName,
 						getBinaryMessageAttribute((ByteBuffer) messageHeaderValue));
 			}
+			else if (messageHeaderValue instanceof List) {
+				messageAttributes.put(messageHeaderName,
+						getStringArrayMessageAttribute((List<Object>) messageHeaderValue));
+			}
 			else {
 				this.logger.warn(String.format(
 						"Message header with name '%s' and type '%s' cannot be sent as"
@@ -109,6 +116,19 @@ public class TopicMessageChannel extends AbstractMessageChannel {
 		}
 
 		return messageAttributes;
+	}
+
+	private MessageAttributeValue getStringArrayMessageAttribute(
+			List<Object> messageHeaderValue) {
+		List<String> stringValues = messageHeaderValue.stream()
+			// TODO: escape string properly (quotes, etc)
+			.map(item -> String.format("\"%s\"", item.toString()))
+			.collect(Collectors.toList());
+		String stringValue = "[" + String.join(", ", stringValues) + "]";
+
+		return new MessageAttributeValue()
+				.withDataType(MessageAttributeDataTypes.STRING_ARRAY)
+				.withStringValue(stringValue);
 	}
 
 	private MessageAttributeValue getBinaryMessageAttribute(

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.aws.messaging.core;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -251,6 +253,34 @@ public class TopicMessageChannelTest {
 		assertThat(sent).isTrue();
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getMessageAttributes()
 				.get(MessageHeaders.ID).getStringValue()).isEqualTo(uuid.toString());
+	}
+
+	@Test
+	public void sendMessage_withStringArrayMessageHeader_shouldBeSentAsTopicMessageAttribute()
+		throws Exception {
+		// Arrange
+		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor
+			.forClass(PublishRequest.class);
+		when(amazonSns.publish(publishRequestArgumentCaptor.capture()))
+			.thenReturn(new PublishResult());
+
+		List<String> headerValue = Arrays.asList("List", "of", "header", "values");
+		String headerName = "MyHeader";
+		Message<String> message = MessageBuilder.withPayload("Hello")
+			.setHeader(headerName, headerValue).build();
+		MessageChannel messageChannel = new TopicMessageChannel(amazonSns, "topicArn");
+
+		// Act
+		boolean sent = messageChannel.send(message);
+
+		// Assert
+		assertThat(sent).isTrue();
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
+			.get(headerName).getStringValue()).isEqualTo("[\"List\", \"of\", \"header\", \"values\"]");
+		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
+			.get(headerName).getDataType())
+			.isEqualTo(MessageAttributeDataTypes.STRING_ARRAY);
 	}
 
 }


### PR DESCRIPTION
According to AWS documentation about SNS Message Attribute Data Types:
https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
There is quite useful DataType String.Array that is not supported by
this library:

String.Array – An array, formatted as a string, that can contain
multiple values. The values can be strings, numbers, or the keywords
true, false, and null.

This patch does not validate the item's type but convert each array item
to its string representation first and then build up the final formatted
string.

Fixes gh-368