### PR TITLE
Fix AwsSecretsManagerProperties.prefix javadoc

### DIFF
--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -41,7 +41,7 @@ public class AwsSecretsManagerProperties {
 
 	/**
 	 * Prefix indicating first level for every property. Value must start with a forward
-	 * slash followed by a valid path segment or be empty. Defaults to "/config".
+	 * slash followed by a valid path segment or be empty. Defaults to "/secret".
 	 */
 	@NotNull
 	@Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")


### PR DESCRIPTION
Javadoc says the default prefix is "/config" when the field is initialized to "/secret".