### PR TITLE
Use S3 exception region info when retrying on 301 error. Fixes gh-501

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactory.java
@@ -93,10 +93,16 @@ public class AmazonS3ClientFactory {
 	}
 
 	public AmazonS3 createClientForEndpointUrl(AmazonS3 prototype, String endpointUrl) {
+		return createClientForEndpointUrl(prototype, endpointUrl, null);
+	}
+
+	AmazonS3 createClientForEndpointUrl(AmazonS3 prototype, String endpointUrl,
+			Regions bucketRegion) {
 		Assert.notNull(prototype, "AmazonS3 must not be null");
 		Assert.notNull(endpointUrl, "Endpoint Url must not be null");
 
-		String region = getRegion(endpointUrl);
+		String region = bucketRegion != null ? bucketRegion.getName()
+				: getRegion(endpointUrl);
 		Assert.notNull(region,
 				"Error detecting region from endpoint url:'" + endpointUrl + "'");
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
@@ -139,7 +139,7 @@ public final class AmazonS3ProxyFactory {
 		 *
 		 * Extracting the region from the exception is needed because the US S3 buckets
 		 * don't always return an endpoint that includes the region and
-		 * {@Link AmazonS3ClientFactoryTest} will default to us-west-2 if the hostname of
+		 * {@link AmazonS3ClientFactory} will default to us-west-2 if the hostname of
 		 * the endpoint is "s3.amazonaws.com". The us-east-1 bucket is quite likely to
 		 * return the "s3.amazonaws.com" endpoint.
 		 *

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -131,11 +132,34 @@ public final class AmazonS3ProxyFactory {
 			}
 		}
 
+		/**
+		 * Builds a new S3 client based on the information from the
+		 * {@link AmazonS3Exception}. Extracts from the exception's additional details the
+		 * region and endpoint of the bucket to be redirected to.
+		 *
+		 * Extracting the region from the exception is needed because the US S3 buckets
+		 * don't always return an endpoint that includes the region and
+		 * {@Link AmazonS3ClientFactoryTest} will default to us-west-2 if the hostname of
+		 * the endpoint is "s3.amazonaws.com". The us-east-1 bucket is quite likely to
+		 * return the "s3.amazonaws.com" endpoint.
+		 *
+		 * @author André Caron
+		 */
 		private AmazonS3 buildAmazonS3ForRedirectLocation(AmazonS3 prototype,
 				AmazonS3Exception e) {
 			try {
+				Regions redirectRegion;
+				try {
+					redirectRegion = Regions.fromName(
+							e.getAdditionalDetails().get("x-amz-bucket-region"));
+				}
+				catch (IllegalArgumentException iae) {
+					redirectRegion = null;
+				}
+
 				return this.amazonS3ClientFactory.createClientForEndpointUrl(prototype,
-						"https://" + e.getAdditionalDetails().get("Endpoint"));
+						"https://" + e.getAdditionalDetails().get("Endpoint"),
+						redirectRegion);
 			}
 			catch (Exception ex) {
 				LOGGER.error("Error getting new Amazon S3 for redirect", ex);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
@@ -82,6 +82,21 @@ public class AmazonS3ClientFactoryTest {
 	}
 
 	@Test
+	public void createClientForEndpointUrl_withProvidedBucketRegion_createClientForDefaultRegion() {
+		// Arrange
+		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
+		AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard()
+				.withRegion(Regions.EU_CENTRAL_1).build();
+
+		// Act
+		AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
+				"https://s3.amazonaws.com", Regions.US_EAST_1);
+
+		// Prepare
+		assertThat(newClient.getRegionName()).isEqualTo(Regions.US_EAST_1.getName());
+	}
+
+	@Test
 	public void createClientForEndpointUrl_withCustomRegionUrl_createClientForCustomRegion() {
 		// Arrange
 		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();


### PR DESCRIPTION
When `AmazonS3ProxyFactory` encounters a 301 error in the `SimpleStorageRedirectInterceptor`, instead of relying solely on the endpoint from the caught exception to create a new client, it will also use the region provided in the additional details of the exception.

Fixes gh-501