### PR TITLE
Upgrade to AWS SDK 2.0

### DIFF
--- a/spring-cloud-aws-actuator/pom.xml
+++ b/spring-cloud-aws-actuator/pom.xml
@@ -30,13 +30,13 @@
 	<description>Spring Cloud AWS Actuator</description>
 
 	<properties>
-		<micrometer.version>1.0.4</micrometer.version>
+		<micrometer.version>1.3.3</micrometer.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-cloudwatch</artifactId>
+			<artifactId>micrometer-registry-cloudwatch2</artifactId>
 			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>

--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -63,13 +63,13 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ses</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ses</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-cloudwatch</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>cloudwatch</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -88,8 +88,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-elasticache</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>elasticache</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -29,7 +29,8 @@ import org.springframework.context.annotation.Import;
 @Configuration(proxyBeanMethods = false)
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableElastiCache
-@ConditionalOnClass(name = "com.amazonaws.services.elasticache.AmazonElastiCache")
+@ConditionalOnClass(
+		name = "software.amazon.awssdk.services.elasticache.ElastiCacheClient")
 @ConditionalOnAwsCloudEnvironment
 public class ElastiCacheAutoConfiguration {
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -42,7 +42,8 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 @Configuration(proxyBeanMethods = false)
 @Import({ ContextDefaultConfigurationRegistrar.class,
 		ContextCredentialsAutoConfiguration.Registrar.class })
-@ConditionalOnClass(name = "com.amazonaws.auth.AWSCredentialsProvider")
+@ConditionalOnClass(
+		name = "software.amazon.awssdk.auth.credentials.AwsCredentialsProvider")
 public class ContextCredentialsAutoConfiguration {
 
 	/**

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,7 +33,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.StringUtils;
 
-import static com.amazonaws.auth.profile.internal.AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerCredentialsProvider;
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerDefaultAWSCredentialsProvider;
 
@@ -102,7 +103,7 @@ public class ContextCredentialsAutoConfiguration {
 										AWS_CREDENTIALS_PROPERTY_PREFIX + ".accessKey"),
 						this.environment.getProperty(
 								AWS_CREDENTIALS_PROPERTY_PREFIX + ".profileName",
-								DEFAULT_PROFILE_NAME),
+								ProfileFileSystemSetting.AWS_PROFILE.defaultValue()),
 						this.environment.getProperty(
 								AWS_CREDENTIALS_PROPERTY_PREFIX + ".profilePath"));
 			}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  */
 @Configuration(proxyBeanMethods = false)
 @Import(ContextResourceLoaderAutoConfiguration.Registrar.class)
-@ConditionalOnClass(name = "com.amazonaws.services.s3.AmazonS3Client")
+@ConditionalOnClass(name = "software.amazon.awssdk.services.s3.S3Client")
 public class ContextResourceLoaderAutoConfiguration {
 
 	/**

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
@@ -43,7 +43,8 @@ import org.springframework.util.StringUtils;
 @Configuration(proxyBeanMethods = false)
 @Import({ ContextCredentialsAutoConfiguration.class,
 		ContextDefaultConfigurationRegistrar.class })
-@ConditionalOnClass(name = "com.amazonaws.services.cloudformation.AmazonCloudFormation")
+@ConditionalOnClass(
+		name = "software.amazon.awssdk.services.cloudformation.CloudFormationClient")
 public class ContextStackAutoConfiguration {
 
 	@Autowired

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-import com.amazonaws.services.ec2.AmazonEC2;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -51,18 +50,18 @@ public class ContextStackAutoConfiguration {
 	private Environment environment;
 
 	@Autowired(required = false)
-	private AmazonEC2 amazonEC2;
+	private Ec2Client amazonEC2;
 
 	@Autowired(required = false)
 	private RegionProvider regionProvider;
 
 	@Autowired(required = false)
-	private AWSCredentialsProvider credentialsProvider;
+	private AwsCredentialsProvider credentialsProvider;
 
 	@Bean
 	@ConditionalOnMissingBean(StackResourceRegistry.class)
 	public StackResourceRegistryFactoryBean stackResourceRegistryFactoryBean(
-			AmazonCloudFormation amazonCloudFormation) {
+			CloudFormationClient amazonCloudFormation) {
 
 		if (StringUtils.hasText(environment.getProperty("cloud.aws.stack.name"))) {
 			return new StackResourceRegistryFactoryBean(amazonCloudFormation,
@@ -81,9 +80,9 @@ public class ContextStackAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingAmazonClient(AmazonCloudFormation.class)
-	public AmazonWebserviceClientFactoryBean<AmazonCloudFormationClient> amazonCloudFormation() {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonCloudFormationClient.class,
+	@ConditionalOnMissingAmazonClient(CloudFormationClient.class)
+	public AmazonWebserviceClientFactoryBean<CloudFormationClient> amazonCloudFormation() {
+		return new AmazonWebserviceClientFactoryBean<>(CloudFormationClient.class,
 				this.credentialsProvider, this.regionProvider);
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
-import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 
 /**
  * Properties related to AWS credentials.
@@ -51,7 +51,7 @@ public class AwsCredentialsProperties {
 	/**
 	 * The AWS profile name.
 	 */
-	private String profileName = AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
+	private String profileName = ProfileFileSystemSetting.AWS_PROFILE.defaultValue();
 
 	/**
 	 * The AWS profile path.

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -72,7 +72,7 @@ public class AmazonRdsDatabaseAutoConfiguration {
 				BeanDefinitionRegistry registry) {
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null)
+							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
 					.getBeanName();
 			Map<String, Map<String, String>> dbInstanceConfigurations = getDbInstanceConfigurations();
 			for (Map.Entry<String, Map<String, String>> dbInstanceEntry : dbInstanceConfigurations

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureBefore(DataSourceAutoConfiguration.class)
 @Import(AmazonRdsDatabaseAutoConfiguration.Registrar.class)
-@ConditionalOnClass(name = { "com.amazonaws.services.rds.AmazonRDSClient",
+@ConditionalOnClass(name = { "software.amazon.awssdk.services.rds.RdsClient",
 		"org.springframework.cloud.aws.jdbc.config.annotation.AmazonRdsInstanceConfiguration" })
 @ConditionalOnMissingBean(AmazonRdsInstanceConfiguration.class)
 public class AmazonRdsDatabaseAutoConfiguration {
@@ -72,7 +72,7 @@ public class AmazonRdsDatabaseAutoConfiguration {
 				BeanDefinitionRegistry registry) {
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
+							"software.amazon.awssdk.services.rds.RdsClient", null, null)
 					.getBeanName();
 			Map<String, Map<String, String>> dbInstanceConfigurations = getDbInstanceConfigurations();
 			for (Map.Entry<String, Map<String, String>> dbInstanceEntry : dbInstanceConfigurations

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -72,7 +72,7 @@ public class AmazonRdsDatabaseAutoConfiguration {
 				BeanDefinitionRegistry registry) {
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
+							"com.amazonaws.services.rds.AmazonRDSClient", null)
 					.getBeanName();
 			Map<String, Map<String, String>> dbInstanceConfigurations = getDbInstanceConfigurations();
 			for (Map.Entry<String, Map<String, String>> dbInstanceEntry : dbInstanceConfigurations

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.aws.autoconfigure.mail;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.ses.SesClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -52,25 +51,22 @@ public class MailSenderAutoConfiguration {
 	private RegionProvider regionProvider;
 
 	@Bean
-	@ConditionalOnMissingAmazonClient(AmazonSimpleEmailService.class)
-	public AmazonWebserviceClientFactoryBean<AmazonSimpleEmailServiceClient> amazonSimpleEmailService(
-			AWSCredentialsProvider credentialsProvider) {
-		return new AmazonWebserviceClientFactoryBean<>(
-				AmazonSimpleEmailServiceClient.class, credentialsProvider,
-				this.regionProvider);
+	@ConditionalOnMissingAmazonClient(SesClient.class)
+	public AmazonWebserviceClientFactoryBean<SesClient> amazonSimpleEmailService(
+			AwsCredentialsProvider credentialsProvider) {
+		return new AmazonWebserviceClientFactoryBean<>(SesClient.class,
+				credentialsProvider, this.regionProvider);
 	}
 
 	@Bean
 	@ConditionalOnMissingClass("org.springframework.cloud.aws.mail.simplemail.SimpleEmailServiceJavaMailSender")
-	public MailSender simpleMailSender(
-			AmazonSimpleEmailService amazonSimpleEmailService) {
+	public MailSender simpleMailSender(SesClient amazonSimpleEmailService) {
 		return new SimpleEmailServiceMailSender(amazonSimpleEmailService);
 	}
 
 	@Bean
 	@ConditionalOnClass(name = "javax.mail.Session")
-	public JavaMailSender javaMailSender(
-			AmazonSimpleEmailService amazonSimpleEmailService) {
+	public JavaMailSender javaMailSender(SesClient amazonSimpleEmailService) {
 		return new SimpleEmailServiceJavaMailSender(amazonSimpleEmailService);
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/MailSenderAutoConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration.class)
 @ConditionalOnClass(name = { "org.springframework.mail.MailSender",
-		"com.amazonaws.services.simpleemail.AmazonSimpleEmailService" })
+		"software.amazon.awssdk.services.ses.SesClient" })
 @ConditionalOnMissingBean(MailSender.class)
 @Import(ContextCredentialsAutoConfiguration.class)
 public class MailSenderAutoConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/MessagingAutoConfiguration.java
@@ -45,7 +45,7 @@ public class MessagingAutoConfiguration {
 	/**
 	 * Auto configuration for SNS.
 	 */
-	@ConditionalOnClass(name = "com.amazonaws.services.sns.AmazonSNS")
+	@ConditionalOnClass(name = "software.amazon.awssdk.services.sns.SnsClient")
 	@EnableSns
 	@Configuration(proxyBeanMethods = false)
 	public static class SnsAutoConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -16,12 +16,11 @@
 
 package org.springframework.cloud.aws.autoconfigure.metrics;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient;
-import io.micrometer.cloudwatch.CloudWatchConfig;
-import io.micrometer.cloudwatch.CloudWatchMeterRegistry;
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
@@ -67,15 +66,15 @@ public class CloudWatchExportAutoConfiguration {
 	@ConditionalOnProperty(value = "management.metrics.export.cloudwatch.enabled",
 			matchIfMissing = true)
 	public CloudWatchMeterRegistry cloudWatchMeterRegistry(CloudWatchConfig config,
-			Clock clock, AmazonCloudWatchAsync client) {
+			Clock clock, CloudWatchAsyncClient client) {
 		return new CloudWatchMeterRegistry(config, clock, client);
 	}
 
 	@Bean
-	@ConditionalOnMissingAmazonClient(AmazonCloudWatchAsync.class)
-	public AmazonWebserviceClientFactoryBean<AmazonCloudWatchAsyncClient> amazonCloudWatchAsync(
-			AWSCredentialsProvider credentialsProvider) {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonCloudWatchAsyncClient.class,
+	@ConditionalOnMissingAmazonClient(CloudWatchAsyncClient.class)
+	public AmazonWebserviceClientFactoryBean<CloudWatchAsyncClient> amazonCloudWatchAsync(
+			AwsCredentialsProvider credentialsProvider) {
+		return new AmazonWebserviceClientFactoryBean<>(CloudWatchAsyncClient.class,
 				credentialsProvider, this.regionProvider);
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchPropertiesConfigAdapter.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.metrics;
 
-import io.micrometer.cloudwatch.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchConfig;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
@@ -19,11 +19,6 @@ package org.springframework.cloud.aws.autoconfigure.cache;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
-import com.amazonaws.services.elasticache.AmazonElastiCache;
-import com.amazonaws.services.elasticache.model.CacheCluster;
-import com.amazonaws.services.elasticache.model.DescribeCacheClustersRequest;
-import com.amazonaws.services.elasticache.model.DescribeCacheClustersResult;
-import com.amazonaws.services.elasticache.model.Endpoint;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
@@ -31,6 +26,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
+import software.amazon.awssdk.services.elasticache.model.CacheCluster;
+import software.amazon.awssdk.services.elasticache.model.DescribeCacheClustersRequest;
+import software.amazon.awssdk.services.elasticache.model.DescribeCacheClustersResponse;
+import software.amazon.awssdk.services.elasticache.model.Endpoint;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
@@ -128,40 +128,32 @@ public class ElastiCacheAutoConfigurationTest {
 	public static class MockCacheConfigurationWithStackCaches {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest sampleCacheOneLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheOneLogical");
-			sampleCacheOneLogical.setShowCacheNodeInfo(true);
+			DescribeCacheClustersRequest sampleCacheOneLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheOneLogical")
+					.showCacheNodeInfo(true).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheOneLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 
-			DescribeCacheClustersRequest sampleCacheTwoLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheTwoLogical");
-			sampleCacheTwoLogical.setShowCacheNodeInfo(true);
+			DescribeCacheClustersRequest sampleCacheTwoLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheTwoLogical")
+					.showCacheNodeInfo(true).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheTwoLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.After;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
@@ -89,8 +88,7 @@ public class ContextRegionProviderAutoConfigurationTest {
 				.getBean(StaticRegionProvider.class);
 
 		// Assert
-		assertThat(regionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		assertThat(regionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfigurationTest.java
@@ -19,18 +19,18 @@ package org.springframework.cloud.aws.autoconfigure.context;
 import java.lang.reflect.Field;
 import java.util.Collections;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
-import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
-import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
-import com.amazonaws.services.cloudformation.model.StackResource;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesResponse;
+import software.amazon.awssdk.services.cloudformation.model.ListStackResourcesRequest;
+import software.amazon.awssdk.services.cloudformation.model.ListStackResourcesResponse;
+import software.amazon.awssdk.services.cloudformation.model.StackResource;
 
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils;
@@ -122,17 +122,19 @@ public class ContextStackAutoConfigurationTest {
 	static class AutoConfigurationStackRegistryTestConfiguration {
 
 		@Bean
-		public AmazonCloudFormation amazonCloudFormation() {
-			AmazonCloudFormation amazonCloudFormation = Mockito
-					.mock(AmazonCloudFormation.class);
-			Mockito.when(amazonCloudFormation.describeStackResources(
-					new DescribeStackResourcesRequest().withPhysicalResourceId("test")))
-					.thenReturn(new DescribeStackResourcesResult().withStackResources(
-							new StackResource().withStackName("testStack")));
+		public CloudFormationClient amazonCloudFormation() {
+			CloudFormationClient amazonCloudFormation = Mockito
+					.mock(CloudFormationClient.class);
+			Mockito.when(amazonCloudFormation
+					.describeStackResources(DescribeStackResourcesRequest.builder()
+							.physicalResourceId("test").build()))
+					.thenReturn(DescribeStackResourcesResponse.builder().stackResources(
+							StackResource.builder().stackName("testStack").build())
+							.build());
 			Mockito.when(amazonCloudFormation.listStackResources(
-					new ListStackResourcesRequest().withStackName("testStack")))
-					.thenReturn(new ListStackResourcesResult()
-							.withStackResourceSummaries(Collections.emptyList()));
+					ListStackResourcesRequest.builder().stackName("testStack").build()))
+					.thenReturn(ListStackResourcesResponse.builder()
+							.stackResourceSummaries(Collections.emptyList()).build());
 			return amazonCloudFormation;
 		}
 
@@ -142,13 +144,13 @@ public class ContextStackAutoConfigurationTest {
 	static class ManualConfigurationStackRegistryTestConfiguration {
 
 		@Bean
-		public AmazonCloudFormation amazonCloudFormation() {
-			AmazonCloudFormation amazonCloudFormation = Mockito
-					.mock(AmazonCloudFormation.class);
-			Mockito.when(amazonCloudFormation.listStackResources(
-					new ListStackResourcesRequest().withStackName("manualStackName")))
-					.thenReturn(new ListStackResourcesResult()
-							.withStackResourceSummaries(Collections.emptyList()));
+		public CloudFormationClient amazonCloudFormation() {
+			CloudFormationClient amazonCloudFormation = Mockito
+					.mock(CloudFormationClient.class);
+			Mockito.when(amazonCloudFormation.listStackResources(ListStackResourcesRequest
+					.builder().stackName("manualStackName").build()))
+					.thenReturn(ListStackResourcesResponse.builder()
+							.stackResourceSummaries(Collections.emptyList()).build());
 			return amazonCloudFormation;
 		}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaDataServer.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/MetaDataServer.java
@@ -22,11 +22,11 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
-import com.amazonaws.SDKGlobalConfiguration;
-import com.amazonaws.util.EC2MetadataUtils;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.util.SocketUtils;
 
@@ -81,14 +81,13 @@ public final class MetaDataServer {
 
 	private static void overwriteMetadataEndpointUrl(
 			String localMetadataServiceEndpointUrl) {
-		System.setProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+		System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
 				localMetadataServiceEndpointUrl);
 	}
 
 	private static void resetMetadataEndpointUrlOverwrite() {
 		System.clearProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+				SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
 	}
 
 	public static class HttpResponseWriterHandler implements HttpHandler {

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
 
 import java.util.UUID;
 
-import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,7 +86,7 @@ public class AwsCredentialsPropertiesTest {
 	public void profileNameCanBeSet() {
 		assertThat(this.properties.getProfileName())
 				.as("Default profile name expected to be set")
-				.isEqualTo(AwsProfileNameLoader.DEFAULT_PROFILE_NAME);
+				.isEqualTo(ProfileFileSystemSetting.AWS_PROFILE.defaultValue());
 
 		String newProfileName = UUID.randomUUID().toString();
 		this.properties.setProfileName(newProfileName);

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
-import com.amazonaws.regions.Regions;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,10 +52,10 @@ public class AwsRegionPropertiesTest {
 		assertThat(this.properties.getStatic())
 				.as("Static region value should have default of null").isNull();
 
-		this.properties.setStatic(Regions.US_EAST_1.getName());
+		this.properties.setStatic(Region.US_EAST_1.id());
 		assertThat(this.properties.getStatic())
 				.as("Static region should have been assigned to us-east-1")
-				.isEqualTo(Regions.US_EAST_1.getName());
+				.isEqualTo(Region.US_EAST_1.id());
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
@@ -18,15 +18,14 @@ package org.springframework.cloud.aws.autoconfigure.jdbc;
 
 import javax.sql.DataSource;
 
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClient;
-import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.Endpoint;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
 
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean;
@@ -141,21 +140,18 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplica {
 
 		@Bean
-		public AmazonRDSClient amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -164,30 +160,32 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithMultipleDatabases {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))));
-			when(client.describeDBInstances(new DescribeDBInstancesRequest()
-					.withDBInstanceIdentifier("anotherOne")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("anotherOne")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build()))
+							.thenReturn(DescribeDbInstancesResponse.builder()
+									.dbInstances(DBInstance.builder()
+											.dbInstanceStatus("available").dbName("test")
+											.dbInstanceIdentifier("test").engine("mysql")
+											.masterUsername("admin")
+											.endpoint(Endpoint.builder()
+													.address("localhost").port(3306)
+													.build())
+											.build())
+									.build());
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("anotherOne").build()))
+							.thenReturn(DescribeDbInstancesResponse.builder()
+									.dbInstances(DBInstance.builder()
+											.dbInstanceStatus("available").dbName("test")
+											.dbInstanceIdentifier("anotherOne")
+											.engine("mysql").masterUsername("admin")
+											.endpoint(Endpoint.builder()
+													.address("localhost").port(3306)
+													.build())
+											.build())
+									.build());
 			return client;
 		}
 
@@ -196,32 +194,30 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithReadReplica {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("read1")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("read1")
-											.withDBInstanceIdentifier("read1")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("read1").build()))
+							.thenReturn(DescribeDbInstancesResponse.builder()
+									.dbInstances(DBInstance.builder()
+											.dbInstanceStatus("available").dbName("read1")
+											.dbInstanceIdentifier("read1").engine("mysql")
+											.masterUsername("admin")
+											.endpoint(Endpoint.builder()
+													.address("localhost").port(3306)
+													.build())
+											.build())
+									.build());
 			return client;
 		}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
@@ -140,7 +140,7 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplica {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -160,7 +160,7 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithMultipleDatabases {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build()))
@@ -194,7 +194,7 @@ public class AmazonRdsDatabaseAutoConfigurationTest {
 	public static class ApplicationConfigurationWithReadReplica {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.aws.autoconfigure.metrics;
 
-import io.micrometer.cloudwatch.CloudWatchConfig;
-import io.micrometer.cloudwatch.CloudWatchMeterRegistry;
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import org.junit.Before;
 import org.junit.Test;

--- a/spring-cloud-aws-context/pom.xml
+++ b/spring-cloud-aws-context/pom.xml
@@ -54,13 +54,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-elasticache</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>elasticache</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ses</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ses</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCacheConfigurer.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCacheConfigurer.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.aws.cache.config.annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amazonaws.services.elasticache.AmazonElastiCache;
+import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -34,7 +34,7 @@ import org.springframework.cloud.aws.core.env.ResourceIdResolver;
  */
 public class ElastiCacheCacheConfigurer extends CachingConfigurerSupport {
 
-	private final AmazonElastiCache amazonElastiCache;
+	private final ElastiCacheClient amazonElastiCache;
 
 	private final ResourceIdResolver resourceIdResolver;
 
@@ -42,7 +42,7 @@ public class ElastiCacheCacheConfigurer extends CachingConfigurerSupport {
 
 	private final List<CacheFactory> cacheFactories;
 
-	public ElastiCacheCacheConfigurer(AmazonElastiCache amazonElastiCache,
+	public ElastiCacheCacheConfigurer(ElastiCacheClient amazonElastiCache,
 			ResourceIdResolver resourceIdResolver, List<String> cacheNames,
 			List<CacheFactory> cacheFactories) {
 		this.cacheNames = cacheNames;

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
@@ -21,9 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.elasticache.AmazonElastiCache;
-import com.amazonaws.services.elasticache.AmazonElastiCacheClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CachingConfigurer;
@@ -64,7 +63,7 @@ public class ElastiCacheCachingConfiguration implements ImportAware {
 	private RegionProvider regionProvider;
 
 	@Autowired(required = false)
-	private AWSCredentialsProvider credentialsProvider;
+	private AwsCredentialsProvider credentialsProvider;
 
 	@Autowired(required = false)
 	private ListableStackResourceFactory stackResourceFactory;
@@ -79,14 +78,14 @@ public class ElastiCacheCachingConfiguration implements ImportAware {
 	}
 
 	@Bean
-	@ConditionalOnMissingAmazonClient(AmazonElastiCache.class)
-	public AmazonWebserviceClientFactoryBean<AmazonElastiCacheClient> amazonElastiCache() {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonElastiCacheClient.class,
+	@ConditionalOnMissingAmazonClient(ElastiCacheClient.class)
+	public AmazonWebserviceClientFactoryBean<ElastiCacheClient> amazonElastiCache() {
+		return new AmazonWebserviceClientFactoryBean<>(ElastiCacheClient.class,
 				this.credentialsProvider, this.regionProvider);
 	}
 
 	@Bean
-	public CachingConfigurer cachingConfigurer(AmazonElastiCache amazonElastiCache,
+	public CachingConfigurer cachingConfigurer(ElastiCacheClient amazonElastiCache,
 			ResourceIdResolver resourceIdResolver, List<CacheFactory> cacheFactories) {
 		if (this.annotationAttributes != null
 				&& this.annotationAttributes.getAnnotationArray("value").length > 0) {

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
@@ -53,7 +53,7 @@ class CacheBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
 	private static final String ELASTICACHE_FACTORY_BEAN = "org.springframework.cloud.aws.cache.ElastiCacheFactoryBean";
 
 	// @checkstyle:off
-	private static final String ELASTI_CACHE_CLIENT_CLASS_NAME = "com.amazonaws.services.elasticache.AmazonElastiCacheClient";
+	private static final String ELASTI_CACHE_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.elasticache.ElastiCacheClient";
 
 	// @checkstyle:on
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.context.config.annotation;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -48,7 +48,7 @@ public class ContextResourceLoaderConfiguration {
 				BeanDefinitionRegistry registry) {
 			BeanDefinitionHolder client = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							AmazonS3Client.class.getName(), null, null);
+							S3Client.class.getName(), null, null);
 
 			BeanDefinitionBuilder configurer = BeanDefinitionBuilder
 					.genericBeanDefinition(SimpleStorageProtocolResolverConfigurer.class);

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -48,7 +48,7 @@ public class ContextResourceLoaderConfiguration {
 				BeanDefinitionRegistry registry) {
 			BeanDefinitionHolder client = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							S3Client.class.getName(), null, null);
+							S3Client.class.getName(), null);
 
 			BeanDefinitionBuilder configurer = BeanDefinitionBuilder
 					.genericBeanDefinition(SimpleStorageProtocolResolverConfigurer.class);

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -48,7 +48,7 @@ public class ContextResourceLoaderConfiguration {
 				BeanDefinitionRegistry registry) {
 			BeanDefinitionHolder client = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							S3Client.class.getName(), null);
+							S3Client.class.getName(), null, null);
 
 			BeanDefinitionBuilder configurer = BeanDefinitionBuilder
 					.genericBeanDefinition(SimpleStorageProtocolResolverConfigurer.class);

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.aws.context.config.annotation;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-import com.amazonaws.services.ec2.AmazonEC2;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
@@ -50,10 +49,10 @@ public class ContextStackConfiguration implements ImportAware {
 	private RegionProvider regionProvider;
 
 	@Autowired(required = false)
-	private AWSCredentialsProvider credentialsProvider;
+	private AwsCredentialsProvider credentialsProvider;
 
 	@Autowired(required = false)
-	private AmazonEC2 amazonEc2;
+	private Ec2Client amazonEc2;
 
 	@Override
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
@@ -67,7 +66,7 @@ public class ContextStackConfiguration implements ImportAware {
 
 	@Bean
 	public StackResourceRegistryFactoryBean stackResourceRegistryFactoryBean(
-			AmazonCloudFormation amazonCloudFormation) {
+			CloudFormationClient amazonCloudFormation) {
 		if (StringUtils.hasText(this.annotationAttributes.getString("stackName"))) {
 			return new StackResourceRegistryFactoryBean(amazonCloudFormation,
 					new StaticStackNameProvider(
@@ -81,9 +80,9 @@ public class ContextStackConfiguration implements ImportAware {
 	}
 
 	@Bean
-	@ConditionalOnMissingAmazonClient(AmazonCloudFormation.class)
-	public AmazonWebserviceClientFactoryBean<AmazonCloudFormationClient> amazonCloudFormation() {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonCloudFormationClient.class,
+	@ConditionalOnMissingAmazonClient(CloudFormationClient.class)
+	public AmazonWebserviceClientFactoryBean<CloudFormationClient> amazonCloudFormation() {
+		return new AmazonWebserviceClientFactoryBean<>(CloudFormationClient.class,
 				this.credentialsProvider, this.regionProvider);
 	}
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
@@ -42,8 +42,8 @@ public @interface EnableContextRegion {
 
 	/**
 	 * Configures the region as a String value. The value must match to an enum defined in
-	 * {@link com.amazonaws.regions.Regions}. This attribute is a String value allowing
-	 * expressions and placeholders to be used for the region configuration.
+	 * {@link software.amazon.awssdk.regions.Region}. This attribute is a String value
+	 * allowing expressions and placeholders to be used for the region configuration.
 	 * @return - the region a constant definition, SpEL expression or placeholder
 	 * definition
 	 */

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.aws.context.config.support;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -89,7 +89,7 @@ public final class ContextConfigurationUtils {
 	public static void registerDefaultAWSCredentialsProvider(
 			BeanDefinitionRegistry registry) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.rootBeanDefinition(DefaultAWSCredentialsProviderChain.class);
+				.rootBeanDefinition(DefaultCredentialsProvider.class);
 		registry.registerBeanDefinition(
 				CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME,
 				builder.getBeanDefinition());
@@ -107,12 +107,12 @@ public final class ContextConfigurationUtils {
 
 		if (StringUtils.hasText(accessKey)) {
 			BeanDefinitionBuilder credentials = BeanDefinitionBuilder
-					.rootBeanDefinition(BasicAWSCredentials.class);
+					.rootBeanDefinition(AwsBasicCredentials.class);
 			credentials.addConstructorArgValue(accessKey);
 			credentials.addConstructorArgValue(secretKey);
 
 			BeanDefinitionBuilder provider = BeanDefinitionBuilder
-					.rootBeanDefinition(AWSStaticCredentialsProvider.class);
+					.rootBeanDefinition(StaticCredentialsProvider.class);
 			provider.addConstructorArgValue(credentials.getBeanDefinition());
 
 			awsCredentialsProviders.add(provider.getBeanDefinition());
@@ -120,7 +120,7 @@ public final class ContextConfigurationUtils {
 
 		if (instanceProfile) {
 			awsCredentialsProviders.add(BeanDefinitionBuilder
-					.rootBeanDefinition(EC2ContainerCredentialsProviderWrapper.class)
+					.rootBeanDefinition(InstanceProfileCredentialsProvider.class)
 					.getBeanDefinition());
 		}
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -126,7 +126,7 @@ public final class ContextConfigurationUtils {
 
 		if (StringUtils.hasText(profileName)) {
 			BeanDefinitionBuilder provider = BeanDefinitionBuilder
-				.rootBeanDefinition(ProfileCredentialsProviderBeanFactory.class);
+					.rootBeanDefinition(ProfileCredentialsProviderBeanFactory.class);
 			provider.addConstructorArgValue(profileName);
 			if (StringUtils.hasText(profilePath)) {
 				provider.addConstructorArgValue(profilePath);

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ProfileCredentialsProviderBeanFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ProfileCredentialsProviderBeanFactory.java
@@ -1,0 +1,43 @@
+package org.springframework.cloud.aws.context.config.support;
+
+import java.nio.file.Paths;
+
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+
+public class ProfileCredentialsProviderBeanFactory extends AbstractFactoryBean<ProfileCredentialsProvider> {
+
+	private final String profileName;
+	private final String profilePath;
+
+	public ProfileCredentialsProviderBeanFactory() {
+		this(null, null);
+	}
+	public ProfileCredentialsProviderBeanFactory(String profileName) {
+		this(profileName, null);
+	}
+
+	public ProfileCredentialsProviderBeanFactory(String profileName, String profilePath) {
+		this.profileName = profileName;
+		this.profilePath = profilePath;
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return ProfileCredentialsProvider.class;
+	}
+
+	@Override
+	protected ProfileCredentialsProvider createInstance() throws Exception {
+		ProfileCredentialsProvider.Builder builder = ProfileCredentialsProvider.builder();
+		if (profileName != null) {
+			builder.profileName(profileName);
+		}
+		if (profilePath != null) {
+			builder.profileFile(ProfileFile.builder().content(Paths.get(profilePath)).type(ProfileFile.Type.CREDENTIALS).build());
+		}
+		return builder.build();
+	}
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ProfileCredentialsProviderBeanFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ProfileCredentialsProviderBeanFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.aws.context.config.support;
 
 import java.nio.file.Paths;
@@ -7,14 +23,20 @@ import software.amazon.awssdk.profiles.ProfileFile;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
-public class ProfileCredentialsProviderBeanFactory extends AbstractFactoryBean<ProfileCredentialsProvider> {
+/**
+ * @author Kristine Jetzke
+ */
+public class ProfileCredentialsProviderBeanFactory
+		extends AbstractFactoryBean<ProfileCredentialsProvider> {
 
 	private final String profileName;
+
 	private final String profilePath;
 
 	public ProfileCredentialsProviderBeanFactory() {
 		this(null, null);
 	}
+
 	public ProfileCredentialsProviderBeanFactory(String profileName) {
 		this(profileName, null);
 	}
@@ -36,8 +58,10 @@ public class ProfileCredentialsProviderBeanFactory extends AbstractFactoryBean<P
 			builder.profileName(profileName);
 		}
 		if (profilePath != null) {
-			builder.profileFile(ProfileFile.builder().content(Paths.get(profilePath)).type(ProfileFile.Type.CREDENTIALS).build());
+			builder.profileFile(ProfileFile.builder().content(Paths.get(profilePath))
+					.type(ProfileFile.Type.CREDENTIALS).build());
 		}
 		return builder.build();
 	}
+
 }

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
@@ -55,7 +55,8 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 	// @checkstyle:on
 
 	// @checkstyle:off
-	private static final String PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = ProfileCredentialsProviderBeanFactory.class.getName();
+	private static final String PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = ProfileCredentialsProviderBeanFactory.class
+			.getName();
 
 	// @checkstyle:on
 
@@ -157,13 +158,17 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 
 			if ("profile-credentials".equals(credentialsProviderElement.getLocalName())) {
 				BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
-					.rootBeanDefinition(PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME);
+						.rootBeanDefinition(PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME);
 
-				if (StringUtils.hasText(credentialsProviderElement.getAttribute("profileName"))) {
-					beanDefinitionBuilder.addConstructorArgValue(credentialsProviderElement.getAttribute("profileName"));
+				if (StringUtils.hasText(
+						credentialsProviderElement.getAttribute("profileName"))) {
+					beanDefinitionBuilder.addConstructorArgValue(
+							credentialsProviderElement.getAttribute("profileName"));
 				}
-				if (StringUtils.hasText(credentialsProviderElement.getAttribute("profilePath"))) {
-					beanDefinitionBuilder.addConstructorArgValue(credentialsProviderElement.getAttribute("profilePath"));
+				if (StringUtils.hasText(
+						credentialsProviderElement.getAttribute("profilePath"))) {
+					beanDefinitionBuilder.addConstructorArgValue(
+							credentialsProviderElement.getAttribute("profilePath"));
 				}
 
 				credentialsProviders.add(beanDefinitionBuilder.getBeanDefinition());

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.w3c.dom.Element;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -44,17 +45,17 @@ import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientCo
 class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
 
 	// @checkstyle:off
-	private static final String STATIC_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.AWSStaticCredentialsProvider";
+	private static final String STATIC_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "software.amazon.awssdk.auth.credentials.StaticCredentialsProvider";
 
 	// @checkstyle:on
 
 	// @checkstyle:off
-	private static final String INSTANCE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.InstanceProfileCredentialsProvider";
+	private static final String INSTANCE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider";
 
 	// @checkstyle:on
 
 	// @checkstyle:off
-	private static final String PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.profile.ProfileCredentialsProvider";
+	private static final String PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider";
 
 	// @checkstyle:on
 
@@ -66,6 +67,7 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 			String credentialsProviderClassName, Object... constructorArg) {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(credentialsProviderClassName);
+		beanDefinitionBuilder.setFactoryMethod("create");
 		for (Object o : constructorArg) {
 			beanDefinitionBuilder.addConstructorArgValue(o);
 		}
@@ -81,13 +83,12 @@ class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitio
 	 * attributes ACCESS_KEY_ATTRIBUTE_NAME and SECRET_KEY_ATTRIBUTE_NAME
 	 * @param parserContext - Used to report any errors if there is no
 	 * ACCESS_KEY_ATTRIBUTE_NAME or SECRET_KEY_ATTRIBUTE_NAME available with a valid value
-	 * @return - the bean definition with an
-	 * {@link com.amazonaws.auth.BasicAWSCredentials} class
+	 * @return - the bean definition with an {@link AwsBasicCredentials} class
 	 */
 	private static BeanDefinition getCredentials(Element credentialsProviderElement,
 			ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.rootBeanDefinition("com.amazonaws.auth.BasicAWSCredentials");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(
+				"software.amazon.awssdk.auth.credentials.AwsBasicCredentials");
 		builder.addConstructorArgValue(getAttributeValue(ACCESS_KEY_ATTRIBUTE_NAME,
 				credentialsProviderElement, parserContext));
 		builder.addConstructorArgValue(getAttributeValue(SECRET_KEY_ATTRIBUTE_NAME,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
@@ -41,7 +41,7 @@ class ContextInstanceDataPropertySourceBeanDefinitionParser
 
 	// @checkstyle:on
 
-	private static final String EC2_CLIENT_CLASS_NAME = "com.amazonaws.services.ec2.AmazonEC2Client";
+	private static final String EC2_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.ec2.Ec2Client";
 
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element,

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
@@ -40,7 +40,7 @@ import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigu
 public class ContextResourceLoaderBeanDefinitionParser
 		extends AbstractSimpleBeanDefinitionParser {
 
-	private static final String AMAZON_S3_CLIENT_CLASS_NAME = "com.amazonaws.services.s3.AmazonS3Client";
+	private static final String AMAZON_S3_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.s3.S3Client";
 
 	// @checkstyle:off
 	private static final String RESOURCE_LOADER_BEAN_POST_PROCESSOR = "org.springframework.cloud.aws.context.support.io.SimpleStorageProtocolResolverConfigurer";

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
@@ -48,11 +48,11 @@ class StackConfigurationBeanDefinitionParser extends AbstractSimpleBeanDefinitio
 
 	private static final String INSTANCE_ID_PROVIDER_CLASS_NAME = "org.springframework.cloud.aws.core.env.ec2.AmazonEc2InstanceIdProvider";
 
-	private static final String CLOUD_FORMATION_CLIENT_CLASS_NAME = "com.amazonaws.services.cloudformation.AmazonCloudFormationClient";
+	private static final String CLOUD_FORMATION_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.cloudformation.CloudFormationClient";
 
 	// @checkstyle:on
 
-	private static final String EC2_CLIENT_CLASS_NAME = "com.amazonaws.services.ec2.AmazonEC2Client";
+	private static final String EC2_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.ec2.Ec2Client";
 
 	private static final String STACK_NAME_ATTRIBUTE_NAME = "stack-name";
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/support/env/AwsCloudEnvironmentCheckUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/support/env/AwsCloudEnvironmentCheckUtils.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.aws.context.support.env;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.util.EC2MetadataUtils;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 /**
  * @author Lukasz Luszczynski
@@ -37,7 +37,7 @@ public final class AwsCloudEnvironmentCheckUtils {
 				isCloudEnvironment = EC2MetadataUtils
 						.getData(EC2_METADATA_ROOT + "/instance-id", 1) != null;
 			}
-			catch (AmazonClientException e) {
+			catch (SdkClientException e) {
 				isCloudEnvironment = false;
 			}
 		}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
@@ -35,7 +35,7 @@ class SimpleEmailServiceBeanDefinitionParser extends AbstractSingleBeanDefinitio
 			SimpleEmailServiceBeanDefinitionParser.class.getClassLoader());
 
 	// @checkstyle:off
-	private static final String SIMPLE_EMAIL_CLIENT_CLASS_NAME = "com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient";
+	private static final String SIMPLE_EMAIL_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.ses.SesClient";
 
 	// @checkstyle:on
 

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
@@ -35,7 +35,7 @@
 			]]></xsd:documentation>
 			<xsd:appinfo>
 				<tool:annotation>
-					<tool:exports type="com.amazonaws.auth.AWSCredentialsProvider"/>
+					<tool:exports type="software.amazon.awssdk.auth.credentials.AwsCredentialsProvider"/>
 				</tool:annotation>
 			</xsd:appinfo>
 		</xsd:annotation>

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
@@ -19,14 +19,14 @@ package org.springframework.cloud.aws.cache.config.annotation;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
-import com.amazonaws.services.elasticache.AmazonElastiCache;
-import com.amazonaws.services.elasticache.model.CacheCluster;
-import com.amazonaws.services.elasticache.model.DescribeCacheClustersRequest;
-import com.amazonaws.services.elasticache.model.DescribeCacheClustersResult;
-import com.amazonaws.services.elasticache.model.Endpoint;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
+import software.amazon.awssdk.services.elasticache.model.CacheCluster;
+import software.amazon.awssdk.services.elasticache.model.DescribeCacheClustersRequest;
+import software.amazon.awssdk.services.elasticache.model.DescribeCacheClustersResponse;
+import software.amazon.awssdk.services.elasticache.model.Endpoint;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -182,32 +182,30 @@ public class ElastiCacheCachingConfigurationTest {
 	public static class ApplicationConfigurationWithExplicitStackConfiguration {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest describeCacheClustersRequest = new DescribeCacheClustersRequest()
-					.withCacheClusterId("firstCache");
-			describeCacheClustersRequest.setShowCacheNodeInfo(true);
+			DescribeCacheClustersRequest describeCacheClustersRequest = DescribeCacheClustersRequest
+					.builder().cacheClusterId("firstCache").showCacheNodeInfo(true)
+					.build();
 			Mockito.when(
 					amazonElastiCache.describeCacheClusters(describeCacheClustersRequest))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
-			DescribeCacheClustersRequest secondCache = new DescribeCacheClustersRequest()
-					.withCacheClusterId("secondCache");
-			secondCache.setShowCacheNodeInfo(true);
-			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache)).thenReturn(
-					new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint()
-									.withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
+			DescribeCacheClustersRequest secondCache = DescribeCacheClustersRequest
+					.builder().cacheClusterId("secondCache").showCacheNodeInfo(true)
+					.build();
+			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache))
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 
@@ -218,27 +216,31 @@ public class ElastiCacheCachingConfigurationTest {
 	public static class ApplicationConfigurationWithExplicitStackConfigurationAndExpiryTime {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest firstCache = new DescribeCacheClustersRequest()
-					.withCacheClusterId("firstCache");
-			firstCache.setShowCacheNodeInfo(true);
+			DescribeCacheClustersRequest firstCache = DescribeCacheClustersRequest
+					.builder().cacheClusterId("firstCache").showCacheNodeInfo(true)
+					.build();
 
-			Mockito.when(amazonElastiCache.describeCacheClusters(firstCache)).thenReturn(
-					new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint()
-									.withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
-			DescribeCacheClustersRequest secondCache = new DescribeCacheClustersRequest()
-					.withCacheClusterId("secondCache");
-			secondCache.setShowCacheNodeInfo(true);
+			Mockito.when(amazonElastiCache.describeCacheClusters(firstCache))
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
+			DescribeCacheClustersRequest secondCache = DescribeCacheClustersRequest
+					.builder().cacheClusterId("secondCache").showCacheNodeInfo(true)
+					.build();
 
-			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache)).thenReturn(
-					new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint()
-									.withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
+			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache))
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 
@@ -251,27 +253,31 @@ public class ElastiCacheCachingConfigurationTest {
 	public static class ApplicationConfigurationWithExplicitStackConfigurationAndMixedExpiryTime {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest firstCache = new DescribeCacheClustersRequest()
-					.withCacheClusterId("firstCache");
-			firstCache.setShowCacheNodeInfo(true);
+			DescribeCacheClustersRequest firstCache = DescribeCacheClustersRequest
+					.builder().cacheClusterId("firstCache").showCacheNodeInfo(true)
+					.build();
 
-			Mockito.when(amazonElastiCache.describeCacheClusters(firstCache)).thenReturn(
-					new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint()
-									.withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
-			DescribeCacheClustersRequest secondCache = new DescribeCacheClustersRequest()
-					.withCacheClusterId("secondCache");
-			secondCache.setShowCacheNodeInfo(true);
+			Mockito.when(amazonElastiCache.describeCacheClusters(firstCache))
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
+			DescribeCacheClustersRequest secondCache = DescribeCacheClustersRequest
+					.builder().cacheClusterId("secondCache").showCacheNodeInfo(true)
+					.build();
 
-			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache)).thenReturn(
-					new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint()
-									.withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
+			Mockito.when(amazonElastiCache.describeCacheClusters(secondCache))
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 
@@ -281,40 +287,32 @@ public class ElastiCacheCachingConfigurationTest {
 	public static class ApplicationConfigurationWithNoExplicitStackConfiguration {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest sampleCacheOneLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheOneLogical");
-			sampleCacheOneLogical.setShowCacheNodeInfo(Boolean.TRUE);
+			DescribeCacheClustersRequest sampleCacheOneLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheOneLogical")
+					.showCacheNodeInfo(Boolean.TRUE).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheOneLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 
-			DescribeCacheClustersRequest sampleCacheTwoLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheTwoLogical");
-			sampleCacheTwoLogical.setShowCacheNodeInfo(Boolean.TRUE);
+			DescribeCacheClustersRequest sampleCacheTwoLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheTwoLogical")
+					.showCacheNodeInfo(Boolean.TRUE).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheTwoLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 
@@ -338,40 +336,32 @@ public class ElastiCacheCachingConfigurationTest {
 	public static class ApplicationConfigurationWithNoExplicitStackConfigurationAndDefaultExpiration {
 
 		@Bean
-		public AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = Mockito.mock(AmazonElastiCache.class);
+		public ElastiCacheClient amazonElastiCache() {
+			ElastiCacheClient amazonElastiCache = Mockito.mock(ElastiCacheClient.class);
 			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest sampleCacheOneLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheOneLogical");
-			sampleCacheOneLogical.setShowCacheNodeInfo(Boolean.TRUE);
+			DescribeCacheClustersRequest sampleCacheOneLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheOneLogical")
+					.showCacheNodeInfo(Boolean.TRUE).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheOneLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 
-			DescribeCacheClustersRequest sampleCacheTwoLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheTwoLogical");
-			sampleCacheTwoLogical.setShowCacheNodeInfo(Boolean.TRUE);
+			DescribeCacheClustersRequest sampleCacheTwoLogical = DescribeCacheClustersRequest
+					.builder().cacheClusterId("sampleCacheTwoLogical")
+					.showCacheNodeInfo(Boolean.TRUE).build();
 
 			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheTwoLogical))
-					.thenReturn(
-							new DescribeCacheClustersResult()
-									.withCacheClusters(
-											new CacheCluster()
-													.withConfigurationEndpoint(
-															new Endpoint()
-																	.withAddress(
-																			"localhost")
-																	.withPort(port))
-													.withEngine("memcached")));
+					.thenReturn(DescribeCacheClustersResponse.builder()
+							.cacheClusters(CacheCluster.builder()
+									.configurationEndpoint(Endpoint.builder()
+											.address("localhost").port(port).build())
+									.engine("memcached").build())
+							.build());
 			return amazonElastiCache;
 		}
 

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/MetaDataServer.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/MetaDataServer.java
@@ -22,11 +22,11 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
-import com.amazonaws.SDKGlobalConfiguration;
-import com.amazonaws.util.EC2MetadataUtils;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.util.SocketUtils;
 
@@ -69,14 +69,13 @@ public final class MetaDataServer {
 
 	private static void overwriteMetadataEndpointUrl(
 			String localMetadataServiceEndpointUrl) {
-		System.setProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+		System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
 				localMetadataServiceEndpointUrl);
 	}
 
 	private static void resetMetadataEndpointUrlOverwrite() {
 		System.clearProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+				SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
 	}
 
 	private static void resetMetaDataCache() {

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientConditionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/annotation/OnMissingAmazonClientConditionTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.aws.context.annotation;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -56,8 +56,8 @@ public class OnMissingAmazonClientConditionTest {
 	protected static class ConfigWithDummyS3Client {
 
 		@Bean
-		public AmazonS3 amazonS3() {
-			return mock(AmazonS3.class);
+		public S3Client amazonS3() {
+			return mock(S3Client.class);
 		}
 
 	}
@@ -66,7 +66,7 @@ public class OnMissingAmazonClientConditionTest {
 	protected static class ConfigWithMissingAmazonClientCondition {
 
 		@Bean
-		@ConditionalOnMissingAmazonClient(AmazonS3.class)
+		@ConditionalOnMissingAmazonClient(S3Client.class)
 		public String foo() {
 			return "foo";
 		}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
@@ -20,14 +20,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import org.apache.http.client.CredentialsProvider;
 import org.junit.After;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
@@ -56,13 +55,13 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithDefaultCredentialsProvider.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
-		assertThat(DefaultAWSCredentialsProviderChain.class
-				.isInstance(awsCredentialsProvider)).isTrue();
+		assertThat(DefaultCredentialsProvider.class.isInstance(awsCredentialsProvider))
+				.isTrue();
 	}
 
 	@Test
@@ -73,22 +72,23 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithAccessKeyAndSecretKey.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
+		assertThat(
+				StaticCredentialsProvider.class.isInstance(credentialsProviders.get(0)))
+						.isTrue();
 
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
+		assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId())
 				.isEqualTo("accessTest");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
+		assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey())
 				.isEqualTo("testSecret");
 	}
 
@@ -111,22 +111,23 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithAccessKeyAndSecretKeyAsExpressions.class);
 		this.context.refresh();
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
+		assertThat(
+				StaticCredentialsProvider.class.isInstance(credentialsProviders.get(0)))
+						.isTrue();
 
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
+		assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId())
 				.isEqualTo("accessTest");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
+		assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey())
 				.isEqualTo("testSecret");
 	}
 
@@ -152,22 +153,23 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithAccessKeyAndSecretKeyAsPlaceHolder.class);
 		this.context.refresh();
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
+		assertThat(
+				StaticCredentialsProvider.class.isInstance(credentialsProviders.get(0)))
+						.isTrue();
 
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
+		assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId())
 				.isEqualTo("accessTest");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
+		assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey())
 				.isEqualTo("testSecret");
 	}
 
@@ -181,19 +183,20 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithAccessKeyAndSecretKeyAndInstanceProfile.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
+		assertThat(
+				StaticCredentialsProvider.class.isInstance(credentialsProviders.get(0)))
+						.isTrue();
+		assertThat(InstanceProfileCredentialsProvider.class
 				.isInstance(credentialsProviders.get(1))).isTrue();
 	}
 
@@ -205,17 +208,17 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithInstanceProfileOnly.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
+		assertThat(InstanceProfileCredentialsProvider.class
 				.isInstance(credentialsProviders.get(0))).isTrue();
 	}
 
@@ -227,14 +230,14 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithProfileAndDefaultProfilePath.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
 		assertThat(
@@ -269,14 +272,14 @@ public class ContextCredentialsConfigurationRegistrarTest {
 		this.context.refresh();
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(1);
 		assertThat(
@@ -285,9 +288,9 @@ public class ContextCredentialsConfigurationRegistrarTest {
 
 		ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
 				.get(0);
-		assertThat(provider.getCredentials().getAWSAccessKeyId())
+		assertThat(provider.resolveCredentials().accessKeyId())
 				.isEqualTo("testAccessKey");
-		assertThat(provider.getCredentials().getAWSSecretKey())
+		assertThat(provider.resolveCredentials().secretAccessKey())
 				.isEqualTo("testSecretKey");
 	}
 
@@ -299,19 +302,20 @@ public class ContextCredentialsConfigurationRegistrarTest {
 				ApplicationConfigurationWithAllProviders.class);
 
 		// Act
-		AWSCredentialsProvider awsCredentialsProvider = this.context
-				.getBean(AWSCredentialsProvider.class);
+		AwsCredentialsProvider awsCredentialsProvider = this.context
+				.getBean(AwsCredentialsProvider.class);
 
 		// Assert
 		assertThat(awsCredentialsProvider).isNotNull();
 
 		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+		List<AwsCredentialsProvider> credentialsProviders = (List<AwsCredentialsProvider>) ReflectionTestUtils
 				.getField(awsCredentialsProvider, "credentialsProviders");
 		assertThat(credentialsProviders.size()).isEqualTo(3);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
+		assertThat(
+				StaticCredentialsProvider.class.isInstance(credentialsProviders.get(0)))
+						.isTrue();
+		assertThat(InstanceProfileCredentialsProvider.class
 				.isInstance(credentialsProviders.get(1))).isTrue();
 		assertThat(
 				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(2)))

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrarTest.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
@@ -42,6 +43,8 @@ public class ContextCredentialsConfigurationRegistrarTest {
 
 	@After
 	public void tearDown() throws Exception {
+		System.clearProperty(
+				ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.property());
 		if (this.context != null) {
 			this.context.close();
 		}
@@ -226,6 +229,10 @@ public class ContextCredentialsConfigurationRegistrarTest {
 	public void credentialsProvider_configWithProfileNameAndNoProfilePath_profileCredentialsProviderConfigured()
 			throws Exception {
 		// Arrange
+		System.setProperty(
+				ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.property(),
+				new ClassPathResource(getClass().getSimpleName() + "-profile", getClass())
+						.getFile().getAbsolutePath());
 		this.context = new AnnotationConfigApplicationContext(
 				ApplicationConfigurationWithProfileAndDefaultProfilePath.class);
 
@@ -247,7 +254,7 @@ public class ContextCredentialsConfigurationRegistrarTest {
 		ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
 				.get(0);
 		assertThat(ReflectionTestUtils.getField(provider, "profileName"))
-				.isEqualTo("test");
+				.isEqualTo("customProfile");
 	}
 
 	@Test
@@ -354,7 +361,7 @@ public class ContextCredentialsConfigurationRegistrarTest {
 
 	}
 
-	@EnableContextCredentials(profileName = "test")
+	@EnableContextCredentials(profileName = "customProfile")
 	public static class ApplicationConfigurationWithProfileAndDefaultProfilePath {
 
 	}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
@@ -18,12 +18,11 @@ package org.springframework.cloud.aws.context.config.annotation;
 
 import java.util.Collections;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
@@ -63,8 +62,7 @@ public class ContextRegionConfigurationRegistrarTest {
 
 		// Assert
 		assertThat(staticRegionProvider).isNotNull();
-		assertThat(staticRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		assertThat(staticRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 	}
 
 	@Test
@@ -88,7 +86,7 @@ public class ContextRegionConfigurationRegistrarTest {
 		// Arrange
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.getEnvironment().getPropertySources().addLast(new MapPropertySource(
-				"test", Collections.singletonMap("region", Regions.EU_WEST_1.getName())));
+				"test", Collections.singletonMap("region", Region.EU_WEST_1.id())));
 		this.context.register(ApplicationConfigurationWithExpressionRegion.class);
 
 		// Act
@@ -98,8 +96,7 @@ public class ContextRegionConfigurationRegistrarTest {
 
 		// Assert
 		assertThat(staticRegionProvider).isNotNull();
-		assertThat(staticRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		assertThat(staticRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 	}
 
 	@Test
@@ -108,7 +105,7 @@ public class ContextRegionConfigurationRegistrarTest {
 		// Arrange
 		this.context = new AnnotationConfigApplicationContext();
 		this.context.getEnvironment().getPropertySources().addLast(new MapPropertySource(
-				"test", Collections.singletonMap("region", Regions.EU_WEST_1.getName())));
+				"test", Collections.singletonMap("region", Region.EU_WEST_1.id())));
 		this.context.register(ApplicationConfigurationWithPlaceHolderRegion.class);
 
 		// Act
@@ -118,8 +115,7 @@ public class ContextRegionConfigurationRegistrarTest {
 
 		// Assert
 		assertThat(staticRegionProvider).isNotNull();
-		assertThat(staticRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		assertThat(staticRegionProvider.getRegion()).isEqualTo(Region.EU_WEST_1);
 	}
 
 	@Test

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfigurationTest.java
@@ -18,17 +18,17 @@ package org.springframework.cloud.aws.context.config.annotation;
 
 import java.util.Collections;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
-import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
-import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
-import com.amazonaws.services.cloudformation.model.StackResource;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesResponse;
+import software.amazon.awssdk.services.cloudformation.model.ListStackResourcesRequest;
+import software.amazon.awssdk.services.cloudformation.model.ListStackResourcesResponse;
+import software.amazon.awssdk.services.cloudformation.model.StackResource;
 
 import org.springframework.cloud.aws.context.MetaDataServer;
 import org.springframework.cloud.aws.core.env.stack.StackResourceRegistry;
@@ -96,17 +96,19 @@ public class ContextStackConfigurationTest {
 	static class ApplicationConfigurationWithEmptyStackName {
 
 		@Bean
-		public AmazonCloudFormation amazonCloudFormation() {
-			AmazonCloudFormation amazonCloudFormation = Mockito
-					.mock(AmazonCloudFormation.class);
-			Mockito.when(amazonCloudFormation.describeStackResources(
-					new DescribeStackResourcesRequest().withPhysicalResourceId("test")))
-					.thenReturn(new DescribeStackResourcesResult().withStackResources(
-							new StackResource().withStackName("testStack")));
+		public CloudFormationClient amazonCloudFormation() {
+			CloudFormationClient amazonCloudFormation = Mockito
+					.mock(CloudFormationClient.class);
+			Mockito.when(amazonCloudFormation
+					.describeStackResources(DescribeStackResourcesRequest.builder()
+							.physicalResourceId("test").build()))
+					.thenReturn(DescribeStackResourcesResponse.builder().stackResources(
+							StackResource.builder().stackName("testStack").build())
+							.build());
 			Mockito.when(amazonCloudFormation.listStackResources(
-					new ListStackResourcesRequest().withStackName("testStack")))
-					.thenReturn(new ListStackResourcesResult()
-							.withStackResourceSummaries(Collections.emptyList()));
+					ListStackResourcesRequest.builder().stackName("testStack").build()))
+					.thenReturn(ListStackResourcesResponse.builder()
+							.stackResourceSummaries(Collections.emptyList()).build());
 			return amazonCloudFormation;
 		}
 
@@ -117,13 +119,13 @@ public class ContextStackConfigurationTest {
 	static class ManualConfigurationStackRegistryTestConfiguration {
 
 		@Bean
-		public AmazonCloudFormation amazonCloudFormation() {
-			AmazonCloudFormation amazonCloudFormation = Mockito
-					.mock(AmazonCloudFormation.class);
-			Mockito.when(amazonCloudFormation.listStackResources(
-					new ListStackResourcesRequest().withStackName("manualStackName")))
-					.thenReturn(new ListStackResourcesResult()
-							.withStackResourceSummaries(Collections.emptyList()));
+		public CloudFormationClient amazonCloudFormation() {
+			CloudFormationClient amazonCloudFormation = Mockito
+					.mock(CloudFormationClient.class);
+			Mockito.when(amazonCloudFormation.listStackResources(ListStackResourcesRequest
+					.builder().stackName("manualStackName").build()))
+					.thenReturn(ListStackResourcesResponse.builder()
+							.stackResourceSummaries(Collections.emptyList()).build());
 			return amazonCloudFormation;
 		}
 

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.aws.context.config.xml;
 
 import java.lang.reflect.Field;
 
-import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanReference;
@@ -107,7 +107,7 @@ public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
 		assertThat(beanFactory.containsBeanDefinition("myUserTags")).isTrue();
 		assertThat(beanFactory
 				.containsBeanDefinition(AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonEC2Client.class.getName()))).isTrue();
+						.getBeanName(Ec2Client.class.getName()))).isTrue();
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
 		assertThat(beanReference.getBeanName()).isEqualTo("amazonEC2Client");
 		assertThat(beanFactory
 				.containsBeanDefinition(AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonEC2Client.class.getName()))).isFalse();
+						.getBeanName(Ec2Client.class.getName()))).isFalse();
 	}
 
 	// @checkstyle:off

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
@@ -111,7 +111,6 @@ public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
 	}
 
 	@Test
-	// TODO SDK2 migration: this test shouldn't pass now... find out why it does
 	public void parseInternal_singleElementWithCustomAmazonEc2Client_userTagMapCreatedWithCustomEc2Client()
 			throws Exception {
 		// Arrange
@@ -129,7 +128,7 @@ public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
 				.getBeanDefinition("myUserTags").getConstructorArgumentValues()
 				.getArgumentValue(0, BeanReference.class);
 		BeanReference beanReference = (BeanReference) valueHolder.getValue();
-		assertThat(beanReference.getBeanName()).isEqualTo("amazonEC2Client");
+		assertThat(beanReference.getBeanName()).isEqualTo("customEC2Client");
 		assertThat(beanFactory
 				.containsBeanDefinition(AmazonWebserviceClientConfigurationUtils
 						.getBeanName(Ec2Client.class.getName()))).isFalse();

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
@@ -111,6 +111,7 @@ public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
 	}
 
 	@Test
+	// TODO SDK2 migration: this test shouldn't pass now... find out why it does
 	public void parseInternal_singleElementWithCustomAmazonEc2Client_userTagMapCreatedWithCustomEc2Client()
 			throws Exception {
 		// Arrange

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.aws.context.config.xml;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
@@ -51,8 +50,7 @@ public class ContextRegionBeanDefinitionParserTest {
 
 		// Assert
 		assertThat(myRegionProvider).isNotNull();
-		assertThat(myRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.SA_EAST_1);
 	}
 
 	@Test
@@ -69,8 +67,7 @@ public class ContextRegionBeanDefinitionParserTest {
 
 		// Assert
 		assertThat(myRegionProvider).isNotNull();
-		assertThat(myRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.SA_EAST_1);
 	}
 
 	@Test
@@ -87,8 +84,7 @@ public class ContextRegionBeanDefinitionParserTest {
 
 		// Assert
 		assertThat(myRegionProvider).isNotNull();
-		assertThat(myRegionProvider.getRegion())
-				.isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.SA_EAST_1);
 	}
 
 	@Test

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
@@ -16,13 +16,10 @@
 
 package org.springframework.cloud.aws.context.config.xml;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
@@ -74,12 +71,12 @@ public class ContextResourceLoaderBeanDefinitionParserTest {
 		// Act
 		ResourceLoader resourceLoader = applicationContext
 				.getBean(ResourceLoaderBean.class).getResourceLoader();
-		AmazonS3Client webServiceClient = applicationContext
-				.getBean(AmazonS3Client.class);
+		S3Client webServiceClient = applicationContext.getBean(S3Client.class);
 
 		// Assert
-		assertThat(webServiceClient.getRegion().toAWSRegion())
-				.isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		// TODO SDK2 migration: adapt
+		// assertThat(webServiceClient.getRegion().toAWSRegion())
+		// .isEqualTo(Region.EU_WEST_1);
 
 		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
 		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
@@ -96,12 +93,12 @@ public class ContextResourceLoaderBeanDefinitionParserTest {
 		// Act
 		ResourceLoader resourceLoader = applicationContext
 				.getBean(ResourceLoaderBean.class).getResourceLoader();
-		AmazonS3Client webServiceClient = applicationContext
-				.getBean(AmazonS3Client.class);
+		S3Client webServiceClient = applicationContext.getBean(S3Client.class);
 
 		// Assert
-		assertThat(webServiceClient.getRegion().toAWSRegion())
-				.isEqualTo(Region.getRegion(Regions.US_WEST_2));
+		// TODO SDK2 migration: adapt
+		// assertThat(webServiceClient.getRegion().toAWSRegion())
+		// .isEqualTo(Region.EU_WEST_2);
 
 		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
 		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
@@ -144,16 +141,16 @@ public class ContextResourceLoaderBeanDefinitionParserTest {
 
 		// Assert that the proxied AmazonS2 instances are the same as the customS3Client
 		// in the app context.
-		AmazonS3 customS3Client = applicationContext.getBean(AmazonS3.class);
+		S3Client customS3Client = applicationContext.getBean(S3Client.class);
 
 		SimpleStorageProtocolResolver resourceLoader = (SimpleStorageProtocolResolver) protocolResolver;
-		AmazonS3 amazonS3FromResourceLoader = (AmazonS3) ReflectionTestUtils
+		S3Client amazonS3FromResourceLoader = (S3Client) ReflectionTestUtils
 				.getField(resourceLoader, "amazonS3");
 
 		assertThat(AopUtils.isAopProxy(amazonS3FromResourceLoader)).isTrue();
 
 		Advised advised2 = (Advised) amazonS3FromResourceLoader;
-		AmazonS3 amazonS3WrappedInsideSimpleStorageResourceLoader = (AmazonS3) advised2
+		S3Client amazonS3WrappedInsideSimpleStorageResourceLoader = (S3Client) advised2
 				.getTargetSource().getTarget();
 
 		assertThat(amazonS3WrappedInsideSimpleStorageResourceLoader)

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.aws.context.config.xml;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.aop.framework.Advised;
@@ -74,9 +77,10 @@ public class ContextResourceLoaderBeanDefinitionParserTest {
 		S3Client webServiceClient = applicationContext.getBean(S3Client.class);
 
 		// Assert
-		// TODO SDK2 migration: adapt
-		// assertThat(webServiceClient.getRegion().toAWSRegion())
-		// .isEqualTo(Region.EU_WEST_1);
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(webServiceClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(AwsClientOption.AWS_REGION))
+				.isEqualTo(Region.EU_WEST_1);
 
 		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
 		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
@@ -96,9 +100,10 @@ public class ContextResourceLoaderBeanDefinitionParserTest {
 		S3Client webServiceClient = applicationContext.getBean(S3Client.class);
 
 		// Assert
-		// TODO SDK2 migration: adapt
-		// assertThat(webServiceClient.getRegion().toAWSRegion())
-		// .isEqualTo(Region.EU_WEST_2);
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(webServiceClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(AwsClientOption.AWS_REGION))
+				.isEqualTo(Region.US_WEST_2);
 
 		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
 		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
@@ -21,6 +21,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
@@ -111,10 +113,11 @@ public class StackConfigurationBeanDefinitionParserTest {
 		// Assert
 		CloudFormationClient amazonCloudFormation = registry
 				.getBean(CloudFormationClient.class);
-		assertThat(
-				ReflectionTestUtils.getField(amazonCloudFormation, "endpoint").toString())
-						.isEqualTo("https://" + ServiceMetadata.of("cloudformation")
-								.endpointFor(Region.SA_EAST_1));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonCloudFormation, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
+				.isEqualTo("https://" + ServiceMetadata.of("cloudformation")
+						.endpointFor(Region.SA_EAST_1));
 	}
 
 	@Test
@@ -131,10 +134,11 @@ public class StackConfigurationBeanDefinitionParserTest {
 		// Assert
 		CloudFormationClient amazonCloudFormation = registry
 				.getBean(CloudFormationClient.class);
-		assertThat(
-				ReflectionTestUtils.getField(amazonCloudFormation, "endpoint").toString())
-						.isEqualTo("https://" + ServiceMetadata.of("cloudformation")
-								.endpointFor(Region.AP_SOUTHEAST_2));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonCloudFormation, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
+				.isEqualTo("https://" + ServiceMetadata.of("cloudformation")
+						.endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 	@Test

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/SimpleStorageProtocolResolverConfigurerTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/SimpleStorageProtocolResolverConfigurerTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.aws.context.support.io;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -40,7 +40,7 @@ public class SimpleStorageProtocolResolverConfigurerTest {
 
 	private static void configureApplicationContext(
 			StaticApplicationContext staticApplicationContext) {
-		AmazonS3 amazonS3Mock = mock(AmazonS3.class);
+		S3Client amazonS3Mock = mock(S3Client.class);
 
 		AnnotationConfigUtils
 				.registerAnnotationConfigProcessors(staticApplicationContext);

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
@@ -19,8 +19,8 @@ package org.springframework.cloud.aws.mail.config.xml;
 import java.lang.reflect.Field;
 import java.net.URI;
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import org.junit.Test;
+import software.amazon.awssdk.services.ses.SesClient;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.mail.MailSender;
@@ -37,9 +37,9 @@ import static org.springframework.util.ReflectionUtils.makeAccessible;
  */
 public class SimpleEmailServiceBeanDefinitionParserTest {
 
-	private static String getEndpointUrlFromWebserviceClient(
-			AmazonSimpleEmailServiceClient client) throws Exception {
-		Field field = findField(AmazonSimpleEmailServiceClient.class, "endpoint");
+	private static String getEndpointUrlFromWebserviceClient(SesClient client)
+			throws Exception {
+		Field field = findField(SesClient.class, "endpoint");
 		makeAccessible(field);
 		URI endpointUri = (URI) field.get(client);
 		return endpointUri.toASCIIString();
@@ -53,9 +53,8 @@ public class SimpleEmailServiceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-context.xml", getClass());
 
 		// Act
-		AmazonSimpleEmailServiceClient emailService = context.getBean(
-				getBeanName(AmazonSimpleEmailServiceClient.class.getName()),
-				AmazonSimpleEmailServiceClient.class);
+		SesClient emailService = context.getBean(getBeanName(SesClient.class.getName()),
+				SesClient.class);
 
 		MailSender mailSender = context.getBean(MailSender.class);
 
@@ -74,9 +73,8 @@ public class SimpleEmailServiceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-region.xml", getClass());
 
 		// Act
-		AmazonSimpleEmailServiceClient emailService = context.getBean(
-				getBeanName(AmazonSimpleEmailServiceClient.class.getName()),
-				AmazonSimpleEmailServiceClient.class);
+		SesClient emailService = context.getBean(getBeanName(SesClient.class.getName()),
+				SesClient.class);
 
 		MailSender mailSender = context.getBean(MailSender.class);
 
@@ -95,9 +93,8 @@ public class SimpleEmailServiceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-regionProvider.xml", getClass());
 
 		// Act
-		AmazonSimpleEmailServiceClient emailService = context.getBean(
-				getBeanName(AmazonSimpleEmailServiceClient.class.getName()),
-				AmazonSimpleEmailServiceClient.class);
+		SesClient emailService = context.getBean(getBeanName(SesClient.class.getName()),
+				SesClient.class);
 
 		MailSender mailSender = context.getBean(MailSender.class);
 
@@ -116,8 +113,7 @@ public class SimpleEmailServiceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-ses-client.xml", getClass());
 
 		// Act
-		AmazonSimpleEmailServiceClient emailService = context
-				.getBean("emailServiceClient", AmazonSimpleEmailServiceClient.class);
+		SesClient emailService = context.getBean("emailServiceClient", SesClient.class);
 
 		MailSender mailSender = context.getBean(MailSender.class);
 

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.aws.mail.config.xml;
 
-import java.lang.reflect.Field;
 import java.net.URI;
 
 import org.junit.Test;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.ses.SesClient;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -29,8 +30,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName;
-import static org.springframework.util.ReflectionUtils.findField;
-import static org.springframework.util.ReflectionUtils.makeAccessible;
 
 /**
  * @author Agim Emruli
@@ -39,9 +38,9 @@ public class SimpleEmailServiceBeanDefinitionParserTest {
 
 	private static String getEndpointUrlFromWebserviceClient(SesClient client)
 			throws Exception {
-		Field field = findField(SesClient.class, "endpoint");
-		makeAccessible(field);
-		URI endpointUri = (URI) field.get(client);
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(client, "clientConfiguration");
+		URI endpointUri = clientConfiguration.option(SdkClientOption.ENDPOINT);
 		return endpointUri.toASCIIString();
 	}
 

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
@@ -29,6 +29,6 @@
 	</aws-cache:cache-manager>
 
 	<bean id="customClient" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="com.amazonaws.services.elasticache.AmazonElastiCache"/>
+		<constructor-arg value="software.amazon.awssdk.services.elasticache.ElastiCacheClient"/>
 	</bean>
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
@@ -24,6 +24,6 @@
 	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-credentials>
-		<context:profile-credentials profileName="test"/>
+		<context:profile-credentials profileName="customProfile"/>
 	</context:context-credentials>
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
@@ -24,8 +24,8 @@
 	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
 	<context:context-instance-data user-tags-map="myUserTags"
-								   amazon-ec2="amazonEC2Client"/>
+								   amazon-ec2="customEC2Client"/>
 
-	<bean id="amazonEC2Client" class="com.amazonaws.services.ec2.AmazonEC2Client"/>
+	<bean id="customEC2Client" class="does-not-matter"/>
 
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
@@ -29,7 +29,7 @@
 
 	<aws-context:context-resource-loader amazon-s3="customS3Client"/>
 
-	<bean id="customS3Client" class="com.amazonaws.services.s3.AmazonS3Client"/>
+	<bean id="customS3Client" class="software.amazon.awssdk.services.s3.S3Client" factory-method="create"/>
 
 	<bean
 		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
@@ -30,6 +30,6 @@
 	<bean id="customCloudFormationClient" class="org.mockito.Mockito"
 		  factory-method="mock">
 		<constructor-arg
-			value="com.amazonaws.services.cloudformation.AmazonCloudFormation"/>
+			value="software.amazon.awssdk.services.cloudformation.CloudFormationClient"/>
 	</bean>
 </beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
@@ -29,7 +29,7 @@
 	<aws-mail:mail-sender id="test" amazon-ses="emailServiceClient"/>
 
 	<bean id="emailServiceClient"
-		  class="com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient"/>
+		  class="software.amazon.awssdk.services.ses.SesClient" factory-method="create"/>
 
 	<aws-context:context-credentials>
 		<aws-context:simple-credentials access-key="test" secret-key="abc"/>

--- a/spring-cloud-aws-core/pom.xml
+++ b/spring-cloud-aws-core/pom.xml
@@ -39,20 +39,16 @@
 			<artifactId>spring-aop</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ec2</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ec2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-cloudformation</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>cloudformation</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -60,7 +60,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source,
 			BeanDefinitionRegistry registry, String serviceNameClassName,
-			String customRegionProvider) {
+			String customRegionProvider, String customRegion) {
 
 		String beanName = getBeanName(serviceNameClassName);
 
@@ -70,7 +70,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		}
 
 		BeanDefinition definition = getAmazonWebserviceClientBeanDefinition(source,
-				serviceNameClassName, customRegionProvider, registry);
+				serviceNameClassName, customRegionProvider, customRegion, registry);
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(definition, beanName);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
 
@@ -79,7 +79,13 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static AbstractBeanDefinition getAmazonWebserviceClientBeanDefinition(
 			Object source, String serviceNameClassName, String customRegionProvider,
-			BeanDefinitionRegistry beanDefinitionRegistry) {
+			String customRegion, BeanDefinitionRegistry beanDefinitionRegistry) {
+
+		if (StringUtils.hasText(customRegionProvider)
+				&& StringUtils.hasText(customRegion)) {
+			throw new IllegalArgumentException(
+					"Only region or regionProvider can be configured, but not both");
+		}
 
 		registerCredentialsProviderIfNeeded(beanDefinitionRegistry);
 
@@ -93,9 +99,12 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		// Configure source of the bean definition
 		builder.getRawBeanDefinition().setSource(source);
 
-		// Configure region properties
+		// Configure region properties (either custom region provider or custom region)
 		if (StringUtils.hasText(customRegionProvider)) {
 			builder.addPropertyReference("regionProvider", customRegionProvider);
+		}
+		else if (StringUtils.hasText(customRegion)) {
+			builder.addPropertyValue("customRegion", customRegion);
 		}
 		else {
 			registerRegionProviderBeanIfNeeded(beanDefinitionRegistry);

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -116,9 +116,9 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		String clientClassName = ClassUtils.getShortName(serviceClassName);
 		String shortenedClassName = StringUtils.delete(clientClassName,
 				SERVICE_IMPLEMENTATION_SUFFIX);
-		// TODO SDK2 migration: backwards-compatible this way. find a better solution?
-		// Note not completely backwards-
-		// compatible since it used to be amazonRDS and now it is amazonRds (lower case).
+		// "amazon" is added as prefix to stay close to the naming scheme used with AWS SDK 1.x
+		// In the 1.x SDK the clients were named Amazon[ServiceName]Client, s. https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md#63-client-names
+		// and the bean name was the client class name without the "Client" suffix.
 		return "amazon" + shortenedClassName;
 	}
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -116,8 +116,10 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		String clientClassName = ClassUtils.getShortName(serviceClassName);
 		String shortenedClassName = StringUtils.delete(clientClassName,
 				SERVICE_IMPLEMENTATION_SUFFIX);
-		// "amazon" is added as prefix to stay close to the naming scheme used with AWS SDK 1.x
-		// In the 1.x SDK the clients were named Amazon[ServiceName]Client, s. https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md#63-client-names
+		// "amazon" is added as prefix to stay close to the naming scheme used with AWS
+		// SDK 1.x
+		// In the 1.x SDK the clients were named Amazon[ServiceName]Client, s.
+		// https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md#63-client-names
 		// and the bean name was the client class name without the "Client" suffix.
 		return "amazon" + shortenedClassName;
 	}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.aws.core.config;
 
-import java.beans.Introspector;
-
 import software.amazon.awssdk.regions.Region;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -118,7 +116,10 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		String clientClassName = ClassUtils.getShortName(serviceClassName);
 		String shortenedClassName = StringUtils.delete(clientClassName,
 				SERVICE_IMPLEMENTATION_SUFFIX);
-		return Introspector.decapitalize(shortenedClassName);
+		// TODO SDK2 migration: backwards-compatible this way. find a better solution?
+		// Note not completely backwards-
+		// compatible since it used to be amazonRDS and now it is amazonRds (lower case).
+		return "amazon" + shortenedClassName;
 	}
 
 	public static String getRegionProviderBeanName(

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.aws.core.config;
 
 import java.beans.Introspector;
 
-import com.amazonaws.regions.Regions;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -140,7 +140,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		if (!registry.containsBeanDefinition(REGION_PROVIDER_BEAN_NAME)) {
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder
 					.genericBeanDefinition(StaticRegionProvider.class);
-			builder.addConstructorArgValue(Regions.DEFAULT_REGION.getName());
+			builder.addConstructorArgValue(Region.US_WEST_2.id());
 			builder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(REGION_PROVIDER_BEAN_NAME,
 					builder.getBeanDefinition());

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -60,7 +60,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source,
 			BeanDefinitionRegistry registry, String serviceNameClassName,
-			String customRegionProvider, String customRegion) {
+			String customRegionProvider) {
 
 		String beanName = getBeanName(serviceNameClassName);
 
@@ -70,7 +70,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		}
 
 		BeanDefinition definition = getAmazonWebserviceClientBeanDefinition(source,
-				serviceNameClassName, customRegionProvider, customRegion, registry);
+				serviceNameClassName, customRegionProvider, registry);
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(definition, beanName);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
 
@@ -79,13 +79,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static AbstractBeanDefinition getAmazonWebserviceClientBeanDefinition(
 			Object source, String serviceNameClassName, String customRegionProvider,
-			String customRegion, BeanDefinitionRegistry beanDefinitionRegistry) {
-
-		if (StringUtils.hasText(customRegionProvider)
-				&& StringUtils.hasText(customRegion)) {
-			throw new IllegalArgumentException(
-					"Only region or regionProvider can be configured, but not both");
-		}
+			BeanDefinitionRegistry beanDefinitionRegistry) {
 
 		registerCredentialsProviderIfNeeded(beanDefinitionRegistry);
 
@@ -99,12 +93,9 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		// Configure source of the bean definition
 		builder.getRawBeanDefinition().setSource(source);
 
-		// Configure region properties (either custom region provider or custom region)
+		// Configure region properties
 		if (StringUtils.hasText(customRegionProvider)) {
 			builder.addPropertyReference("regionProvider", customRegionProvider);
-		}
-		else if (StringUtils.hasText(customRegion)) {
-			builder.addPropertyValue("customRegion", customRegion);
 		}
 		else {
 			registerRegionProviderBeanIfNeeded(beanDefinitionRegistry);

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -52,6 +52,8 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 
 	private RegionProvider regionProvider;
 
+	private Region customRegion;
+
 	private ExecutorService executor;
 
 	public AmazonWebserviceClientFactoryBean(Class<T> clientClass,
@@ -82,6 +84,7 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 		AwsClientBuilder<?, T> builder = (AwsClientBuilder<?, T>) ReflectionUtils
 				.invokeMethod(builderMethod, null);
 
+		// TODO SDK2 migration: does this still work?
 		if (this.executor != null) {
 			AwsAsyncClientBuilder<?, T> asyncBuilder = (AwsAsyncClientBuilder<?, T>) builder;
 			asyncBuilder.asyncConfiguration(ClientAsyncConfiguration.builder()
@@ -95,7 +98,10 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 			builder.credentialsProvider(this.credentialsProvider);
 		}
 
-		if (this.regionProvider != null) {
+		if (this.customRegion != null) {
+			builder.region(this.customRegion);
+		}
+		else if (this.regionProvider != null) {
 			builder.region(this.regionProvider.getRegion());
 		}
 		else {
@@ -106,6 +112,10 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 
 	public void setRegionProvider(RegionProvider regionProvider) {
 		this.regionProvider = regionProvider;
+	}
+
+	public void setCustomRegion(String customRegionName) {
+		this.customRegion = Region.of(customRegionName);
 	}
 
 	public void setExecutor(ExecutorService executor) {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -85,12 +85,12 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 				.invokeMethod(builderMethod, null);
 
 		if (this.executor != null) {
-			Assert.isAssignable(AwsAsyncClientBuilder.class, builder.getClass(), "Client must be async if executor is set.");
-			((AwsAsyncClientBuilder<?, T>) builder).asyncConfiguration(ClientAsyncConfiguration.builder()
-					.advancedOption(
+			Assert.isAssignable(AwsAsyncClientBuilder.class, builder.getClass(),
+					"Client must be async if executor is set.");
+			((AwsAsyncClientBuilder<?, T>) builder)
+					.asyncConfiguration(ClientAsyncConfiguration.builder().advancedOption(
 							SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR,
-							executor)
-					.build());
+							executor).build());
 		}
 
 		if (this.credentialsProvider != null) {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -84,10 +84,9 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 		AwsClientBuilder<?, T> builder = (AwsClientBuilder<?, T>) ReflectionUtils
 				.invokeMethod(builderMethod, null);
 
-		// TODO SDK2 migration: does this still work?
 		if (this.executor != null) {
-			AwsAsyncClientBuilder<?, T> asyncBuilder = (AwsAsyncClientBuilder<?, T>) builder;
-			asyncBuilder.asyncConfiguration(ClientAsyncConfiguration.builder()
+			Assert.isAssignable(AwsAsyncClientBuilder.class, builder.getClass(), "Client must be async if executor is set.");
+			((AwsAsyncClientBuilder<?, T>) builder).asyncConfiguration(ClientAsyncConfiguration.builder()
 					.advancedOption(
 							SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR,
 							executor)

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -95,7 +95,7 @@ public class AmazonWebserviceClientFactoryBean<T extends SdkClient>
 			builder.credentialsProvider(this.credentialsProvider);
 		}
 
-		else if (this.regionProvider != null) {
+		if (this.regionProvider != null) {
 			builder.region(this.regionProvider.getRegion());
 		}
 		else {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
@@ -31,6 +31,8 @@ import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientCo
  */
 public final class XmlWebserviceConfigurationUtils {
 
+	private static final String REGION_ATTRIBUTE_NAME = "region";
+
 	private static final String REGION_PROVIDER_ATTRIBUTE_NAME = "region-provider";
 
 	private XmlWebserviceConfigurationUtils() {
@@ -55,6 +57,7 @@ public final class XmlWebserviceConfigurationUtils {
 		try {
 			return getAmazonWebserviceClientBeanDefinition(source, serviceClassName,
 					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME),
+					element.getAttribute(REGION_ATTRIBUTE_NAME),
 					parserContext.getRegistry());
 		}
 		catch (Exception e) {
@@ -69,7 +72,8 @@ public final class XmlWebserviceConfigurationUtils {
 		try {
 			return registerAmazonWebserviceClient(source, parserContext.getRegistry(),
 					serviceClassName,
-					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME));
+					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME),
+					element.getAttribute(REGION_ATTRIBUTE_NAME));
 		}
 		catch (Exception e) {
 			parserContext.getReaderContext().error(e.getMessage(), source, e);

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
@@ -31,8 +31,6 @@ import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientCo
  */
 public final class XmlWebserviceConfigurationUtils {
 
-	private static final String REGION_ATTRIBUTE_NAME = "region";
-
 	private static final String REGION_PROVIDER_ATTRIBUTE_NAME = "region-provider";
 
 	private XmlWebserviceConfigurationUtils() {
@@ -57,7 +55,6 @@ public final class XmlWebserviceConfigurationUtils {
 		try {
 			return getAmazonWebserviceClientBeanDefinition(source, serviceClassName,
 					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME),
-					element.getAttribute(REGION_ATTRIBUTE_NAME),
 					parserContext.getRegistry());
 		}
 		catch (Exception e) {
@@ -72,8 +69,7 @@ public final class XmlWebserviceConfigurationUtils {
 		try {
 			return registerAmazonWebserviceClient(source, parserContext.getRegistry(),
 					serviceClassName,
-					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME),
-					element.getAttribute(REGION_ATTRIBUTE_NAME));
+					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME));
 		}
 		catch (Exception e) {
 			parserContext.getReaderContext().error(e.getMessage(), source, e);

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
@@ -41,6 +41,11 @@ public class CredentialsProviderFactoryBean
 	 */
 	public static final String CREDENTIALS_PROVIDER_BEAN_NAME = "credentialsProvider";
 
+	/**
+	 * Name of the credentials provider builder bean.
+	 */
+	public static final String CREDENTIALS_PROVIDER_BUILDER_BEAN_NAME = "credentialsProviderBuilder";
+
 	private final List<AwsCredentialsProvider> delegates;
 
 	public CredentialsProviderFactoryBean() {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
@@ -19,57 +19,58 @@ package org.springframework.cloud.aws.core.credentials;
 import java.util.Collections;
 import java.util.List;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.util.Assert;
 
 /**
  * {@link org.springframework.beans.factory.FactoryBean} that creates a composite
- * {@link AWSCredentialsProvider} based on the delegates.
+ * {@link AwsCredentialsProvider} based on the delegates.
  *
  * @author Agim Emruli
  * @since 1.0
  */
 public class CredentialsProviderFactoryBean
-		extends AbstractFactoryBean<AWSCredentialsProvider> {
+		extends AbstractFactoryBean<AwsCredentialsProvider> {
 
 	/**
 	 * Name of the credentials provider bean.
 	 */
 	public static final String CREDENTIALS_PROVIDER_BEAN_NAME = "credentialsProvider";
 
-	private final List<AWSCredentialsProvider> delegates;
+	private final List<AwsCredentialsProvider> delegates;
 
 	public CredentialsProviderFactoryBean() {
 		this(Collections.emptyList());
 	}
 
-	public CredentialsProviderFactoryBean(List<AWSCredentialsProvider> delegates) {
+	public CredentialsProviderFactoryBean(List<AwsCredentialsProvider> delegates) {
 		Assert.notNull(delegates, "Delegates must not be null");
 		this.delegates = delegates;
 	}
 
 	@Override
 	public Class<?> getObjectType() {
-		return AWSCredentialsProvider.class;
+		return AwsCredentialsProvider.class;
 	}
 
 	@Override
-	protected AWSCredentialsProvider createInstance() throws Exception {
-		AWSCredentialsProviderChain awsCredentialsProviderChain;
+	protected AwsCredentialsProvider createInstance() throws Exception {
+		AwsCredentialsProviderChain.Builder awsCredentialsProviderChainBuilder;
 		if (this.delegates.isEmpty()) {
-			awsCredentialsProviderChain = new DefaultAWSCredentialsProviderChain();
+			awsCredentialsProviderChainBuilder = AwsCredentialsProviderChain.builder()
+					.credentialsProviders(DefaultCredentialsProvider.create());
 		}
 		else {
-			awsCredentialsProviderChain = new AWSCredentialsProviderChain(this.delegates
-					.toArray(new AWSCredentialsProvider[this.delegates.size()]));
+			awsCredentialsProviderChainBuilder = AwsCredentialsProviderChain.builder()
+					.credentialsProviders(this.delegates);
 		}
 
-		awsCredentialsProviderChain.setReuseLastProvider(false);
-		return awsCredentialsProviderChain;
+		awsCredentialsProviderChainBuilder.reuseLastProviderEnabled(false);
+		return awsCredentialsProviderChainBuilder.build();
 	}
 
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBean.java
@@ -59,18 +59,15 @@ public class CredentialsProviderFactoryBean
 
 	@Override
 	protected AwsCredentialsProvider createInstance() throws Exception {
-		AwsCredentialsProviderChain.Builder awsCredentialsProviderChainBuilder;
 		if (this.delegates.isEmpty()) {
-			awsCredentialsProviderChainBuilder = AwsCredentialsProviderChain.builder()
-					.credentialsProviders(DefaultCredentialsProvider.create());
+			return DefaultCredentialsProvider.builder().reuseLastProviderEnabled(false)
+					.build();
 		}
 		else {
-			awsCredentialsProviderChainBuilder = AwsCredentialsProviderChain.builder()
-					.credentialsProviders(this.delegates);
+			return AwsCredentialsProviderChain.builder()
+					.credentialsProviders(this.delegates).reuseLastProviderEnabled(false)
+					.build();
 		}
-
-		awsCredentialsProviderChainBuilder.reuseLastProviderEnabled(false);
-		return awsCredentialsProviderChainBuilder.build();
 	}
 
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySource.java
@@ -23,10 +23,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.util.EC2MetadataUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.beans.factory.config.PlaceholderConfigurerSupport;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -104,7 +104,7 @@ public class AmazonEc2InstanceDataPropertySource
 		try {
 			return EC2MetadataUtils.getData(EC2_METADATA_ROOT + "/" + name);
 		}
-		catch (AmazonClientException e) {
+		catch (SdkClientException e) {
 			// Suppress exception if we are not able to contact the service,
 			// because that is quite often the case if we run in unit tests outside the
 			// environment.
@@ -122,7 +122,7 @@ public class AmazonEc2InstanceDataPropertySource
 			try {
 				userData = EC2MetadataUtils.getUserData();
 			}
-			catch (AmazonClientException e) {
+			catch (SdkClientException e) {
 				// Suppress exception if we are not able to contact the service,
 				// because that is quite often the case if we run in unit tests outside
 				// the environment.

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceIdProvider.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.core.env.ec2;
 
-import com.amazonaws.util.EC2MetadataUtils;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 /**
  * Provides the instance id of the current Amazon EC2 instance.

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBean.java
@@ -19,11 +19,11 @@ package org.springframework.cloud.aws.core.env.stack.config;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
-import com.amazonaws.services.cloudformation.model.Stack;
-import com.amazonaws.services.cloudformation.model.Tag;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksResponse;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.cloudformation.model.Tag;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
@@ -33,11 +33,11 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 public class StackResourceUserTagsFactoryBean
 		extends AbstractFactoryBean<Map<String, String>> {
 
-	private final AmazonCloudFormation amazonCloudFormation;
+	private final CloudFormationClient amazonCloudFormation;
 
 	private final StackNameProvider stackNameProvider;
 
-	public StackResourceUserTagsFactoryBean(AmazonCloudFormation amazonCloudFormation,
+	public StackResourceUserTagsFactoryBean(CloudFormationClient amazonCloudFormation,
 			StackNameProvider stackNameProvider) {
 		this.amazonCloudFormation = amazonCloudFormation;
 		this.stackNameProvider = stackNameProvider;
@@ -51,12 +51,12 @@ public class StackResourceUserTagsFactoryBean
 	@Override
 	protected Map<String, String> createInstance() throws Exception {
 		LinkedHashMap<String, String> userTags = new LinkedHashMap<>();
-		DescribeStacksResult stacksResult = this.amazonCloudFormation
-				.describeStacks(new DescribeStacksRequest()
-						.withStackName(this.stackNameProvider.getStackName()));
-		for (Stack stack : stacksResult.getStacks()) {
-			for (Tag tag : stack.getTags()) {
-				userTags.put(tag.getKey(), tag.getValue());
+		DescribeStacksResponse stacksResult = this.amazonCloudFormation
+				.describeStacks(DescribeStacksRequest.builder()
+						.stackName(this.stackNameProvider.getStackName()).build());
+		for (Stack stack : stacksResult.stacks()) {
+			for (Tag tag : stack.tags()) {
+				userTags.put(tag.key(), tag.value());
 			}
 		}
 		return userTags;

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactory.java
@@ -38,6 +38,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Greg Turnquist
  * @author Agim Emruli
+ * @author Kristine Jetzke
  * @since 1.1
  */
 public final class AmazonS3ProxyFactory {
@@ -135,6 +136,7 @@ public final class AmazonS3ProxyFactory {
 		private S3Client buildAmazonS3ForRedirectLocation(S3Client prototype,
 				S3Exception e) {
 			try {
+				// TODO SDK2 migration: add integration test
 				final String region = e.awsErrorDetails().sdkHttpResponse()
 						.firstMatchingHeader("x-amx-bucket-region")
 						.orElseThrow(() -> new RuntimeException(

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
@@ -33,7 +33,7 @@ import org.springframework.core.task.TaskExecutor;
  */
 public class SimpleStorageProtocolResolver implements ProtocolResolver, InitializingBean {
 
-	private final AmazonS3 amazonS3;
+	private final S3Client amazonS3;
 
 	/**
 	 * <b>IMPORTANT:</b> If a task executor is set with an unbounded queue there will be a
@@ -42,7 +42,7 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 	 */
 	private TaskExecutor taskExecutor;
 
-	public SimpleStorageProtocolResolver(AmazonS3 amazonS3) {
+	public SimpleStorageProtocolResolver(S3Client amazonS3) {
 		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 	}
 
@@ -72,7 +72,7 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 		}
 	}
 
-	public AmazonS3 getAmazonS3() {
+	public S3Client getAmazonS3() {
 		return this.amazonS3;
 	}
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -139,7 +139,7 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 	}
 
 	@Override
-	public URL getURL() throws IOException {
+	public URL getURL() {
 		return this.amazonS3.utilities().getUrl(GetUrlRequest.builder()
 				.bucket(this.bucketName).key(this.objectName).build());
 	}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/naming/AmazonResourceName.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.aws.core.naming;
 
 import java.util.Arrays;
 
-import com.amazonaws.regions.Region;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -254,7 +254,7 @@ public final class AmazonResourceName {
 		}
 
 		public Builder withRegion(Region region) {
-			this.region = region.getName();
+			this.region = region.id();
 			return this;
 		}
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.aws.core.region;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.util.EC2MetadataUtils;
-import com.amazonaws.util.EC2MetadataUtils.InstanceInfo;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.util.Assert;
 
@@ -45,11 +43,12 @@ public class Ec2MetadataRegionProvider implements RegionProvider {
 
 	protected Region getCurrentRegion() {
 		try {
-			InstanceInfo instanceInfo = EC2MetadataUtils.getInstanceInfo();
+			EC2MetadataUtils.InstanceInfo instanceInfo = EC2MetadataUtils
+					.getInstanceInfo();
 			return instanceInfo != null && instanceInfo.getRegion() != null
-					? RegionUtils.getRegion(instanceInfo.getRegion()) : null;
+					? Region.of(instanceInfo.getRegion()) : null;
 		}
-		catch (AmazonClientException e) {
+		catch (SdkClientException e) {
 			return null;
 		}
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/RegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/RegionProvider.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.core.region;
 
-import com.amazonaws.regions.Region;
+import software.amazon.awssdk.regions.Region;
 
 /**
  * Provider that can be used to retrieve the configured {@link Region}. A region can be

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
@@ -16,8 +16,7 @@
 
 package org.springframework.cloud.aws.core.region;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 
@@ -41,7 +40,7 @@ public class StaticRegionProvider implements RegionProvider {
 	@RuntimeUse
 	public StaticRegionProvider(String configuredRegion) {
 		try {
-			this.configuredRegion = Region.getRegion(Regions.fromName(configuredRegion));
+			this.configuredRegion = Region.of(configuredRegion);
 		}
 		catch (IllegalArgumentException e) {
 			throw new IllegalArgumentException(

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/StaticRegionProvider.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.core.region;
 import software.amazon.awssdk.regions.Region;
 
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
+import org.springframework.util.Assert;
 
 /**
  * Static {@link RegionProvider} implementation that can used to statically configure a
@@ -39,13 +40,9 @@ public class StaticRegionProvider implements RegionProvider {
 	 */
 	@RuntimeUse
 	public StaticRegionProvider(String configuredRegion) {
-		try {
-			this.configuredRegion = Region.of(configuredRegion);
-		}
-		catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException(
-					"The region '" + configuredRegion + "' is not a valid region!", e);
-		}
+		this.configuredRegion = Region.of(configuredRegion);
+		Assert.isTrue(Region.regions().contains(this.configuredRegion),
+				"The region '" + configuredRegion + "' is not a valid region!");
 	}
 
 	/**

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClientBuilder.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClientBuilder.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.regions.Region;
 
 public class AmazonTestWebserviceClientBuilder extends
-		AwsDefaultClientBuilder<AmazonTestWebserviceClientBuilder, AmazonTestWebserviceClient> {
+		AwsDefaultClientBuilder<AmazonTestWebserviceClientBuilder, TestWebserviceClient> {
 
 	@Override
 	protected String serviceEndpointPrefix() {
@@ -39,10 +39,10 @@ public class AmazonTestWebserviceClientBuilder extends
 	}
 
 	@Override
-	protected AmazonTestWebserviceClient buildClient() {
+	protected TestWebserviceClient buildClient() {
 		final Region region = super.clientConfiguration.build()
 				.option(AwsClientOption.AWS_REGION);
-		return new DefaultAmazonTestWebserviceClient(region);
+		return new DefaultTestWebserviceClient(region);
 	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClientBuilder.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonTestWebserviceClientBuilder.java
@@ -16,27 +16,33 @@
 
 package org.springframework.cloud.aws.core.config;
 
-import com.amazonaws.ClientConfigurationFactory;
-import com.amazonaws.client.AwsSyncClientParams;
-import com.amazonaws.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.regions.Region;
 
-/**
- * @author Agim Emruli
- */
-public final class AmazonTestWebserviceClientBuilder extends
-		AwsSyncClientBuilder<AmazonTestWebserviceClientBuilder, AmazonTestWebserviceClient> {
+public class AmazonTestWebserviceClientBuilder extends
+		AwsDefaultClientBuilder<AmazonTestWebserviceClientBuilder, AmazonTestWebserviceClient> {
 
-	private AmazonTestWebserviceClientBuilder() {
-		super(new ClientConfigurationFactory());
-	}
-
-	public static AmazonTestWebserviceClientBuilder standard() {
-		return new AmazonTestWebserviceClientBuilder();
+	@Override
+	protected String serviceEndpointPrefix() {
+		return null;
 	}
 
 	@Override
-	protected AmazonTestWebserviceClient build(AwsSyncClientParams clientParams) {
-		return new AmazonTestWebserviceClient(getCredentials());
+	protected String signingName() {
+		return null;
+	}
+
+	@Override
+	protected String serviceName() {
+		return null;
+	}
+
+	@Override
+	protected AmazonTestWebserviceClient buildClient() {
+		final Region region = super.clientConfiguration.build()
+				.option(AwsClientOption.AWS_REGION);
+		return new DefaultAmazonTestWebserviceClient(region);
 	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -50,7 +50,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), null);
+						AmazonTestWebserviceClient.class.getName(), null, null);
 
 		// Act
 		beanFactory.preInstantiateSingletons();
@@ -77,7 +77,8 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), "myRegionProvider");
+						AmazonTestWebserviceClient.class.getName(), "myRegionProvider",
+						null);
 
 		// Act
 		beanFactory.preInstantiateSingletons();
@@ -87,6 +88,55 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		// Assert
 		assertThat(client).isNotNull();
 		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
+	}
+
+	@Test
+	public void registerAmazonWebserviceClient_withCustomRegionConfiguration_returnsBeanDefinitionWithRegionConfigured()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerSingleton(
+				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+				new StaticAwsCredentialsProvider());
+
+		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
+				.registerAmazonWebserviceClient(new Object(), beanFactory,
+						AmazonTestWebserviceClient.class.getName(), null,
+						Region.EU_WEST_1.id());
+
+		// Act
+		beanFactory.preInstantiateSingletons();
+		AmazonTestWebserviceClient client = beanFactory.getBean(
+				beanDefinitionHolder.getBeanName(), AmazonTestWebserviceClient.class);
+
+		// Assert
+		assertThat(client).isNotNull();
+		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
+	}
+
+	@Test
+	public void registerAmazonWebserviceClient_withCustomRegionAndRegionProviderConfigured_reportsError()
+			throws Exception {
+		// Arrange
+		this.expectedException.expect(IllegalArgumentException.class);
+		this.expectedException.expectMessage(
+				"Only region or regionProvider can be configured, but not both");
+
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerSingleton(
+				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+				new StaticAwsCredentialsProvider());
+
+		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
+				.registerAmazonWebserviceClient(new Object(), beanFactory,
+						AmazonTestWebserviceClient.class.getName(), "someProvider",
+						Region.EU_WEST_1.id());
+
+		// Act
+		beanFactory.getBean(beanDefinitionHolder.getBeanName(),
+				AmazonTestWebserviceClient.class);
+
+		// Assert
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -50,7 +50,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), null, null);
+						AmazonTestWebserviceClient.class.getName(), null);
 
 		// Act
 		beanFactory.preInstantiateSingletons();
@@ -77,8 +77,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), "myRegionProvider",
-						null);
+						AmazonTestWebserviceClient.class.getName(), "myRegionProvider");
 
 		// Act
 		beanFactory.preInstantiateSingletons();
@@ -88,55 +87,6 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		// Assert
 		assertThat(client).isNotNull();
 		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
-	}
-
-	@Test
-	public void registerAmazonWebserviceClient_withCustomRegionConfiguration_returnsBeanDefinitionWithRegionConfigured()
-			throws Exception {
-		// Arrange
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerSingleton(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				new StaticAwsCredentialsProvider());
-
-		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
-				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), null,
-						Region.EU_WEST_1.id());
-
-		// Act
-		beanFactory.preInstantiateSingletons();
-		AmazonTestWebserviceClient client = beanFactory.getBean(
-				beanDefinitionHolder.getBeanName(), AmazonTestWebserviceClient.class);
-
-		// Assert
-		assertThat(client).isNotNull();
-		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
-	}
-
-	@Test
-	public void registerAmazonWebserviceClient_withCustomRegionAndRegionProviderConfigured_reportsError()
-			throws Exception {
-		// Arrange
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage(
-				"Only region or regionProvider can be configured, but not both");
-
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerSingleton(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				new StaticAwsCredentialsProvider());
-
-		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
-				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), "someProvider",
-						Region.EU_WEST_1.id());
-
-		// Act
-		beanFactory.getBean(beanDefinitionHolder.getBeanName(),
-				AmazonTestWebserviceClient.class);
-
-		// Assert
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -148,10 +148,6 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 				.getBeanName("software.amazon.awssdk.services.rds.RdsClient");
 
 		// Assert
-		// TODO SDK2 migration: should it stay this way? See
-		// org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName
-		// as well.
-		// This is also a breaking change because before it was amazonRDS (upper case)
 		assertThat(beanName).isEqualTo("amazonRds");
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -16,14 +16,13 @@
 
 package org.springframework.cloud.aws.core.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -61,8 +60,6 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		// Assert
 		assertThat(client).isNotNull();
 		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
-		assertThat(client.getRegion())
-				.isEqualTo(Region.getRegion(Regions.DEFAULT_REGION));
 	}
 
 	// @checkstyle:off
@@ -76,7 +73,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 				CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME,
 				new StaticAwsCredentialsProvider());
 		beanFactory.registerSingleton("myRegionProvider",
-				new StaticRegionProvider(Regions.AP_SOUTHEAST_2.getName()));
+				new StaticRegionProvider(Region.AP_SOUTHEAST_2.id()));
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
@@ -91,8 +88,6 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		// Assert
 		assertThat(client).isNotNull();
 		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
-		assertThat(client.getRegion())
-				.isEqualTo(Region.getRegion(Regions.AP_SOUTHEAST_2));
 	}
 
 	@Test
@@ -107,7 +102,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
 						AmazonTestWebserviceClient.class.getName(), null,
-						Regions.EU_WEST_1.getName());
+						Region.EU_WEST_1.id());
 
 		// Act
 		beanFactory.preInstantiateSingletons();
@@ -117,7 +112,6 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		// Assert
 		assertThat(client).isNotNull();
 		assertThat(beanDefinitionHolder.getBeanName()).isEqualTo("amazonTestWebservice");
-		assertThat(client.getRegion()).isEqualTo(Region.getRegion(Regions.EU_WEST_1));
 	}
 
 	@Test
@@ -136,7 +130,7 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
 						AmazonTestWebserviceClient.class.getName(), "someProvider",
-						Regions.EU_WEST_1.getName());
+						Region.EU_WEST_1.id());
 
 		// Act
 		beanFactory.getBean(beanDefinitionHolder.getBeanName(),
@@ -158,15 +152,11 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 		assertThat(beanName).isEqualTo("amazonRDS");
 	}
 
-	private static class StaticAwsCredentialsProvider implements AWSCredentialsProvider {
+	private static class StaticAwsCredentialsProvider implements AwsCredentialsProvider {
 
 		@Override
-		public AWSCredentials getCredentials() {
-			return new BasicAWSCredentials("test", "secret");
-		}
-
-		@Override
-		public void refresh() {
+		public AwsCredentials resolveCredentials() {
+			return AwsBasicCredentials.create("test", "secret");
 		}
 
 	}

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtilsTest.java
@@ -50,12 +50,12 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), null, null);
+						TestWebserviceClient.class.getName(), null, null);
 
 		// Act
 		beanFactory.preInstantiateSingletons();
-		AmazonTestWebserviceClient client = beanFactory.getBean(
-				beanDefinitionHolder.getBeanName(), AmazonTestWebserviceClient.class);
+		TestWebserviceClient client = beanFactory
+				.getBean(beanDefinitionHolder.getBeanName(), TestWebserviceClient.class);
 
 		// Assert
 		assertThat(client).isNotNull();
@@ -77,13 +77,12 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), "myRegionProvider",
-						null);
+						TestWebserviceClient.class.getName(), "myRegionProvider", null);
 
 		// Act
 		beanFactory.preInstantiateSingletons();
-		AmazonTestWebserviceClient client = beanFactory.getBean(
-				beanDefinitionHolder.getBeanName(), AmazonTestWebserviceClient.class);
+		TestWebserviceClient client = beanFactory
+				.getBean(beanDefinitionHolder.getBeanName(), TestWebserviceClient.class);
 
 		// Assert
 		assertThat(client).isNotNull();
@@ -101,13 +100,13 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), null,
+						TestWebserviceClient.class.getName(), null,
 						Region.EU_WEST_1.id());
 
 		// Act
 		beanFactory.preInstantiateSingletons();
-		AmazonTestWebserviceClient client = beanFactory.getBean(
-				beanDefinitionHolder.getBeanName(), AmazonTestWebserviceClient.class);
+		TestWebserviceClient client = beanFactory
+				.getBean(beanDefinitionHolder.getBeanName(), TestWebserviceClient.class);
 
 		// Assert
 		assertThat(client).isNotNull();
@@ -129,12 +128,12 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		BeanDefinitionHolder beanDefinitionHolder = AmazonWebserviceClientConfigurationUtils
 				.registerAmazonWebserviceClient(new Object(), beanFactory,
-						AmazonTestWebserviceClient.class.getName(), "someProvider",
+						TestWebserviceClient.class.getName(), "someProvider",
 						Region.EU_WEST_1.id());
 
 		// Act
 		beanFactory.getBean(beanDefinitionHolder.getBeanName(),
-				AmazonTestWebserviceClient.class);
+				TestWebserviceClient.class);
 
 		// Assert
 	}
@@ -146,10 +145,14 @@ public class AmazonWebserviceClientConfigurationUtilsTest {
 
 		// Act
 		String beanName = AmazonWebserviceClientConfigurationUtils
-				.getBeanName("com.amazonaws.services.rds.AmazonRDS");
+				.getBeanName("software.amazon.awssdk.services.rds.RdsClient");
 
 		// Assert
-		assertThat(beanName).isEqualTo("amazonRDS");
+		// TODO SDK2 migration: should it stay this way? See
+		// org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName
+		// as well.
+		// This is also a breaking change because before it was amazonRDS (upper case)
+		assertThat(beanName).isEqualTo("amazonRds");
 	}
 
 	private static class StaticAwsCredentialsProvider implements AwsCredentialsProvider {

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.core.config;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 
@@ -29,6 +30,25 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class AmazonWebserviceClientFactoryBeanTest {
 
+	@Test
+	public void getObject_withCustomRegion_returnsClientWithCustomRegion()
+		throws Exception {
+
+		// Arrange
+		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
+			AmazonTestWebserviceClient.class,
+			StaticCredentialsProvider
+				.create(AwsBasicCredentials.create("aaa", "bbb")));
+		factoryBean.setCustomRegion("eu-west-1");
+
+		// Act
+		factoryBean.afterPropertiesSet();
+		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
+
+		// Assert
+		assertThat(webserviceClient.getRegion()).isEqualTo(Region.EU_WEST_1);
+
+	}
 	@Test
 	public void getObject_withRegionProvider_returnsClientWithRegionReturnedByProvider()
 			throws Exception {

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
@@ -32,36 +32,36 @@ public class AmazonWebserviceClientFactoryBeanTest {
 
 	@Test
 	public void getObject_withCustomRegion_returnsClientWithCustomRegion()
-		throws Exception {
+			throws Exception {
 
 		// Arrange
-		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
-			AmazonTestWebserviceClient.class,
-			StaticCredentialsProvider
-				.create(AwsBasicCredentials.create("aaa", "bbb")));
+		AmazonWebserviceClientFactoryBean<TestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
+				TestWebserviceClient.class, StaticCredentialsProvider
+						.create(AwsBasicCredentials.create("aaa", "bbb")));
 		factoryBean.setCustomRegion("eu-west-1");
 
 		// Act
 		factoryBean.afterPropertiesSet();
-		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
+		TestWebserviceClient webserviceClient = factoryBean.getObject();
 
 		// Assert
 		assertThat(webserviceClient.getRegion()).isEqualTo(Region.EU_WEST_1);
 
 	}
+
 	@Test
 	public void getObject_withRegionProvider_returnsClientWithRegionReturnedByProvider()
 			throws Exception {
 
 		// Arrange
-		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
-				AmazonTestWebserviceClient.class, StaticCredentialsProvider
+		AmazonWebserviceClientFactoryBean<TestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
+				TestWebserviceClient.class, StaticCredentialsProvider
 						.create(AwsBasicCredentials.create("aaa", "bbb")));
 		factoryBean.setRegionProvider(new StaticRegionProvider("eu-west-1"));
 
 		// Act
 		factoryBean.afterPropertiesSet();
-		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
+		TestWebserviceClient webserviceClient = factoryBean.getObject();
 
 		// Assert
 		assertThat(webserviceClient.getRegion().id()).isEqualTo("eu-west-1");

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBeanTest.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.aws.core.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 
@@ -30,32 +30,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AmazonWebserviceClientFactoryBeanTest {
 
 	@Test
-	public void getObject_withCustomRegion_returnsClientWithCustomRegion()
-			throws Exception {
-
-		// Arrange
-		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
-				AmazonTestWebserviceClient.class,
-				new AWSStaticCredentialsProvider(new BasicAWSCredentials("aaa", "bbb")));
-		factoryBean.setCustomRegion("eu-west-1");
-
-		// Act
-		factoryBean.afterPropertiesSet();
-		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
-
-		// Assert
-		assertThat(webserviceClient.getRegion().getName()).isEqualTo("eu-west-1");
-
-	}
-
-	@Test
 	public void getObject_withRegionProvider_returnsClientWithRegionReturnedByProvider()
 			throws Exception {
 
 		// Arrange
 		AmazonWebserviceClientFactoryBean<AmazonTestWebserviceClient> factoryBean = new AmazonWebserviceClientFactoryBean<>(
-				AmazonTestWebserviceClient.class,
-				new AWSStaticCredentialsProvider(new BasicAWSCredentials("aaa", "bbb")));
+				AmazonTestWebserviceClient.class, StaticCredentialsProvider
+						.create(AwsBasicCredentials.create("aaa", "bbb")));
 		factoryBean.setRegionProvider(new StaticRegionProvider("eu-west-1"));
 
 		// Act
@@ -63,7 +44,7 @@ public class AmazonWebserviceClientFactoryBeanTest {
 		AmazonTestWebserviceClient webserviceClient = factoryBean.getObject();
 
 		// Assert
-		assertThat(webserviceClient.getRegion().getName()).isEqualTo("eu-west-1");
+		assertThat(webserviceClient.getRegion().id()).isEqualTo("eu-west-1");
 
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/DefaultAmazonTestWebserviceClient.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/DefaultAmazonTestWebserviceClient.java
@@ -16,19 +16,29 @@
 
 package org.springframework.cloud.aws.core.config;
 
-import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.regions.Region;
 
-/**
- * @author Agim Emruli Test stub used by
- * {@link AmazonWebserviceClientConfigurationUtilsTest}
- */
-public interface AmazonTestWebserviceClient extends SdkClient {
+public class DefaultAmazonTestWebserviceClient implements AmazonTestWebserviceClient {
 
-	static AmazonTestWebserviceClientBuilder builder() {
-		return new AmazonTestWebserviceClientBuilder();
+	private final Region region;
+
+	public DefaultAmazonTestWebserviceClient(Region region) {
+		this.region = region;
 	}
 
-	Region getRegion();
+	@Override
+	public String serviceName() {
+		return "test";
+	}
+
+	@Override
+	public void close() {
+
+	}
+
+	@Override
+	public Region getRegion() {
+		return region;
+	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/DefaultTestWebserviceClient.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/DefaultTestWebserviceClient.java
@@ -18,11 +18,11 @@ package org.springframework.cloud.aws.core.config;
 
 import software.amazon.awssdk.regions.Region;
 
-public class DefaultAmazonTestWebserviceClient implements AmazonTestWebserviceClient {
+public class DefaultTestWebserviceClient implements TestWebserviceClient {
 
 	private final Region region;
 
-	public DefaultAmazonTestWebserviceClient(Region region) {
+	public DefaultTestWebserviceClient(Region region) {
 		this.region = region;
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/TestWebserviceClient.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/config/TestWebserviceClient.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.regions.Region;
  * @author Agim Emruli Test stub used by
  * {@link AmazonWebserviceClientConfigurationUtilsTest}
  */
-public interface AmazonTestWebserviceClient extends SdkClient {
+public interface TestWebserviceClient extends SdkClient {
 
 	static AmazonTestWebserviceClientBuilder builder() {
 		return new AmazonTestWebserviceClientBuilder();

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
@@ -79,7 +79,8 @@ public class CredentialsProviderFactoryBeanTest {
 		AwsBasicCredentials foo = AwsBasicCredentials.create("foo", "foo");
 		AwsBasicCredentials bar = AwsBasicCredentials.create("bar", "bar");
 
-		when(first.resolveCredentials()).thenReturn(null, foo);
+		when(first.resolveCredentials())
+				.thenThrow(new RuntimeException("first call fails")).thenReturn(foo);
 		when(second.resolveCredentials()).thenReturn(bar);
 
 		assertThat(provider.resolveCredentials()).isEqualTo(bar);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/credentials/CredentialsProviderFactoryBeanTest.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.aws.core.credentials;
 
 import java.util.Arrays;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -56,35 +56,34 @@ public class CredentialsProviderFactoryBeanTest {
 		credentialsProviderFactoryBean.afterPropertiesSet();
 
 		// Act
-		AWSCredentialsProvider credentialsProvider = credentialsProviderFactoryBean
+		AwsCredentialsProvider credentialsProvider = credentialsProviderFactoryBean
 				.getObject();
 
 		// Assert
 		assertThat(credentialsProvider).isNotNull();
-		assertThat(
-				DefaultAWSCredentialsProviderChain.class.isInstance(credentialsProvider))
-						.isTrue();
+		assertThat(DefaultCredentialsProvider.class.isInstance(credentialsProvider))
+				.isTrue();
 	}
 
 	@Test
 	public void testCreateWithMultiple() throws Exception {
-		AWSCredentialsProvider first = mock(AWSCredentialsProvider.class);
-		AWSCredentialsProvider second = mock(AWSCredentialsProvider.class);
+		AwsCredentialsProvider first = mock(AwsCredentialsProvider.class);
+		AwsCredentialsProvider second = mock(AwsCredentialsProvider.class);
 
 		CredentialsProviderFactoryBean credentialsProviderFactoryBean = new CredentialsProviderFactoryBean(
 				Arrays.asList(first, second));
 		credentialsProviderFactoryBean.afterPropertiesSet();
 
-		AWSCredentialsProvider provider = credentialsProviderFactoryBean.getObject();
+		AwsCredentialsProvider provider = credentialsProviderFactoryBean.getObject();
 
-		BasicAWSCredentials foo = new BasicAWSCredentials("foo", "foo");
-		BasicAWSCredentials bar = new BasicAWSCredentials("bar", "bar");
+		AwsBasicCredentials foo = AwsBasicCredentials.create("foo", "foo");
+		AwsBasicCredentials bar = AwsBasicCredentials.create("bar", "bar");
 
-		when(first.getCredentials()).thenReturn(null, foo);
-		when(second.getCredentials()).thenReturn(bar);
+		when(first.resolveCredentials()).thenReturn(null, foo);
+		when(second.resolveCredentials()).thenReturn(bar);
 
-		assertThat(provider.getCredentials()).isEqualTo(bar);
-		assertThat(provider.getCredentials()).isEqualTo(foo);
+		assertThat(provider.resolveCredentials()).isEqualTo(bar);
+		assertThat(provider.resolveCredentials()).isEqualTo(foo);
 	}
 
 }

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceTest.java
@@ -22,8 +22,6 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
-import com.amazonaws.SDKGlobalConfiguration;
-import com.amazonaws.util.EC2MetadataUtils;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -31,6 +29,8 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.util.SocketUtils;
 
@@ -65,14 +65,13 @@ public class AmazonEc2InstanceDataPropertySourceTest {
 
 	private static void overwriteMetadataEndpointUrl(
 			String localMetadataServiceEndpointUrl) {
-		System.setProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+		System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
 				localMetadataServiceEndpointUrl);
 	}
 
 	private static void resetMetadataEndpointUrlOverwrite() {
 		System.clearProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+				SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
@@ -16,16 +16,15 @@
 
 package org.springframework.cloud.aws.core.env.ec2;
 
-import java.util.Collections;
 import java.util.Map;
 
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.DescribeTagsRequest;
-import com.amazonaws.services.ec2.model.DescribeTagsResult;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.ResourceType;
-import com.amazonaws.services.ec2.model.TagDescription;
 import org.junit.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeTagsRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeTagsResponse;
+import software.amazon.awssdk.services.ec2.model.Filter;
+import software.amazon.awssdk.services.ec2.model.ResourceType;
+import software.amazon.awssdk.services.ec2.model.TagDescription;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -40,20 +39,23 @@ public class AmazonEc2InstanceUserTagsFactoryBeanTest {
 	public void getObject_userTagDataAvailable_objectContainsAllAvailableKeys()
 			throws Exception {
 		// Arrange
-		AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
+		Ec2Client amazonEC2 = mock(Ec2Client.class);
 
 		InstanceIdProvider instanceIdProvider = mock(InstanceIdProvider.class);
 		when(instanceIdProvider.getCurrentInstanceId()).thenReturn("1234567890");
 
-		DescribeTagsRequest describeTagsRequest = new DescribeTagsRequest().withFilters(
-				new Filter("resource-id", Collections.singletonList("1234567890")),
-				new Filter("resource-type", Collections.singletonList("instance")));
+		DescribeTagsRequest describeTagsRequest = DescribeTagsRequest.builder()
+				.filters(
+						Filter.builder().name("resource-id").values("1234567890").build(),
+						Filter.builder().name("resource-type").values("instance").build())
+				.build();
 
-		DescribeTagsResult describeTagsResult = new DescribeTagsResult().withTags(
-				new TagDescription().withKey("keyA")
-						.withResourceType(ResourceType.Instance).withValue("valueA"),
-				new TagDescription().withKey("keyB")
-						.withResourceType(ResourceType.Instance).withValue("valueB"));
+		DescribeTagsResponse describeTagsResult = DescribeTagsResponse.builder().tags(
+				TagDescription.builder().key("keyA").resourceType(ResourceType.INSTANCE)
+						.value("valueA").build(),
+				TagDescription.builder().key("keyB").resourceType(ResourceType.INSTANCE)
+						.value("keyB").build())
+				.build();
 
 		when(amazonEC2.describeTags(describeTagsRequest)).thenReturn(describeTagsResult);
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanTest.java
@@ -54,7 +54,7 @@ public class AmazonEc2InstanceUserTagsFactoryBeanTest {
 				TagDescription.builder().key("keyA").resourceType(ResourceType.INSTANCE)
 						.value("valueA").build(),
 				TagDescription.builder().key("keyB").resourceType(ResourceType.INSTANCE)
-						.value("keyB").build())
+						.value("valueB").build())
 				.build();
 
 		when(amazonEC2.describeTags(describeTagsRequest)).thenReturn(describeTagsResult);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBeanTest.java
@@ -95,10 +95,8 @@ public class StackResourceRegistryFactoryBeanTest {
 				.entrySet()) {
 			String stackName = entry.getKey();
 
-			ListStackResourcesResponse listStackResourcesResult = mock(
-					ListStackResourcesResponse.class);
-			when(listStackResourcesResult.stackResourceSummaries())
-					.thenReturn(entry.getValue());
+			ListStackResourcesResponse listStackResourcesResult = ListStackResourcesResponse
+					.builder().stackResourceSummaries(entry.getValue()).build();
 
 			when(amazonCloudFormationClient.listStackResources(
 					ArgumentMatchers.<ListStackResourcesRequest>argThat(
@@ -111,12 +109,12 @@ public class StackResourceRegistryFactoryBeanTest {
 
 	private static StackResourceSummary makeStackResourceSummary(String logicalResourceId,
 			String physicalResourceId) {
-		StackResourceSummary stackResourceSummary = mock(StackResourceSummary.class);
-		when(stackResourceSummary.logicalResourceId()).thenReturn(logicalResourceId);
-		when(stackResourceSummary.physicalResourceId()).thenReturn(physicalResourceId);
-		when(stackResourceSummary.resourceType())
-				.thenReturn(logicalResourceId.endsWith("Stack")
-						? "AWS::CloudFormation::Stack" : "Amazon::SES::Test");
+		StackResourceSummary stackResourceSummary = StackResourceSummary.builder()
+				.logicalResourceId(logicalResourceId)
+				.physicalResourceId(physicalResourceId)
+				.resourceType(logicalResourceId.endsWith("Stack")
+						? "AWS::CloudFormation::Stack" : "Amazon::SES::Test")
+				.build();
 		return stackResourceSummary;
 	}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBeanTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceUserTagsFactoryBeanTest.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.aws.core.env.stack.config;
 
 import java.util.Map;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
-import com.amazonaws.services.cloudformation.model.Stack;
-import com.amazonaws.services.cloudformation.model.Tag;
 import org.junit.Test;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksResponse;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.cloudformation.model.Tag;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -37,15 +37,18 @@ public class StackResourceUserTagsFactoryBeanTest {
 	@Test
 	public void getObject_stackWithTagsDefined_createTagsMap() throws Exception {
 		// Arrange
-		AmazonCloudFormation cloudFormation = mock(AmazonCloudFormation.class);
+		CloudFormationClient cloudFormation = mock(CloudFormationClient.class);
 		StackNameProvider stackNameProvider = mock(StackNameProvider.class);
 
 		when(stackNameProvider.getStackName()).thenReturn("testStack");
-		when(cloudFormation
-				.describeStacks(new DescribeStacksRequest().withStackName("testStack")))
-						.thenReturn(new DescribeStacksResult().withStacks(new Stack()
-								.withTags(new Tag().withKey("key1").withValue("value1"),
-										new Tag().withKey("key2").withValue("value2"))));
+		when(cloudFormation.describeStacks(DescribeStacksRequest.builder()
+				.stackName("testStack").build())).thenReturn(DescribeStacksResponse
+						.builder()
+						.stacks(Stack.builder()
+								.tags(Tag.builder().key("key1").value("value1").build(),
+										Tag.builder().key("key2").value("value2").build())
+								.build())
+						.build());
 
 		StackResourceUserTagsFactoryBean factoryBean = new StackResourceUserTagsFactoryBean(
 				cloudFormation, stackNameProvider);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
@@ -19,15 +19,18 @@ package org.springframework.cloud.aws.core.io.s3;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Agim Emruli
  */
-// TODO SDK2 migration: test for missing header
 public class AmazonS3ClientFactoryTest {
 
 	@Rule
@@ -40,7 +43,7 @@ public class AmazonS3ClientFactoryTest {
 		S3Client amazonS3 = S3Client.builder().region(Region.US_WEST_2).build();
 
 		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("Endpoint Url must not be null");
+		this.expectedException.expectMessage("Region must not be null");
 
 		// Act
 		amazonS3ClientFactory.createClientForRegion(amazonS3, null);
@@ -75,8 +78,10 @@ public class AmazonS3ClientFactoryTest {
 				"us-west-1");
 
 		// Prepare
-		// TODO SDK2 migration: update and uncomment
-		// assertThat(newClient.getRegionName()).isEqualTo(Region.US_WEST_1);
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(newClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(AwsClientOption.AWS_REGION))
+				.isEqualTo(Region.US_WEST_1);
 	}
 
 	@Test
@@ -90,8 +95,10 @@ public class AmazonS3ClientFactoryTest {
 				"eu-central-1");
 
 		// Prepare
-		// TODO SDK2 migration: update and uncomment
-		// assertThat(newClient.getRegionName()).isEqualTo(Regions.EU_CENTRAL_1.getName());
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(newClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(AwsClientOption.AWS_REGION))
+				.isEqualTo(Region.EU_CENTRAL_1);
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ClientFactoryTest.java
@@ -16,18 +16,18 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Agim Emruli
  */
+// TODO SDK2 migration: test for missing header
 public class AmazonS3ClientFactoryTest {
 
 	@Rule
@@ -37,14 +37,13 @@ public class AmazonS3ClientFactoryTest {
 	public void createClientForEndpointUrl_withNullEndpoint_throwsIllegalArgumentException() {
 		// Arrange
 		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
-		AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard()
-				.withRegion(Regions.DEFAULT_REGION).build();
+		S3Client amazonS3 = S3Client.builder().region(Region.US_WEST_2).build();
 
 		this.expectedException.expect(IllegalArgumentException.class);
 		this.expectedException.expectMessage("Endpoint Url must not be null");
 
 		// Act
-		amazonS3ClientFactory.createClientForEndpointUrl(amazonS3, null);
+		amazonS3ClientFactory.createClientForRegion(amazonS3, null);
 
 		// Prepare
 
@@ -59,71 +58,54 @@ public class AmazonS3ClientFactoryTest {
 		this.expectedException.expectMessage("AmazonS3 must not be null");
 
 		// Act
-		amazonS3ClientFactory.createClientForEndpointUrl(null,
-				"https://s3.amazonaws.com");
+		amazonS3ClientFactory.createClientForRegion(null, "eu-central-1");
 
 		// Prepare
 
 	}
 
 	@Test
-	public void createClientForEndpointUrl_withDefaultRegionUrl_createClientForDefaultRegion() {
+	public void createClientForEndpointUrl_withRegion_createClientForRegion() {
 		// Arrange
 		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
-		AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard()
-				.withRegion(Regions.EU_CENTRAL_1).build();
+		S3Client amazonS3 = S3Client.builder().region(Region.EU_CENTRAL_1).build();
 
 		// Act
-		AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
-				"https://s3.amazonaws.com");
+		S3Client newClient = amazonS3ClientFactory.createClientForRegion(amazonS3,
+				"us-west-1");
 
 		// Prepare
-		assertThat(newClient.getRegionName()).isEqualTo(Regions.DEFAULT_REGION.getName());
-	}
-
-	@Test
-	public void createClientForEndpointUrl_withCustomRegionUrl_createClientForCustomRegion() {
-		// Arrange
-		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
-		AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1)
-				.build();
-
-		// Act
-		AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
-				"https://myBucket.s3.eu-central-1.amazonaws.com");
-
-		// Prepare
-		assertThat(newClient.getRegionName()).isEqualTo(Regions.EU_CENTRAL_1.getName());
+		// TODO SDK2 migration: update and uncomment
+		// assertThat(newClient.getRegionName()).isEqualTo(Region.US_WEST_1);
 	}
 
 	@Test
 	public void createClientForEndpointUrl_withProxiedClient_createClientForCustomRegion() {
 		// Arrange
 		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
-		AmazonS3 amazonS3 = AmazonS3ProxyFactory.createProxy(
-				AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1).build());
+		S3Client amazonS3 = S3Client.builder().region(Region.EU_WEST_1).build();
 
 		// Act
-		AmazonS3 newClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
-				"https://myBucket.s3.eu-central-1.amazonaws.com");
+		S3Client newClient = amazonS3ClientFactory.createClientForRegion(amazonS3,
+				"eu-central-1");
 
 		// Prepare
-		assertThat(newClient.getRegionName()).isEqualTo(Regions.EU_CENTRAL_1.getName());
+		// TODO SDK2 migration: update and uncomment
+		// assertThat(newClient.getRegionName()).isEqualTo(Regions.EU_CENTRAL_1.getName());
 	}
 
 	@Test
 	public void createClientForEndpointUrl_withCustomRegionUrlAndCachedClient_returnsCachedClient() {
 		// Arrange
 		AmazonS3ClientFactory amazonS3ClientFactory = new AmazonS3ClientFactory();
-		AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_WEST_1)
-				.build();
+		S3Client amazonS3 = S3Client.builder().region(Region.EU_WEST_1).build();
 
-		AmazonS3 existingClient = amazonS3ClientFactory.createClientForEndpointUrl(
-				amazonS3, "https://myBucket.s3.eu-central-1.amazonaws.com");
+		S3Client existingClient = amazonS3ClientFactory.createClientForRegion(amazonS3,
+				"eu-central-1");
 
 		// Act
-		AmazonS3 cachedClient = amazonS3ClientFactory.createClientForEndpointUrl(amazonS3,
-				"https://myBucket.s3.eu-central-1.amazonaws.com");
+		S3Client cachedClient = amazonS3ClientFactory.createClientForRegion(amazonS3,
+				"eu-central-1");
 
 		// Prepare
 		assertThat(existingClient).isSameAs(cachedClient);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
@@ -19,13 +19,11 @@ package org.springframework.cloud.aws.core.io.s3;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
@@ -43,10 +41,10 @@ public class AmazonS3ProxyFactoryTest {
 	@Test
 	public void verifyBasicAdvice() throws Exception {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 		assertThat(AopUtils.isAopProxy(amazonS3)).isFalse();
 
-		AmazonS3 proxy = AmazonS3ProxyFactory.createProxy(amazonS3);
+		S3Client proxy = AmazonS3ProxyFactory.createProxy(amazonS3);
 		assertThat(AopUtils.isAopProxy(proxy)).isTrue();
 
 		Advised advised = (Advised) proxy;
@@ -59,9 +57,9 @@ public class AmazonS3ProxyFactoryTest {
 	@Test
 	public void verifyDoubleWrappingHandled() throws Exception {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
-		AmazonS3 proxy = AmazonS3ProxyFactory
+		S3Client proxy = AmazonS3ProxyFactory
 				.createProxy(AmazonS3ProxyFactory.createProxy(amazonS3));
 		assertThat(AopUtils.isAopProxy(proxy)).isTrue();
 
@@ -75,32 +73,31 @@ public class AmazonS3ProxyFactoryTest {
 	@Test
 	public void verifyPolymorphicHandling() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		AmazonS3 proxy1 = AmazonS3ProxyFactory.createProxy(amazonS3);
+		S3Client amazonS3 = mock(S3Client.class);
+		S3Client proxy1 = AmazonS3ProxyFactory.createProxy(amazonS3);
 
-		assertThat(AmazonS3.class.isAssignableFrom(proxy1.getClass())).isTrue();
-		assertThat(AmazonS3Client.class.isAssignableFrom(proxy1.getClass())).isFalse();
+		assertThat(S3Client.class.isAssignableFrom(proxy1.getClass())).isTrue();
+		assertThat(S3Client.class.isAssignableFrom(proxy1.getClass())).isFalse();
 
-		AmazonS3 amazonS3Client = AmazonS3ClientBuilder.standard()
-				.withRegion(Regions.DEFAULT_REGION).build();
-		AmazonS3 proxy2 = AmazonS3ProxyFactory.createProxy(amazonS3Client);
+		S3Client amazonS3Client = S3Client.builder().region(Region.US_WEST_2).build();
+		S3Client proxy2 = AmazonS3ProxyFactory.createProxy(amazonS3Client);
 
-		assertThat(AmazonS3.class.isAssignableFrom(proxy2.getClass())).isTrue();
+		assertThat(S3Client.class.isAssignableFrom(proxy2.getClass())).isTrue();
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
 	public void verifyAddingRedirectAdviceToExistingProxy() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		ProxyFactory factory = new ProxyFactory(amazonS3);
 		factory.addAdvice(new TestAdvice());
-		AmazonS3 proxy1 = (AmazonS3) factory.getProxy();
+		S3Client proxy1 = (S3Client) factory.getProxy();
 
 		assertThat(((Advised) proxy1).getAdvisors().length).isEqualTo(1);
 
-		AmazonS3 proxy2 = AmazonS3ProxyFactory.createProxy(proxy1);
+		S3Client proxy2 = AmazonS3ProxyFactory.createProxy(proxy1);
 		Advised advised = (Advised) proxy2;
 
 		assertThat(advised.getAdvisors().length).isEqualTo(2);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/AmazonS3ProxyFactoryTest.java
@@ -29,6 +29,7 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.util.ClassUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -72,12 +73,14 @@ public class AmazonS3ProxyFactoryTest {
 
 	@Test
 	public void verifyPolymorphicHandling() {
+		Class<?> defaultS3ClientClass = ClassUtils.resolveClassName(
+				"software.amazon.awssdk.services.s3.DefaultS3Client", null);
 
 		S3Client amazonS3 = mock(S3Client.class);
 		S3Client proxy1 = AmazonS3ProxyFactory.createProxy(amazonS3);
 
 		assertThat(S3Client.class.isAssignableFrom(proxy1.getClass())).isTrue();
-		assertThat(S3Client.class.isAssignableFrom(proxy1.getClass())).isFalse();
+		assertThat(defaultS3ClientClass.isAssignableFrom(proxy1.getClass())).isFalse();
 
 		S3Client amazonS3Client = S3Client.builder().region(Region.US_WEST_2).build();
 		S3Client proxy2 = AmazonS3ProxyFactory.createProxy(amazonS3Client);

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -127,17 +127,17 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooOne/bazOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt")),
-				Collections.emptyList(), true);
+				Collections.emptyList(), "token1");
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, null, null))))
 						.thenReturn(objectListingWithoutPrefixPart1);
 
 		ListObjectsV2Response objectListingWithoutPrefixPart2 = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooThree/baz/test.txt"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, null, "token1"))))
 						.thenReturn(objectListingWithoutPrefixPart2);
 
 		// With prefix calls
@@ -145,33 +145,33 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Collections.emptyList(),
 				Arrays.asList(CommonPrefix.builder().prefix("dooOne/").build(),
 						CommonPrefix.builder().prefix("dooTwo/").build()),
-				true);
+				"token2");
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, "/", null))))
 						.thenReturn(objectListingWithPrefixPart1);
 
 		ListObjectsV2Response objectListingWithPrefixPart2 = createObjectListingMock(
 				Collections.emptyList(), Collections.singletonList(
 						CommonPrefix.builder().prefix("fooOne/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, "/", "token2"))))
 						.thenReturn(objectListingWithPrefixPart2);
 
 		ListObjectsV2Response objectListingWithPrefixFooOne = createObjectListingMock(
 				Collections.emptyList(), Collections.singletonList(
 						CommonPrefix.builder().prefix("fooOne/barOne/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/", null))))
 						.thenReturn(objectListingWithPrefixFooOne);
 
 		ListObjectsV2Response objectListingWithPrefixFooOneBarOne = createObjectListingMock(
 				Collections.singletonList(
 						createS3ObjectSummaryWithKey("fooOne/barOne/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(argThat(
-				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/"))))
+				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/", null))))
 						.thenReturn(objectListingWithPrefixFooOneBarOne);
 
 		when(amazonS3.headObject(any(HeadObjectRequest.class)))
@@ -192,20 +192,20 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		// Mocks for the '**' case
 		ListObjectsV2Response objectListingWithOneFile = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		ListObjectsV2Response emptyObjectListing = createObjectListingMock(
-				Collections.emptyList(), Collections.emptyList(), false);
+				Collections.emptyList(), Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucketOne", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBucketOne", null, null, null))))
 						.thenReturn(objectListingWithOneFile);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucketTwo", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBucketTwo", null, null, null))))
 						.thenReturn(emptyObjectListing);
-		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("anotherBucket", null, null))))
+		when(amazonS3.listObjectsV2(argThat(
+				new ListObjectsRequestMatcher("anotherBucket", null, null, null))))
 						.thenReturn(objectListingWithOneFile);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBuckez", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBuckez", null, null, null))))
 						.thenReturn(emptyObjectListing);
 
 		when(amazonS3.headObject(any(HeadObjectRequest.class)))
@@ -235,9 +235,9 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 						CommonPrefix.builder().prefix("fooOne/").build(),
 						CommonPrefix.builder().prefix("fooThree/").build(),
 						CommonPrefix.builder().prefix("fooTwo/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, "/", null))))
 						.thenReturn(objectListingMockAtRoot);
 
 		// Requests on fooOne
@@ -245,25 +245,25 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooOne/")),
 				Arrays.asList(CommonPrefix.builder().prefix("fooOne/barOne/").build(),
 						CommonPrefix.builder().prefix("fooOne/bazOne/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/", null))))
 						.thenReturn(objectListingFooOne);
 
 		ListObjectsV2Response objectListingFooOneBarOne = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/"),
 						createS3ObjectSummaryWithKey("fooOne/barOne/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(argThat(
-				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/"))))
+				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/", null))))
 						.thenReturn(objectListingFooOneBarOne);
 
 		ListObjectsV2Response objectListingFooOneBazOne = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/bazOne/"),
 						createS3ObjectSummaryWithKey("fooOne/bazOne/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(argThat(
-				new ListObjectsRequestMatcher("myBucket", "fooOne/bazOne/", "/"))))
+				new ListObjectsRequestMatcher("myBucket", "fooOne/bazOne/", "/", null))))
 						.thenReturn(objectListingFooOneBazOne);
 
 		// Requests on fooTwo
@@ -271,17 +271,17 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooTwo/")),
 				Collections.singletonList(
 						CommonPrefix.builder().prefix("fooTwo/barTwo/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "fooTwo/", "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", "fooTwo/", "/", null))))
 						.thenReturn(objectListingFooTwo);
 
 		ListObjectsV2Response objectListingFooTwoBarTwo = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooTwo/barTwo/"),
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(argThat(
-				new ListObjectsRequestMatcher("myBucket", "fooTwo/barTwo/", "/"))))
+				new ListObjectsRequestMatcher("myBucket", "fooTwo/barTwo/", "/", null))))
 						.thenReturn(objectListingFooTwoBarTwo);
 
 		// Requests on fooThree
@@ -289,17 +289,17 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooThree/")),
 				Collections.singletonList(
 						CommonPrefix.builder().prefix("fooTwo/baz/").build()),
-				false);
-		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "fooThree/", "/"))))
+				null);
+		when(amazonS3.listObjectsV2(argThat(
+				new ListObjectsRequestMatcher("myBucket", "fooThree/", "/", null))))
 						.thenReturn(objectListingFooThree);
 
 		ListObjectsV2Response objectListingFooThreeBaz = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooThree/baz/"),
 						createS3ObjectSummaryWithKey("fooThree/baz/test.txt")),
-				Collections.emptyList(), false);
-		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "fooThree/baz/", "/"))))
+				Collections.emptyList(), null);
+		when(amazonS3.listObjectsV2(argThat(
+				new ListObjectsRequestMatcher("myBucket", "fooThree/baz/", "/", null))))
 						.thenReturn(objectListingFooThreeBaz);
 
 		// Requests for foFour
@@ -307,17 +307,17 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				Collections.singletonList(createS3ObjectSummaryWithKey("foFour/")),
 				Collections.singletonList(
 						CommonPrefix.builder().prefix("foFour/barFour/").build()),
-				false);
+				null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", "foFour/", "/"))))
+				argThat(new ListObjectsRequestMatcher("myBucket", "foFour/", "/", null))))
 						.thenReturn(objectListingFoFour);
 
 		ListObjectsV2Response objectListingFoFourBarFour = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("foFour/barFour/"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(argThat(
-				new ListObjectsRequestMatcher("myBucket", "foFour/barFour/", "/"))))
+				new ListObjectsRequestMatcher("myBucket", "foFour/barFour/", "/", null))))
 						.thenReturn(objectListingFoFourBarFour);
 
 		// Requests for all
@@ -327,9 +327,9 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt"),
 						createS3ObjectSummaryWithKey("fooThree/baz/test.txt"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
-				Collections.emptyList(), false);
+				Collections.emptyList(), null);
 		when(amazonS3.listObjectsV2(
-				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
+				argThat(new ListObjectsRequestMatcher("myBucket", null, null, null))))
 						.thenReturn(fullObjectListing);
 
 		when(amazonS3.headObject(any(HeadObjectRequest.class)))
@@ -338,12 +338,12 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		return amazonS3;
 	}
 
-	private ListObjectsV2Response createObjectListingMock(List<S3Object> objectSummaries,
-			List<CommonPrefix> commonPrefixes, boolean truncated) {
-		ListObjectsV2Response objectListing = mock(ListObjectsV2Response.class);
-		when(objectListing.contents()).thenReturn(objectSummaries);
-		when(objectListing.commonPrefixes()).thenReturn(commonPrefixes);
-		when(objectListing.isTruncated()).thenReturn(truncated);
+	private ListObjectsV2Response createObjectListingMock(List<S3Object> contents,
+			List<CommonPrefix> commonPrefixes, String nextContinuationToken) {
+		ListObjectsV2Response objectListing = ListObjectsV2Response.builder()
+				.contents(contents).commonPrefixes(commonPrefixes)
+				.isTruncated(nextContinuationToken != null)
+				.nextContinuationToken(nextContinuationToken).build();
 		return objectListing;
 	}
 
@@ -367,11 +367,14 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
 		private final String delimiter;
 
+		private final String continuationToken;
+
 		private ListObjectsRequestMatcher(String bucketName, String prefix,
-				String delimiter) {
+				String delimiter, String continuationToken) {
 			this.bucketName = bucketName;
 			this.prefix = prefix;
 			this.delimiter = delimiter;
+			this.continuationToken = continuationToken;
 		}
 
 		@Override
@@ -403,7 +406,17 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				delimiterIsEqual = this.delimiter == null;
 			}
 
-			return delimiterIsEqual && prefixIsEqual && bucketNameIsEqual;
+			boolean continuationTokenIsEqual;
+			if (listObjectsRequest.continuationToken() != null) {
+				continuationTokenIsEqual = listObjectsRequest.continuationToken()
+						.equals(this.continuationToken);
+			}
+			else {
+				continuationTokenIsEqual = this.continuationToken == null;
+			}
+
+			return delimiterIsEqual && prefixIsEqual
+					&& bucketNameIsEqual & continuationTokenIsEqual;
 		}
 
 	}

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/PathMatchingSimpleStorageResourcePatternResolverTest.java
@@ -21,15 +21,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -52,7 +54,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
 	@Test
 	public void testWildcardInBucketName() throws Exception {
-		AmazonS3 amazonS3 = prepareMockForTestWildcardInBucketName();
+		S3Client amazonS3 = prepareMockForTestWildcardInBucketName();
 
 		ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
 
@@ -66,7 +68,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
 	@Test
 	public void testWildcardInKey() throws IOException {
-		AmazonS3 amazonS3 = prepareMockForTestWildcardInKey();
+		S3Client amazonS3 = prepareMockForTestWildcardInKey();
 
 		ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
 
@@ -85,7 +87,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
 	@Test
 	public void testLoadingClasspathFile() throws Exception {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 		ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
 
 		Resource[] resources = resourceLoader.getResources(
@@ -102,7 +104,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 
 	@Test
 	public void testTruncatedListings() throws Exception {
-		AmazonS3 amazonS3 = prepareMockForTestTruncatedListings();
+		S3Client amazonS3 = prepareMockForTestTruncatedListings();
 		ResourcePatternResolver resourceLoader = getResourceLoader(amazonS3);
 
 		assertThat(resourceLoader.getResources("s3://myBucket/**/test.txt").length).as(
@@ -117,86 +119,97 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 				.isEqualTo(1);
 	}
 
-	private AmazonS3 prepareMockForTestTruncatedListings() {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+	private S3Client prepareMockForTestTruncatedListings() {
+		S3Client amazonS3 = mock(S3Client.class);
 
 		// Without prefix calls
-		ObjectListing objectListingWithoutPrefixPart1 = createObjectListingMock(
+		ListObjectsV2Response objectListingWithoutPrefixPart1 = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooOne/bazOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt")),
 				Collections.emptyList(), true);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
 						.thenReturn(objectListingWithoutPrefixPart1);
 
-		ObjectListing objectListingWithoutPrefixPart2 = createObjectListingMock(
+		ListObjectsV2Response objectListingWithoutPrefixPart2 = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooThree/baz/test.txt"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listNextBatchOfObjects(objectListingWithoutPrefixPart1))
-				.thenReturn(objectListingWithoutPrefixPart2);
+		when(amazonS3.listObjectsV2(
+				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
+						.thenReturn(objectListingWithoutPrefixPart2);
 
 		// With prefix calls
-		ObjectListing objectListingWithPrefixPart1 = createObjectListingMock(
-				Collections.emptyList(), Arrays.asList("dooOne/", "dooTwo/"), true);
-		when(amazonS3.listObjects(
+		ListObjectsV2Response objectListingWithPrefixPart1 = createObjectListingMock(
+				Collections.emptyList(),
+				Arrays.asList(CommonPrefix.builder().prefix("dooOne/").build(),
+						CommonPrefix.builder().prefix("dooTwo/").build()),
+				true);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
 						.thenReturn(objectListingWithPrefixPart1);
 
-		ObjectListing objectListingWithPrefixPart2 = createObjectListingMock(
-				Collections.emptyList(), Collections.singletonList("fooOne/"), false);
-		when(amazonS3.listNextBatchOfObjects(objectListingWithPrefixPart1))
-				.thenReturn(objectListingWithPrefixPart2);
-
-		ObjectListing objectListingWithPrefixFooOne = createObjectListingMock(
-				Collections.emptyList(), Collections.singletonList("fooOne/barOne/"),
+		ListObjectsV2Response objectListingWithPrefixPart2 = createObjectListingMock(
+				Collections.emptyList(), Collections.singletonList(
+						CommonPrefix.builder().prefix("fooOne/").build()),
 				false);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
+				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
+						.thenReturn(objectListingWithPrefixPart2);
+
+		ListObjectsV2Response objectListingWithPrefixFooOne = createObjectListingMock(
+				Collections.emptyList(), Collections.singletonList(
+						CommonPrefix.builder().prefix("fooOne/barOne/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/"))))
 						.thenReturn(objectListingWithPrefixFooOne);
 
-		ObjectListing objectListingWithPrefixFooOneBarOne = createObjectListingMock(
+		ListObjectsV2Response objectListingWithPrefixFooOneBarOne = createObjectListingMock(
 				Collections.singletonList(
 						createS3ObjectSummaryWithKey("fooOne/barOne/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(argThat(
+		when(amazonS3.listObjectsV2(argThat(
 				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/"))))
 						.thenReturn(objectListingWithPrefixFooOneBarOne);
 
-		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
-				.thenReturn(new ObjectMetadata());
+		when(amazonS3.headObject(any(HeadObjectRequest.class)))
+				.thenReturn(HeadObjectResponse.builder().build());
 
 		return amazonS3;
 	}
 
-	private AmazonS3 prepareMockForTestWildcardInBucketName() {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
-		when(amazonS3.listBuckets()).thenReturn(
-				Arrays.asList(new Bucket("myBucketOne"), new Bucket("myBucketTwo"),
-						new Bucket("anotherBucket"), new Bucket("myBuckez")));
+	private S3Client prepareMockForTestWildcardInBucketName() {
+		S3Client amazonS3 = mock(S3Client.class);
+		when(amazonS3.listBuckets()).thenReturn(ListBucketsResponse.builder()
+				.buckets(Bucket.builder().name("myBucketOne").build(),
+						Bucket.builder().name("myBucketTwo").build(),
+						Bucket.builder().name("anotherBucket").build(),
+						Bucket.builder().name("myBuckez").build())
+				.build());
 
 		// Mocks for the '**' case
-		ObjectListing objectListingWithOneFile = createObjectListingMock(
+		ListObjectsV2Response objectListingWithOneFile = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("test.txt")),
 				Collections.emptyList(), false);
-		ObjectListing emptyObjectListing = createObjectListingMock(
+		ListObjectsV2Response emptyObjectListing = createObjectListingMock(
 				Collections.emptyList(), Collections.emptyList(), false);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucketOne", null, null))))
 						.thenReturn(objectListingWithOneFile);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucketTwo", null, null))))
 						.thenReturn(emptyObjectListing);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("anotherBucket", null, null))))
 						.thenReturn(objectListingWithOneFile);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBuckez", null, null))))
 						.thenReturn(emptyObjectListing);
 
-		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
-				.thenReturn(new ObjectMetadata());
+		when(amazonS3.headObject(any(HeadObjectRequest.class)))
+				.thenReturn(HeadObjectResponse.builder().build());
 		return amazonS3;
 	}
 
@@ -204,127 +217,141 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 	 * Virtual test folder structure: fooOne/barOne/test.txt fooOne/bazOne/test.txt
 	 * fooTwo/barTwo/test.txt fooThree/baz/test.txt foFour/barFour/test.txt .
 	 */
-	private AmazonS3 prepareMockForTestWildcardInKey() {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+	private S3Client prepareMockForTestWildcardInKey() {
+		S3Client amazonS3 = mock(S3Client.class);
 
 		// List buckets mock
-		when(amazonS3.listBuckets()).thenReturn(
-				Arrays.asList(new Bucket("myBucket"), new Bucket("myBuckets")));
+		when(amazonS3.listBuckets())
+				.thenReturn(
+						ListBucketsResponse.builder()
+								.buckets(Bucket.builder().name("myBucket").build(),
+										Bucket.builder().name("myBuckets").build())
+								.build());
 
 		// Root requests
-		ObjectListing objectListingMockAtRoot = createObjectListingMock(
+		ListObjectsV2Response objectListingMockAtRoot = createObjectListingMock(
 				Collections.emptyList(),
-				Arrays.asList("foFour/", "fooOne/", "fooThree/", "fooTwo/"), false);
-		when(amazonS3.listObjects(
+				Arrays.asList(CommonPrefix.builder().prefix("foFour/").build(),
+						CommonPrefix.builder().prefix("fooOne/").build(),
+						CommonPrefix.builder().prefix("fooThree/").build(),
+						CommonPrefix.builder().prefix("fooTwo/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", null, "/"))))
 						.thenReturn(objectListingMockAtRoot);
 
 		// Requests on fooOne
-		ObjectListing objectListingFooOne = createObjectListingMock(
+		ListObjectsV2Response objectListingFooOne = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooOne/")),
-				Arrays.asList("fooOne/barOne/", "fooOne/bazOne/"), false);
-		when(amazonS3.listObjects(
+				Arrays.asList(CommonPrefix.builder().prefix("fooOne/barOne/").build(),
+						CommonPrefix.builder().prefix("fooOne/bazOne/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "fooOne/", "/"))))
 						.thenReturn(objectListingFooOne);
 
-		ObjectListing objectListingFooOneBarOne = createObjectListingMock(
+		ListObjectsV2Response objectListingFooOneBarOne = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/"),
 						createS3ObjectSummaryWithKey("fooOne/barOne/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(argThat(
+		when(amazonS3.listObjectsV2(argThat(
 				new ListObjectsRequestMatcher("myBucket", "fooOne/barOne/", "/"))))
 						.thenReturn(objectListingFooOneBarOne);
 
-		ObjectListing objectListingFooOneBazOne = createObjectListingMock(
+		ListObjectsV2Response objectListingFooOneBazOne = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/bazOne/"),
 						createS3ObjectSummaryWithKey("fooOne/bazOne/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(argThat(
+		when(amazonS3.listObjectsV2(argThat(
 				new ListObjectsRequestMatcher("myBucket", "fooOne/bazOne/", "/"))))
 						.thenReturn(objectListingFooOneBazOne);
 
 		// Requests on fooTwo
-		ObjectListing objectListingFooTwo = createObjectListingMock(
+		ListObjectsV2Response objectListingFooTwo = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooTwo/")),
-				Collections.singletonList("fooTwo/barTwo/"), false);
-		when(amazonS3.listObjects(
+				Collections.singletonList(
+						CommonPrefix.builder().prefix("fooTwo/barTwo/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "fooTwo/", "/"))))
 						.thenReturn(objectListingFooTwo);
 
-		ObjectListing objectListingFooTwoBarTwo = createObjectListingMock(
+		ListObjectsV2Response objectListingFooTwoBarTwo = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooTwo/barTwo/"),
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(argThat(
+		when(amazonS3.listObjectsV2(argThat(
 				new ListObjectsRequestMatcher("myBucket", "fooTwo/barTwo/", "/"))))
 						.thenReturn(objectListingFooTwoBarTwo);
 
 		// Requests on fooThree
-		ObjectListing objectListingFooThree = createObjectListingMock(
+		ListObjectsV2Response objectListingFooThree = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("fooThree/")),
-				Collections.singletonList("fooTwo/baz/"), false);
-		when(amazonS3.listObjects(
+				Collections.singletonList(
+						CommonPrefix.builder().prefix("fooTwo/baz/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "fooThree/", "/"))))
 						.thenReturn(objectListingFooThree);
 
-		ObjectListing objectListingFooThreeBaz = createObjectListingMock(
+		ListObjectsV2Response objectListingFooThreeBaz = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooThree/baz/"),
 						createS3ObjectSummaryWithKey("fooThree/baz/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "fooThree/baz/", "/"))))
 						.thenReturn(objectListingFooThreeBaz);
 
 		// Requests for foFour
-		ObjectListing objectListingFoFour = createObjectListingMock(
+		ListObjectsV2Response objectListingFoFour = createObjectListingMock(
 				Collections.singletonList(createS3ObjectSummaryWithKey("foFour/")),
-				Collections.singletonList("foFour/barFour/"), false);
-		when(amazonS3.listObjects(
+				Collections.singletonList(
+						CommonPrefix.builder().prefix("foFour/barFour/").build()),
+				false);
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", "foFour/", "/"))))
 						.thenReturn(objectListingFoFour);
 
-		ObjectListing objectListingFoFourBarFour = createObjectListingMock(
+		ListObjectsV2Response objectListingFoFourBarFour = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("foFour/barFour/"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(argThat(
+		when(amazonS3.listObjectsV2(argThat(
 				new ListObjectsRequestMatcher("myBucket", "foFour/barFour/", "/"))))
 						.thenReturn(objectListingFoFourBarFour);
 
 		// Requests for all
-		ObjectListing fullObjectListing = createObjectListingMock(
+		ListObjectsV2Response fullObjectListing = createObjectListingMock(
 				Arrays.asList(createS3ObjectSummaryWithKey("fooOne/barOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooOne/bazOne/test.txt"),
 						createS3ObjectSummaryWithKey("fooTwo/barTwo/test.txt"),
 						createS3ObjectSummaryWithKey("fooThree/baz/test.txt"),
 						createS3ObjectSummaryWithKey("foFour/barFour/test.txt")),
 				Collections.emptyList(), false);
-		when(amazonS3.listObjects(
+		when(amazonS3.listObjectsV2(
 				argThat(new ListObjectsRequestMatcher("myBucket", null, null))))
 						.thenReturn(fullObjectListing);
 
-		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
-				.thenReturn(new ObjectMetadata());
+		when(amazonS3.headObject(any(HeadObjectRequest.class)))
+				.thenReturn(HeadObjectResponse.builder().build());
 
 		return amazonS3;
 	}
 
-	private ObjectListing createObjectListingMock(List<S3ObjectSummary> objectSummaries,
-			List<String> commonPrefixes, boolean truncated) {
-		ObjectListing objectListing = mock(ObjectListing.class);
-		when(objectListing.getObjectSummaries()).thenReturn(objectSummaries);
-		when(objectListing.getCommonPrefixes()).thenReturn(commonPrefixes);
+	private ListObjectsV2Response createObjectListingMock(List<S3Object> objectSummaries,
+			List<CommonPrefix> commonPrefixes, boolean truncated) {
+		ListObjectsV2Response objectListing = mock(ListObjectsV2Response.class);
+		when(objectListing.contents()).thenReturn(objectSummaries);
+		when(objectListing.commonPrefixes()).thenReturn(commonPrefixes);
 		when(objectListing.isTruncated()).thenReturn(truncated);
 		return objectListing;
 	}
 
-	private S3ObjectSummary createS3ObjectSummaryWithKey(String key) {
-		S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
-		s3ObjectSummary.setKey(key);
-		return s3ObjectSummary;
+	private S3Object createS3ObjectSummaryWithKey(String key) {
+		return S3Object.builder().key(key).build();
 	}
 
-	private ResourcePatternResolver getResourceLoader(AmazonS3 amazonS3) {
+	private ResourcePatternResolver getResourceLoader(S3Client amazonS3) {
 		DefaultResourceLoader loader = new DefaultResourceLoader();
 		loader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
 		return new PathMatchingSimpleStorageResourcePatternResolver(amazonS3,
@@ -332,7 +359,7 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 	}
 
 	private static final class ListObjectsRequestMatcher
-			implements ArgumentMatcher<ListObjectsRequest> {
+			implements ArgumentMatcher<ListObjectsV2Request> {
 
 		private final String bucketName;
 
@@ -348,31 +375,29 @@ public class PathMatchingSimpleStorageResourcePatternResolverTest {
 		}
 
 		@Override
-		public boolean matches(ListObjectsRequest listObjectsRequest) {
+		public boolean matches(ListObjectsV2Request listObjectsRequest) {
 			if (listObjectsRequest == null) {
 				return false;
 			}
 			boolean bucketNameIsEqual;
-			if (listObjectsRequest.getBucketName() != null) {
-				bucketNameIsEqual = listObjectsRequest.getBucketName()
-						.equals(this.bucketName);
+			if (listObjectsRequest.bucket() != null) {
+				bucketNameIsEqual = listObjectsRequest.bucket().equals(this.bucketName);
 			}
 			else {
 				bucketNameIsEqual = this.bucketName == null;
 			}
 
 			boolean prefixIsEqual;
-			if (listObjectsRequest.getPrefix() != null) {
-				prefixIsEqual = listObjectsRequest.getPrefix().equals(this.prefix);
+			if (listObjectsRequest.prefix() != null) {
+				prefixIsEqual = listObjectsRequest.prefix().equals(this.prefix);
 			}
 			else {
 				prefixIsEqual = this.prefix == null;
 			}
 
 			boolean delimiterIsEqual;
-			if (listObjectsRequest.getDelimiter() != null) {
-				delimiterIsEqual = listObjectsRequest.getDelimiter()
-						.equals(this.delimiter);
+			if (listObjectsRequest.delimiter() != null) {
+				delimiterIsEqual = listObjectsRequest.delimiter().equals(this.delimiter);
 			}
 			else {
 				delimiterIsEqual = this.delimiter == null;

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolverTest.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -28,8 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -42,14 +40,14 @@ public class SimpleStorageProtocolResolverTest {
 	@Test
 	public void testGetResourceWithExistingResource() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
 
-		ObjectMetadata metadata = new ObjectMetadata();
-		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
-				.thenReturn(metadata);
+		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().build();
+		when(amazonS3.headObject(any(HeadObjectRequest.class)))
+				.thenReturn(headObjectResponse);
 
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);
@@ -59,7 +57,7 @@ public class SimpleStorageProtocolResolverTest {
 	@Test
 	public void testGetResourceWithNonExistingResource() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
@@ -71,15 +69,14 @@ public class SimpleStorageProtocolResolverTest {
 
 	@Test
 	public void testGetResourceWithVersionId() {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		SimpleStorageProtocolResolver resourceLoader = new SimpleStorageProtocolResolver(
 				amazonS3);
 
-		ObjectMetadata metadata = new ObjectMetadata();
-
-		when(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class)))
-				.thenReturn(metadata);
+		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().build();
+		when(amazonS3.headObject(any(HeadObjectRequest.class)))
+				.thenReturn(headObjectResponse);
 
 		String resourceName = "s3://bucket/object^versionIdValue";
 		Resource resource = resourceLoader.resolve(resourceName,
@@ -90,7 +87,7 @@ public class SimpleStorageProtocolResolverTest {
 	@Test
 	public void testGetResourceWithDifferentPatterns() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
@@ -102,13 +99,14 @@ public class SimpleStorageProtocolResolverTest {
 		assertThat(resourceLoader.getResource("s3://prefix.bucket/object.suffix"))
 				.isNotNull();
 
-		verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
+		// TODO SDK2 migration: update and uncomment
+		// verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
 	}
 
 	@Test
 	public void testGetResourceWithMalFormedUrl() {
 
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
@@ -121,12 +119,13 @@ public class SimpleStorageProtocolResolverTest {
 			assertThat(e.getMessage().contains("valid bucket name")).isTrue();
 		}
 
-		verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
+		// TODO SDK2 migration: update and uncomment
+		// verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
 	}
 
 	@Test
 	public void testValidS3Pattern() {
-		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		S3Client amazonS3 = mock(S3Client.class);
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolverTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolverTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -44,10 +45,6 @@ public class SimpleStorageProtocolResolverTest {
 
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		resourceLoader.addProtocolResolver(new SimpleStorageProtocolResolver(amazonS3));
-
-		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().build();
-		when(amazonS3.headObject(any(HeadObjectRequest.class)))
-				.thenReturn(headObjectResponse);
 
 		String resourceName = "s3://bucket/object/";
 		Resource resource = resourceLoader.getResource(resourceName);
@@ -99,8 +96,7 @@ public class SimpleStorageProtocolResolverTest {
 		assertThat(resourceLoader.getResource("s3://prefix.bucket/object.suffix"))
 				.isNotNull();
 
-		// TODO SDK2 migration: update and uncomment
-		// verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
+		verifyNoInteractions(amazonS3);
 	}
 
 	@Test
@@ -119,8 +115,7 @@ public class SimpleStorageProtocolResolverTest {
 			assertThat(e.getMessage().contains("valid bucket name")).isTrue();
 		}
 
-		// TODO SDK2 migration: update and uncomment
-		// verify(amazonS3, times(0)).getObjectMetadata("bucket", "object");
+		verifyNoInteractions(amazonS3);
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/naming/AmazonResourceNameTest.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.aws.core.naming;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.regions.Region;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.aws.core.naming.AmazonResourceName.Builder;
@@ -84,7 +83,7 @@ public class AmazonResourceNameTest {
 	public void testDynamoDbBuilder() {
 		Builder builder = new Builder();
 		builder.withService("dynamodb");
-		builder.withRegion(Region.getRegion(Regions.US_EAST_1));
+		builder.withRegion(Region.US_EAST_1);
 		builder.withAccount("123456789012");
 		builder.withResourceType("table");
 		builder.withResourceName("books_table");
@@ -97,7 +96,7 @@ public class AmazonResourceNameTest {
 	public void testElasticBeansTalkBuilder() {
 		Builder builder = new Builder();
 		builder.withService("elasticbeanstalk");
-		builder.withRegion(Region.getRegion(Regions.US_EAST_1));
+		builder.withRegion(Region.US_EAST_1);
 		builder.withResourceType("solutionstack");
 		builder.withResourceName("32bit Amazon Linux running Tomcat 7");
 		builder.withResourceTypeDelimiter("/");

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProviderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProviderTest.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.aws.core.region;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.regions.Region;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,7 +39,7 @@ public class Ec2MetadataRegionProviderTest {
 
 			@Override
 			protected Region getCurrentRegion() {
-				return Region.getRegion(Regions.EU_WEST_1);
+				return Region.EU_WEST_1;
 			}
 		};
 
@@ -48,7 +47,7 @@ public class Ec2MetadataRegionProviderTest {
 		Region region = regionProvider.getRegion();
 
 		// Assert
-		assertThat(region).isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+		assertThat(region).isEqualTo(Region.EU_WEST_1);
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/StaticRegionProviderTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/StaticRegionProviderTest.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.aws.core.region;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,8 +28,8 @@ public class StaticRegionProviderTest {
 
 	@Test
 	public void testGetRegion() throws Exception {
-		assertThat(new StaticRegionProvider(Regions.US_EAST_1.getName()).getRegion())
-				.isSameAs(Region.getRegion(Regions.US_EAST_1));
+		assertThat(new StaticRegionProvider(Region.US_EAST_1.id()).getRegion())
+				.isSameAs(Region.US_EAST_1);
 	}
 
 }

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -38,38 +38,17 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
-			<!-- TODO SDK2 migration: check exclusions -->
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
 				<version>${aws-java-sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>com.github.tomakehurst</groupId>
-						<artifactId>wiremock</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>core</artifactId>
 				<version>${aws-java-sdk.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>stax</groupId>
-						<artifactId>stax-api</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>activation</groupId>
-						<artifactId>activation</artifactId>
-					</exclusion>
-					<exclusion>
-						<artifactId>commons-logging</artifactId>
-						<groupId>commons-logging</groupId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.thimbleware.jmemcached</groupId>

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -31,16 +31,17 @@
 	<name>Spring Cloud AWS Dependencies</name>
 	<description>Spring Cloud AWS Dependencies</description>
 	<properties>
-		<aws-java-sdk.version>1.11.415</aws-java-sdk.version>
+		<aws-java-sdk.version>2.9.12</aws-java-sdk.version>
 		<elasticache.version>1.1.1</elasticache.version>
 		<jmemcached.version>1.0.0</jmemcached.version>
 		<spring-cloud-context.version>1.3.2.RELEASE</spring-cloud-context.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<!-- TODO SDK2 migration: check exclusions -->
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-bom</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
 				<version>${aws-java-sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
@@ -52,8 +53,8 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-core</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>core</artifactId>
 				<version>${aws-java-sdk.version}</version>
 				<exclusions>
 					<exclusion>

--- a/spring-cloud-aws-integration-test/pom.xml
+++ b/spring-cloud-aws-integration-test/pom.xml
@@ -46,8 +46,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ses</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sns</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -121,8 +121,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-elasticache</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>elasticache</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/IntegrationTestConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 
 import org.springframework.cloud.aws.context.config.annotation.EnableContextCredentials;
 import org.springframework.cloud.aws.context.config.annotation.EnableContextRegion;
@@ -45,13 +45,13 @@ public class IntegrationTestConfig {
 
 	@Bean
 	public TestStackEnvironment testStackEnvironment(
-			AmazonCloudFormation amazonCloudFormation) {
+			CloudFormationClient amazonCloudFormation) {
 		return new TestStackEnvironment(amazonCloudFormation);
 	}
 
 	@Bean
 	public TestStackInstanceIdService testStackInstanceIdService(
-			AmazonCloudFormation amazonCloudFormation) {
+		CloudFormationClient amazonCloudFormation) {
 		return TestStackInstanceIdService.fromStackOutputKey(
 				TestStackEnvironment.DEFAULT_STACK_NAME,
 				TestStackEnvironment.INSTANCE_ID_STACK_OUTPUT_KEY, amazonCloudFormation);

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/core/env/ec2/AmazonEc2InstanceDataPropertySourceAwsTest.java
@@ -21,7 +21,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 
-import com.amazonaws.SDKGlobalConfiguration;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -30,6 +29,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import software.amazon.awssdk.core.SdkSystemSetting;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils;
@@ -77,13 +77,13 @@ public abstract class AmazonEc2InstanceDataPropertySourceAwsTest {
 	private static void overwriteMetadataEndpointUrl(
 			String localMetadataServiceEndpointUrl) {
 		System.setProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY,
+				SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property(),
 				localMetadataServiceEndpointUrl);
 	}
 
 	private static void resetMetadataEndpointUrlOverwrite() {
 		System.clearProperty(
-				SDKGlobalConfiguration.EC2_METADATA_SERVICE_OVERRIDE_SYSTEM_PROPERTY);
+			SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT.property());
 	}
 
 	private static void restContextInstanceDataCondition() throws IllegalAccessException {

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootNotificationMessagingTemplateIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,7 +41,7 @@ public class BootNotificationMessagingTemplateIntegrationTest
 
 		@Bean
 		public NotificationMessagingTemplate notificationMessagingTemplate(
-				AmazonSNS amazonSns, ResourceIdResolver resourceIdResolver) {
+				SnsClient amazonSns, ResourceIdResolver resourceIdResolver) {
 			NotificationMessagingTemplate notificationMessagingTemplate = new NotificationMessagingTemplate(
 					amazonSns, resourceIdResolver);
 			notificationMessagingTemplate

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -55,10 +56,11 @@ public class BootQueueListenerTest extends QueueListenerTest {
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplate(SqsClient amazonSqs,
+				SqsAsyncClient amazonSqsAsync,
 				ResourceIdResolver resourceIdResolver,
 				QueueMessageHandlerFactory factory) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-					amazonSqs, resourceIdResolver);
+					amazonSqs, amazonSqsAsync, resourceIdResolver);
 			factory.setSendToMessagingTemplate(queueMessagingTemplate);
 
 			return queueMessagingTemplate;

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueListenerTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -54,7 +54,7 @@ public class BootQueueListenerTest extends QueueListenerTest {
 		}
 
 		@Bean
-		public QueueMessagingTemplate queueMessagingTemplate(AmazonSQSAsync amazonSqs,
+		public QueueMessagingTemplate queueMessagingTemplate(SqsClient amazonSqs,
 				ResourceIdResolver resourceIdResolver,
 				QueueMessageHandlerFactory factory) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,7 +42,7 @@ public class BootQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate defaultQueueMessagingTemplate(
-				AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 					amazonSqs, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("JsonQueue");
@@ -52,7 +52,7 @@ public class BootQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplateWithCustomConverter(
-				AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 					amazonSqs, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("StreamQueue");

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/BootQueueMessagingTemplateIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -42,9 +43,9 @@ public class BootQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate defaultQueueMessagingTemplate(
-			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-					amazonSqs, resourceIdResolver);
+					amazonSqs, amazonSqsAsync, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("JsonQueue");
 
 			return queueMessagingTemplate;
@@ -52,9 +53,9 @@ public class BootQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplateWithCustomConverter(
-			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-					amazonSqs, resourceIdResolver);
+					amazonSqs, amazonSqsAsync, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("StreamQueue");
 			queueMessagingTemplate.setMessageConverter(new ObjectMessageConverter());
 

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaNotificationMessagingTemplateIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.cloud.aws.IntegrationTestConfig;
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
@@ -43,7 +43,7 @@ public class JavaNotificationMessagingTemplateIntegrationTest
 
 		@Bean
 		public NotificationMessagingTemplate notificationMessagingTemplate(
-				AmazonSNS amazonSns, ResourceIdResolver resourceIdResolver) {
+				SnsClient amazonSns, ResourceIdResolver resourceIdResolver) {
 			NotificationMessagingTemplate notificationMessagingTemplate = new NotificationMessagingTemplate(
 					amazonSns, resourceIdResolver);
 			notificationMessagingTemplate

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.IntegrationTestConfig;
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
@@ -58,7 +58,7 @@ public class JavaQueueListenerTest extends QueueListenerTest {
 		}
 
 		@Bean
-		public QueueMessagingTemplate queueMessagingTemplate(AmazonSQSAsync amazonSqs,
+		public QueueMessagingTemplate queueMessagingTemplate(SqsClient amazonSqs,
 				ResourceIdResolver resourceIdResolver) {
 			return new QueueMessagingTemplate(amazonSqs, resourceIdResolver);
 		}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueListenerTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.IntegrationTestConfig;
@@ -59,8 +60,8 @@ public class JavaQueueListenerTest extends QueueListenerTest {
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplate(SqsClient amazonSqs,
-				ResourceIdResolver resourceIdResolver) {
-			return new QueueMessagingTemplate(amazonSqs, resourceIdResolver);
+			SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
+			return new QueueMessagingTemplate(amazonSqs, amazonSqsAsync, resourceIdResolver);
 		}
 
 		@Bean

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.IntegrationTestConfig;
@@ -42,9 +43,9 @@ public class JavaQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate defaultQueueMessagingTemplate(
-				SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsAsyncClient amazonSqsAsync, SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-					amazonSqs, resourceIdResolver);
+					amazonSqs, amazonSqsAsync, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("JsonQueue");
 
 			return queueMessagingTemplate;
@@ -52,9 +53,9 @@ public class JavaQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplateWithCustomConverter(
-			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-					amazonSqs, resourceIdResolver);
+					amazonSqs, amazonSqsAsync, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("StreamQueue");
 			queueMessagingTemplate.setMessageConverter(new ObjectMessageConverter());
 

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/JavaQueueMessagingTemplateIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.IntegrationTestConfig;
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
@@ -42,7 +42,7 @@ public class JavaQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate defaultQueueMessagingTemplate(
-				AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
+				SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 					amazonSqs, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("JsonQueue");
@@ -52,7 +52,7 @@ public class JavaQueueMessagingTemplateIntegrationTest
 
 		@Bean
 		public QueueMessagingTemplate queueMessagingTemplateWithCustomConverter(
-				AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 			QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 					amazonSqs, resourceIdResolver);
 			queueMessagingTemplate.setDefaultDestinationName("StreamQueue");

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/AmazonWebserviceProfileValueSource.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/support/profile/AmazonWebserviceProfileValueSource.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.support.profile;
 
-import com.amazonaws.util.EC2MetadataUtils;
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 
 import org.springframework.test.annotation.ProfileValueSource;
 

--- a/spring-cloud-aws-jdbc/pom.xml
+++ b/spring-cloud-aws-jdbc/pom.xml
@@ -48,12 +48,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-rds</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>rds</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-iam</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>iam</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
@@ -168,7 +168,7 @@ public class AmazonRdsInstanceConfiguration {
 							+ importingClassMetadata.getClassName());
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null)
+							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
 					.getBeanName();
 			registerDataSource(registry, amazonRdsClientBeanName,
 					annotationAttributes.getString("dbInstanceIdentifier"),

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
@@ -168,7 +168,7 @@ public class AmazonRdsInstanceConfiguration {
 							+ importingClassMetadata.getClassName());
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
+							"com.amazonaws.services.rds.AmazonRDSClient", null)
 					.getBeanName();
 			registerDataSource(registry, amazonRdsClientBeanName,
 					annotationAttributes.getString("dbInstanceIdentifier"),

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfiguration.java
@@ -168,7 +168,7 @@ public class AmazonRdsInstanceConfiguration {
 							+ importingClassMetadata.getClassName());
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry,
-							"com.amazonaws.services.rds.AmazonRDSClient", null, null)
+							"software.amazon.awssdk.services.rds.RdsClient", null, null)
 					.getBeanName();
 			registerDataSource(registry, amazonRdsClientBeanName,
 					annotationAttributes.getString("dbInstanceIdentifier"),

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
@@ -42,8 +42,8 @@ import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigu
  * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} parser
  * implementation for the datasource element. Parses the element and constructs a fully
  * configured {@link AmazonRdsDataSourceFactoryBean} bean definition. Also creates a bean
- * definition for the {@link software.amazon.awssdk.services.rds.RdsClient} if there is not
- * already an existing one this application context.
+ * definition for the {@link software.amazon.awssdk.services.rds.RdsClient} if there is
+ * not already an existing one this application context.
  *
  * @author Agim Emruli
  * @since 1.0

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
@@ -42,7 +42,7 @@ import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigu
  * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} parser
  * implementation for the datasource element. Parses the element and constructs a fully
  * configured {@link AmazonRdsDataSourceFactoryBean} bean definition. Also creates a bean
- * definition for the {@link com.amazonaws.services.rds.AmazonRDSClient} if there is not
+ * definition for the {@link software.amazon.awssdk.services.rds.RdsClient} if there is not
  * already an existing one this application context.
  *
  * @author Agim Emruli
@@ -52,10 +52,10 @@ class AmazonRdsDataSourceBeanDefinitionParser extends AbstractBeanDefinitionPars
 
 	static final String DB_INSTANCE_IDENTIFIER = "db-instance-identifier";
 
-	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "com.amazonaws.services.rds.AmazonRDSClient";
+	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.rds.RdsClient";
 
 	// @checkstyle:off
-	private static final String IDENTITY_MANAGEMENT_CLIENT_CLASS_NAME = "com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient";
+	private static final String IDENTITY_MANAGEMENT_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.iam.IamClient";
 
 	// @checkstyle:on
 

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
@@ -68,7 +68,7 @@ class AmazonRdsRetryInterceptorBeanDefinitionParser
 	 */
 	private static final String BACK_OFF_POLICY = "back-off-policy";
 
-	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "com.amazonaws.services.rds.AmazonRDSClient";
+	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.rds.RdsClient";
 
 	/**
 	 * Builds the RetryOperation {@link BeanDefinition} with its collaborators.

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBean.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/rds/AmazonRdsReadReplicaAwareDataSourceFactoryBean.java
@@ -21,8 +21,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
 
 import org.springframework.cloud.aws.jdbc.datasource.ReadOnlyRoutingDataSource;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
@@ -49,7 +49,7 @@ public class AmazonRdsReadReplicaAwareDataSourceFactoryBean
 	 * @param password - The password used to connect to the datasource. For security
 	 * reasons the password is not available in the
 	 */
-	public AmazonRdsReadReplicaAwareDataSourceFactoryBean(AmazonRDS amazonRDS,
+	public AmazonRdsReadReplicaAwareDataSourceFactoryBean(RdsClient amazonRDS,
 			String dbInstanceIdentifier, String password) {
 		super(amazonRDS, dbInstanceIdentifier, password);
 	}
@@ -74,14 +74,14 @@ public class AmazonRdsReadReplicaAwareDataSourceFactoryBean
 		DBInstance dbInstance = getDbInstance(getDbInstanceIdentifier());
 
 		// If there is no read replica available, delegate to super class
-		if (dbInstance.getReadReplicaDBInstanceIdentifiers().isEmpty()) {
+		if (dbInstance.readReplicaDBInstanceIdentifiers().isEmpty()) {
 			return super.createInstance();
 		}
 
 		HashMap<Object, Object> replicaMap = new HashMap<>(
-				dbInstance.getReadReplicaDBInstanceIdentifiers().size());
+				dbInstance.readReplicaDBInstanceIdentifiers().size());
 
-		for (String replicaName : dbInstance.getReadReplicaDBInstanceIdentifiers()) {
+		for (String replicaName : dbInstance.readReplicaDBInstanceIdentifiers()) {
 			replicaMap.put(replicaName, createDataSourceInstance(replicaName));
 		}
 

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
@@ -180,7 +180,7 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplica {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -202,7 +202,7 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplicaAndCustomDbName {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -223,7 +223,7 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplicaAndCustomDataSourceFactory {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -258,7 +258,7 @@ public class AmazonRdsInstanceConfigurationTest {
 		// @checkstyle:on
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -288,7 +288,7 @@ public class AmazonRdsInstanceConfigurationTest {
 		}
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(
@@ -310,7 +310,7 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithReadReplica {
 
 		@Bean
-		public RdsClient amazonRDS() {
+		public RdsClient amazonRds() {
 			RdsClient client = Mockito.mock(RdsClient.class);
 			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
 					.dbInstanceIdentifier("test").build())).thenReturn(

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/annotation/AmazonRdsInstanceConfigurationTest.java
@@ -20,15 +20,14 @@ import java.util.HashMap;
 
 import javax.sql.DataSource;
 
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClient;
-import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.Endpoint;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
 
 import org.springframework.cloud.aws.jdbc.datasource.TomcatJdbcDataSourceFactory;
 import org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean;
@@ -181,21 +180,18 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplica {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -206,21 +202,18 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplicaAndCustomDbName {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -230,21 +223,18 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithoutReadReplicaAndCustomDataSourceFactory {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -268,21 +258,18 @@ public class AmazonRdsInstanceConfigurationTest {
 		// @checkstyle:on
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -301,21 +288,18 @@ public class AmazonRdsInstanceConfigurationTest {
 		}
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
 			return client;
 		}
 
@@ -326,32 +310,30 @@ public class AmazonRdsInstanceConfigurationTest {
 	public static class ApplicationConfigurationWithReadReplica {
 
 		@Bean
-		public AmazonRDS amazonRDS() {
-			AmazonRDSClient client = Mockito.mock(AmazonRDSClient.class);
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("test")
-											.withDBInstanceIdentifier("test")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))
-											.withReadReplicaDBInstanceIdentifiers(
-													"read1")));
-			when(client.describeDBInstances(
-					new DescribeDBInstancesRequest().withDBInstanceIdentifier("read1")))
-							.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-									new DBInstance().withDBInstanceStatus("available")
-											.withDBName("read1")
-											.withDBInstanceIdentifier("read1")
-											.withEngine("mysql")
-											.withMasterUsername("admin")
-											.withEndpoint(new Endpoint()
-													.withAddress("localhost")
-													.withPort(3306))));
+		public RdsClient amazonRDS() {
+			RdsClient client = Mockito.mock(RdsClient.class);
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("test").build())).thenReturn(
+							DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+									.builder().dbInstanceStatus("available")
+									.dbName("test").dbInstanceIdentifier("test")
+									.engine("mysql").masterUsername("admin")
+									.endpoint(Endpoint.builder().address("localhost")
+											.port(3306).build())
+									.readReplicaDBInstanceIdentifiers("read1").build())
+									.build());
+			when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+					.dbInstanceIdentifier("read1").build()))
+							.thenReturn(DescribeDbInstancesResponse.builder()
+									.dbInstances(DBInstance.builder()
+											.dbInstanceStatus("available").dbName("read1")
+											.dbInstanceIdentifier("read1").engine("mysql")
+											.masterUsername("admin")
+											.endpoint(Endpoint.builder()
+													.address("localhost").port(3306)
+													.build())
+											.build())
+									.build());
 			return client;
 		}
 

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
@@ -21,23 +21,22 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
-import com.amazonaws.services.identitymanagement.model.GetUserResult;
-import com.amazonaws.services.identitymanagement.model.User;
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClient;
-import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.Endpoint;
-import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
-import com.amazonaws.services.rds.model.ListTagsForResourceResult;
-import com.amazonaws.services.rds.model.Tag;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.GetUserResponse;
+import software.amazon.awssdk.services.iam.model.User;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.rds.model.Tag;
 
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.PropertyAccessorFactory;
@@ -77,10 +76,10 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		beanDefinitionBuilder.setFactoryMethod("mock");
-		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanDefinitionBuilder.addConstructorArgValue(RdsClient.class);
 		beanFactory.registerBeanDefinition(
 				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()),
+						.getBeanName(RdsClient.class.getName()),
 				beanDefinitionBuilder.getBeanDefinition());
 
 		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(
@@ -88,19 +87,19 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
 				getClass().getSimpleName() + "-minimal.xml", getClass()));
 
-		AmazonRDS client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
-				.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+		RdsClient client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
+				.getBeanName(RdsClient.class.getName()), RdsClient.class);
 
-		when(client.describeDBInstances(
-				new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-						.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-								new DBInstance().withDBInstanceStatus("available")
-										.withDBName("test")
-										.withDBInstanceIdentifier("test")
-										.withEngine("mysql").withMasterUsername("admin")
-										.withEndpoint(new Endpoint()
-												.withAddress("localhost").withPort(3306))
-										.withReadReplicaDBInstanceIdentifiers("read1")));
+		when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+				.dbInstanceIdentifier("test").build())).thenReturn(
+						DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+								.builder().dbInstanceStatus("available").dbName("test")
+								.dbInstanceIdentifier("test").engine("mysql")
+								.masterUsername("admin")
+								.endpoint(Endpoint.builder().address("localhost")
+										.port(3306).build())
+								.readReplicaDBInstanceIdentifiers("read1").build())
+								.build());
 
 		// Act
 		DataSource dataSource = beanFactory.getBean(DataSource.class);
@@ -119,10 +118,10 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		beanDefinitionBuilder.setFactoryMethod("mock");
-		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanDefinitionBuilder.addConstructorArgValue(RdsClient.class);
 		beanFactory.registerBeanDefinition(
 				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()),
+						.getBeanName(RdsClient.class.getName()),
 				beanDefinitionBuilder.getBeanDefinition());
 
 		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(
@@ -147,10 +146,10 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		beanDefinitionBuilder.setFactoryMethod("mock");
-		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanDefinitionBuilder.addConstructorArgValue(RdsClient.class);
 		beanFactory.registerBeanDefinition(
 				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()),
+						.getBeanName(RdsClient.class.getName()),
 				beanDefinitionBuilder.getBeanDefinition());
 
 		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(
@@ -158,19 +157,19 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
 				getClass().getSimpleName() + "-noCredentials.xml", getClass()));
 
-		AmazonRDS client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
-				.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+		RdsClient client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
+				.getBeanName(RdsClient.class.getName()), RdsClient.class);
 
-		when(client.describeDBInstances(
-				new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-						.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-								new DBInstance().withDBInstanceStatus("available")
-										.withDBName("test")
-										.withDBInstanceIdentifier("test")
-										.withEngine("mysql").withMasterUsername("admin")
-										.withEndpoint(new Endpoint()
-												.withAddress("localhost").withPort(3306))
-										.withReadReplicaDBInstanceIdentifiers("read1")));
+		when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+				.dbInstanceIdentifier("test").build())).thenReturn(
+						DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+								.builder().dbInstanceStatus("available").dbName("test")
+								.dbInstanceIdentifier("test").engine("mysql")
+								.masterUsername("admin")
+								.endpoint(Endpoint.builder().address("localhost")
+										.port(3306).build())
+								.readReplicaDBInstanceIdentifiers("read1").build())
+								.build());
 
 		// Act
 		DataSource dataSource = beanFactory.getBean(DataSource.class);
@@ -189,10 +188,10 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		beanDefinitionBuilder.setFactoryMethod("mock");
-		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanDefinitionBuilder.addConstructorArgValue(RdsClient.class);
 		beanFactory.registerBeanDefinition(
 				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()),
+						.getBeanName(RdsClient.class.getName()),
 				beanDefinitionBuilder.getBeanDefinition());
 
 		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(
@@ -200,20 +199,19 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
 				getClass().getSimpleName() + "-fullConfiguration.xml", getClass()));
 
-		AmazonRDS client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
-				.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+		RdsClient client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
+				.getBeanName(RdsClient.class.getName()), RdsClient.class);
 
-		when(client.describeDBInstances(
-				new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-						.thenReturn(
-								new DescribeDBInstancesResult().withDBInstances(
-										new DBInstance().withDBInstanceStatus("available")
-												.withDBName("test")
-												.withDBInstanceIdentifier("test")
-												.withEngine("mysql")
-												.withEndpoint(new Endpoint()
-														.withAddress("localhost")
-														.withPort(3306))));
+		when(client.describeDBInstances(DescribeDbInstancesRequest.builder()
+				.dbInstanceIdentifier("test").build()))
+						.thenReturn(DescribeDbInstancesResponse.builder()
+								.dbInstances(DBInstance
+										.builder().dbInstanceStatus("available")
+										.dbName("test").dbInstanceIdentifier("test")
+										.engine("mysql").endpoint(Endpoint.builder()
+												.address("localhost").port(3306).build())
+										.build())
+								.build());
 
 		BeanDefinition definition = beanFactory.getBeanDefinition("test");
 		assertThat(definition.getConstructorArgumentValues()
@@ -344,7 +342,7 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegion.xml", getClass()));
 
 		// Act
-		AmazonRDS amazonRDS = beanFactory.getBean(AmazonRDS.class);
+		RdsClient amazonRDS = beanFactory.getBean(RdsClient.class);
 
 		// Assert
 		// have to use reflection utils
@@ -365,7 +363,7 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegionProvider.xml", getClass()));
 
 		// Act
-		AmazonRDS amazonRDS = beanFactory.getBean(AmazonRDS.class);
+		RdsClient amazonRDS = beanFactory.getBean(RdsClient.class);
 
 		// Assert
 		// have to use reflection utils
@@ -399,40 +397,44 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		beanDefinitionBuilder.setFactoryMethod("mock");
-		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanDefinitionBuilder.addConstructorArgValue(RdsClient.class);
 		beanFactory.registerBeanDefinition(
 				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()),
+						.getBeanName(RdsClient.class.getName()),
 				beanDefinitionBuilder.getBeanDefinition());
 
 		BeanDefinitionBuilder identityBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(Mockito.class);
 		identityBuilder.setFactoryMethod("mock");
-		identityBuilder.addConstructorArgValue(AmazonIdentityManagement.class);
-		beanFactory.registerBeanDefinition(
-				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonIdentityManagement.class.getName()),
-				identityBuilder.getBeanDefinition());
+		identityBuilder.addConstructorArgValue(IamClient.class);
+		beanFactory
+				.registerBeanDefinition(
+						AmazonWebserviceClientConfigurationUtils
+								.getBeanName(IamClient.class.getName()),
+						identityBuilder.getBeanDefinition());
 
 		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(
 				beanFactory);
 		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
 				getClass().getSimpleName() + "-userTags.xml", getClass()));
 
-		AmazonRDS client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
-				.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
-		AmazonIdentityManagement amazonIdentityManagement = beanFactory.getBean(
-				AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonIdentityManagement.class.getName()),
-				AmazonIdentityManagement.class);
+		RdsClient client = beanFactory.getBean(AmazonWebserviceClientConfigurationUtils
+				.getBeanName(RdsClient.class.getName()), RdsClient.class);
+		IamClient amazonIdentityManagement = beanFactory
+				.getBean(AmazonWebserviceClientConfigurationUtils
+						.getBeanName(IamClient.class.getName()), IamClient.class);
 
-		when(amazonIdentityManagement.getUser()).thenReturn(
-				new GetUserResult().withUser(new User("/", "aemruli", "123456789012",
-						"arn:aws:iam::1234567890:user/aemruli", new Date())));
-		when(client.listTagsForResource(new ListTagsForResourceRequest()
-				.withResourceName("arn:aws:rds:us-west-2:1234567890:db:test")))
-						.thenReturn(new ListTagsForResourceResult().withTagList(
-								new Tag().withKey("key1").withValue("value2")));
+		when(amazonIdentityManagement.getUser()).thenReturn(GetUserResponse.builder()
+				.user(User.builder().path("/").userName("aemruli").userId("123456789012")
+						.arn("arn:aws:iam::1234567890:user/aemruli")
+						.createDate(new Date().toInstant()).build())
+				.build());
+		when(client.listTagsForResource(ListTagsForResourceRequest.builder()
+				.resourceName("arn:aws:rds:us-west-2:1234567890:db:test").build()))
+						.thenReturn(ListTagsForResourceResponse.builder()
+								.tagList(
+										Tag.builder().key("key1").value("value2").build())
+								.build());
 
 		// Act
 		Map<?, ?> dsTags = beanFactory.getBean("dsTags", Map.class);
@@ -453,29 +455,33 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
 				getClass().getSimpleName() + "-customRdsInstance.xml", getClass()));
 
-		AmazonRDS clientMock = beanFactory.getBean("amazonRds", AmazonRDS.class);
+		RdsClient clientMock = beanFactory.getBean("amazonRds", RdsClient.class);
 
-		when(clientMock.describeDBInstances(
-				new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
-						.thenReturn(new DescribeDBInstancesResult().withDBInstances(
-								new DBInstance().withDBInstanceStatus("available")
-										.withDBName("test")
-										.withDBInstanceIdentifier("test")
-										.withEngine("mysql").withMasterUsername("admin")
-										.withEndpoint(new Endpoint()
-												.withAddress("localhost").withPort(3306))
-										.withReadReplicaDBInstanceIdentifiers("read1")));
+		when(clientMock.describeDBInstances(DescribeDbInstancesRequest.builder()
+				.dbInstanceIdentifier("test").build())).thenReturn(
+						DescribeDbInstancesResponse.builder().dbInstances(DBInstance
+								.builder().dbInstanceStatus("available").dbName("test")
+								.dbInstanceIdentifier("test").engine("mysql")
+								.masterUsername("admin")
+								.endpoint(Endpoint.builder().address("localhost")
+										.port(3306).build())
+								.readReplicaDBInstanceIdentifiers("read1").build())
+								.build());
 
-		AmazonIdentityManagement amazonIdentityManagement = beanFactory
-				.getBean("myIdentityService", AmazonIdentityManagement.class);
+		IamClient amazonIdentityManagement = beanFactory.getBean("myIdentityService",
+				IamClient.class);
 
-		when(amazonIdentityManagement.getUser()).thenReturn(
-				new GetUserResult().withUser(new User("/", "aemruli", "123456789012",
-						"arn:aws:iam::1234567890:user/aemruli", new Date())));
-		when(clientMock.listTagsForResource(new ListTagsForResourceRequest()
-				.withResourceName("arn:aws:rds:us-west-2:1234567890:db:test")))
-						.thenReturn(new ListTagsForResourceResult().withTagList(
-								new Tag().withKey("key1").withValue("value2")));
+		when(amazonIdentityManagement.getUser()).thenReturn(GetUserResponse.builder()
+				.user(User.builder().path("/").userName("aemruli").userId("123456789012")
+						.arn("arn:aws:iam::1234567890:user/aemruli")
+						.createDate(new Date().toInstant()).build())
+				.build());
+		when(clientMock.listTagsForResource(ListTagsForResourceRequest.builder()
+				.resourceName("arn:aws:rds:us-west-2:1234567890:db:test").build()))
+						.thenReturn(ListTagsForResourceResponse.builder()
+								.tagList(
+										Tag.builder().key("key1").value("value2").build())
+								.build());
 
 		// Act
 		Map<?, ?> dsTags = beanFactory.getBean("dsTags", Map.class);

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
@@ -26,6 +26,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.GetUserResponse;
 import software.amazon.awssdk.services.iam.model.User;
@@ -346,7 +348,8 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 
 		// Assert
 		// have to use reflection utils
-		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}
 
@@ -367,7 +370,8 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 
 		// Assert
 		// have to use reflection utils
-		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 
 	}

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
@@ -348,7 +348,8 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 
 		// Assert
 		// have to use reflection utils
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonRDS, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}
@@ -370,7 +371,8 @@ public class AmazonRdsDataSourceBeanDefinitionParserTest {
 
 		// Assert
 		// have to use reflection utils
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonRDS, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
@@ -63,7 +63,8 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonRDS, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}
@@ -79,7 +80,8 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonRDS, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.junit.Test;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.rds.RdsClient;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -61,7 +63,8 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}
 
@@ -76,7 +79,8 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonRDS, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
 				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
 	}
 

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
@@ -18,10 +18,9 @@ package org.springframework.cloud.aws.jdbc.config.xml;
 
 import java.util.List;
 
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClient;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.junit.Test;
+import software.amazon.awssdk.services.rds.RdsClient;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -59,7 +58,7 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegion.xml", getClass());
 
 		// Act
-		AmazonRDS amazonRDS = classPathXmlApplicationContext.getBean(AmazonRDS.class);
+		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
@@ -74,7 +73,7 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegionProvider.xml", getClass());
 
 		// Act
-		AmazonRDS amazonRDS = classPathXmlApplicationContext.getBean(AmazonRDS.class);
+		RdsClient amazonRDS = classPathXmlApplicationContext.getBean(RdsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
@@ -94,7 +93,7 @@ public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
 		// Assert
 		assertThat(classPathXmlApplicationContext
 				.containsBean(AmazonWebserviceClientConfigurationUtils
-						.getBeanName(AmazonRDSClient.class.getName()))).isFalse();
+						.getBeanName(RdsClient.class.getName()))).isFalse();
 	}
 
 	@Test

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
@@ -37,11 +37,11 @@
 					  amazon-identity-management="myIdentityService"/>
 
 	<bean id="amazonRds" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="com.amazonaws.services.rds.AmazonRDS"/>
+		<constructor-arg value="software.amazon.awssdk.services.rds.RdsClient"/>
 	</bean>
 
 	<bean id="myIdentityService" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg
-			value="com.amazonaws.services.identitymanagement.AmazonIdentityManagement"/>
+			value="software.amazon.awssdk.services.iam.IamClient"/>
 	</bean>
 </beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
@@ -35,6 +35,6 @@
 							amazon-rds="customRdsClient"/>
 
 	<bean id="customRdsClient" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="com.amazonaws.services.rds.AmazonRDS"/>
+		<constructor-arg value="software.amazon.awssdk.services.rds.RdsClient"/>
 	</bean>
 </beans>

--- a/spring-cloud-aws-messaging/pom.xml
+++ b/spring-cloud-aws-messaging/pom.xml
@@ -35,12 +35,12 @@
 			<artifactId>spring-cloud-aws-context</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-sns</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sns</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-sqs</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sqs</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -75,6 +75,10 @@
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
@@ -19,8 +19,7 @@ package org.springframework.cloud.aws.messaging.config;
 import java.util.Arrays;
 import java.util.List;
 
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
@@ -47,7 +46,7 @@ public class QueueMessageHandlerFactory {
 
 	private DestinationResolvingMessageSendingOperations<?> sendToMessagingTemplate;
 
-	private AmazonSQSAsync amazonSqs;
+	private SqsClient amazonSqs;
 
 	private ResourceIdResolver resourceIdResolver;
 
@@ -78,26 +77,26 @@ public class QueueMessageHandlerFactory {
 		this.sendToMessagingTemplate = sendToMessagingTemplate;
 	}
 
-	public AmazonSQS getAmazonSqs() {
+	public SqsClient getAmazonSqs() {
 		return this.amazonSqs;
 	}
 
 	/**
 	 * <p>
-	 * Sets the {@link AmazonSQS} client that is going to be used to create a new
+	 * Sets the {@link SqsClient} client that is going to be used to create a new
 	 * {@link QueueMessagingTemplate} if {@code sendToMessagingTemplate} is {@code null}.
 	 * This template is used by the {@link SendToHandlerMethodReturnValueHandler} to send
 	 * the return values of handler methods annotated with
 	 * {@link org.springframework.messaging.handler.annotation.SendTo}.
 	 * </p>
 	 * <p>
-	 * An {@link AmazonSQS} client is only needed if {@code sendToMessagingTemplate} is
+	 * An {@link SqsClient} client is only needed if {@code sendToMessagingTemplate} is
 	 * {@code null}.
 	 * </p>
-	 * @param amazonSqs The {@link AmazonSQS} client that is going to be used by the
+	 * @param amazonSqs The {@link SqsClient} client that is going to be used by the
 	 * {@link SendToHandlerMethodReturnValueHandler} to send messages.
 	 */
-	public void setAmazonSqs(AmazonSQSAsync amazonSqs) {
+	public void setAmazonSqs(SqsClient amazonSqs) {
 		this.amazonSqs = amazonSqs;
 	}
 
@@ -157,7 +156,7 @@ public class QueueMessageHandlerFactory {
 	}
 
 	private QueueMessagingTemplate getDefaultSendToQueueMessagingTemplate(
-			AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
 		return new QueueMessagingTemplate(amazonSqs, resourceIdResolver,
 				getDefaultMappingJackson2MessageConverter());
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.messaging.config;
 import java.util.Arrays;
 import java.util.List;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -47,6 +48,8 @@ public class QueueMessageHandlerFactory {
 	private DestinationResolvingMessageSendingOperations<?> sendToMessagingTemplate;
 
 	private SqsClient amazonSqs;
+
+	private SqsAsyncClient amazonSqsAsync;
 
 	private ResourceIdResolver resourceIdResolver;
 
@@ -81,6 +84,10 @@ public class QueueMessageHandlerFactory {
 		return this.amazonSqs;
 	}
 
+	public SqsAsyncClient getAmazonSqsAsync() {
+		return amazonSqsAsync;
+	}
+
 	/**
 	 * <p>
 	 * Sets the {@link SqsClient} client that is going to be used to create a new
@@ -98,6 +105,25 @@ public class QueueMessageHandlerFactory {
 	 */
 	public void setAmazonSqs(SqsClient amazonSqs) {
 		this.amazonSqs = amazonSqs;
+	}
+
+	/**
+	 * <p>
+	 * Sets the {@link SqsAsyncClient} client that is going to be used to create a new
+	 * {@link QueueMessagingTemplate} if {@code sendToMessagingTemplate} is {@code null}.
+	 * This template is used by the {@link SendToHandlerMethodReturnValueHandler} to send
+	 * the return values of handler methods annotated with
+	 * {@link org.springframework.messaging.handler.annotation.SendTo}.
+	 * </p>
+	 * <p>
+	 * An {@link SqsAsyncClient} client is only needed if {@code sendToMessagingTemplate} is
+	 * {@code null}.
+	 * </p>
+	 * @param amazonSqsAsync The {@link SqsAsyncClient} client that is going to be used by the
+	 * {@link SendToHandlerMethodReturnValueHandler} to send messages.
+	 */
+	public void setAmazonSqsAsync(SqsAsyncClient amazonSqsAsync) {
+		this.amazonSqsAsync = amazonSqsAsync;
 	}
 
 	/**
@@ -144,7 +170,7 @@ public class QueueMessageHandlerFactory {
 		}
 		else {
 			sendToHandlerMethodReturnValueHandler = new SendToHandlerMethodReturnValueHandler(
-					getDefaultSendToQueueMessagingTemplate(this.amazonSqs,
+					getDefaultSendToQueueMessagingTemplate(this.amazonSqs, this.amazonSqsAsync,
 							this.resourceIdResolver));
 
 		}
@@ -156,8 +182,8 @@ public class QueueMessageHandlerFactory {
 	}
 
 	private QueueMessagingTemplate getDefaultSendToQueueMessagingTemplate(
-			SqsClient amazonSqs, ResourceIdResolver resourceIdResolver) {
-		return new QueueMessagingTemplate(amazonSqs, resourceIdResolver,
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
+		return new QueueMessagingTemplate(amazonSqs, amazonSqsAsync, resourceIdResolver,
 				getDefaultMappingJackson2MessageConverter());
 	}
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/QueueMessageHandlerFactory.java
@@ -116,11 +116,11 @@ public class QueueMessageHandlerFactory {
 	 * {@link org.springframework.messaging.handler.annotation.SendTo}.
 	 * </p>
 	 * <p>
-	 * An {@link SqsAsyncClient} client is only needed if {@code sendToMessagingTemplate} is
-	 * {@code null}.
+	 * An {@link SqsAsyncClient} client is only needed if {@code sendToMessagingTemplate}
+	 * is {@code null}.
 	 * </p>
-	 * @param amazonSqsAsync The {@link SqsAsyncClient} client that is going to be used by the
-	 * {@link SendToHandlerMethodReturnValueHandler} to send messages.
+	 * @param amazonSqsAsync The {@link SqsAsyncClient} client that is going to be used by
+	 * the {@link SendToHandlerMethodReturnValueHandler} to send messages.
 	 */
 	public void setAmazonSqsAsync(SqsAsyncClient amazonSqsAsync) {
 		this.amazonSqsAsync = amazonSqsAsync;
@@ -170,8 +170,8 @@ public class QueueMessageHandlerFactory {
 		}
 		else {
 			sendToHandlerMethodReturnValueHandler = new SendToHandlerMethodReturnValueHandler(
-					getDefaultSendToQueueMessagingTemplate(this.amazonSqs, this.amazonSqsAsync,
-							this.resourceIdResolver));
+					getDefaultSendToQueueMessagingTemplate(this.amazonSqs,
+							this.amazonSqsAsync, this.resourceIdResolver));
 
 		}
 		sendToHandlerMethodReturnValueHandler.setBeanFactory(this.beanFactory);
@@ -182,7 +182,8 @@ public class QueueMessageHandlerFactory {
 	}
 
 	private QueueMessagingTemplate getDefaultSendToQueueMessagingTemplate(
-			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync,
+			ResourceIdResolver resourceIdResolver) {
 		return new QueueMessagingTemplate(amazonSqs, amazonSqsAsync, resourceIdResolver,
 				getDefaultMappingJackson2MessageConverter());
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -16,8 +16,7 @@
 
 package org.springframework.cloud.aws.messaging.config;
 
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
@@ -43,7 +42,7 @@ public class SimpleMessageListenerContainerFactory {
 
 	private boolean autoStartup = true;
 
-	private AmazonSQSAsync amazonSqs;
+	private SqsClient amazonSqs;
 
 	private QueueMessageHandler queueMessageHandler;
 
@@ -105,16 +104,16 @@ public class SimpleMessageListenerContainerFactory {
 		this.autoStartup = autoStartup;
 	}
 
-	public AmazonSQS getAmazonSqs() {
+	public SqsClient getAmazonSqs() {
 		return this.amazonSqs;
 	}
 
 	/**
-	 * Sets the {@link AmazonSQSAsync} that is going to be used by the container to
-	 * interact with the messaging (SQS) API.
-	 * @param amazonSqs The {@link AmazonSQSAsync}, must not be {@code null}.
+	 * Sets the {@link SqsClient} that is going to be used by the container to interact
+	 * with the messaging (SQS) API.
+	 * @param amazonSqs The {@link SqsClient}, must not be {@code null}.
 	 */
-	public void setAmazonSqs(AmazonSQSAsync amazonSqs) {
+	public void setAmazonSqs(SqsClient amazonSqs) {
 		Assert.notNull(amazonSqs, "amazonSqs must not be null");
 		this.amazonSqs = amazonSqs;
 	}
@@ -188,6 +187,7 @@ public class SimpleMessageListenerContainerFactory {
 		Assert.notNull(this.amazonSqs, "amazonSqs must not be null");
 
 		SimpleMessageListenerContainer simpleMessageListenerContainer = new SimpleMessageListenerContainer();
+		// TODO SDK2 migration: solve the issue with the async and sync client
 		simpleMessageListenerContainer.setAmazonSqs(this.amazonSqs);
 		simpleMessageListenerContainer.setAutoStartup(this.autoStartup);
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -124,9 +124,10 @@ public class SimpleMessageListenerContainerFactory {
 		Assert.notNull(amazonSqs, "amazonSqs must not be null");
 		this.amazonSqs = amazonSqs;
 	}
+
 	/**
-	 * Sets the {@link SqsAsyncClient} that is going to be used by the container to interact
-	 * with the messaging (SQS) API.
+	 * Sets the {@link SqsAsyncClient} that is going to be used by the container to
+	 * interact with the messaging (SQS) API.
 	 * @param amazonSqsAsync The {@link SqsAsyncClient}, must not be {@code null}.
 	 */
 	public void setAmazonSqsAsync(SqsAsyncClient amazonSqsAsync) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.messaging.config;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
@@ -43,6 +44,8 @@ public class SimpleMessageListenerContainerFactory {
 	private boolean autoStartup = true;
 
 	private SqsClient amazonSqs;
+
+	private SqsAsyncClient amazonSqsAsync;
 
 	private QueueMessageHandler queueMessageHandler;
 
@@ -108,6 +111,10 @@ public class SimpleMessageListenerContainerFactory {
 		return this.amazonSqs;
 	}
 
+	public SqsAsyncClient getAmazonSqsAsync() {
+		return this.amazonSqsAsync;
+	}
+
 	/**
 	 * Sets the {@link SqsClient} that is going to be used by the container to interact
 	 * with the messaging (SQS) API.
@@ -116,6 +123,15 @@ public class SimpleMessageListenerContainerFactory {
 	public void setAmazonSqs(SqsClient amazonSqs) {
 		Assert.notNull(amazonSqs, "amazonSqs must not be null");
 		this.amazonSqs = amazonSqs;
+	}
+	/**
+	 * Sets the {@link SqsAsyncClient} that is going to be used by the container to interact
+	 * with the messaging (SQS) API.
+	 * @param amazonSqsAsync The {@link SqsAsyncClient}, must not be {@code null}.
+	 */
+	public void setAmazonSqsAsync(SqsAsyncClient amazonSqsAsync) {
+		Assert.notNull(amazonSqsAsync, "amazonSqsAsync must not be null");
+		this.amazonSqsAsync = amazonSqsAsync;
 	}
 
 	public QueueMessageHandler getQueueMessageHandler() {
@@ -185,10 +201,11 @@ public class SimpleMessageListenerContainerFactory {
 
 	public SimpleMessageListenerContainer createSimpleMessageListenerContainer() {
 		Assert.notNull(this.amazonSqs, "amazonSqs must not be null");
+		Assert.notNull(this.amazonSqsAsync, "amazonSqsAsync must not be null");
 
 		SimpleMessageListenerContainer simpleMessageListenerContainer = new SimpleMessageListenerContainer();
-		// TODO SDK2 migration: solve the issue with the async and sync client
 		simpleMessageListenerContainer.setAmazonSqs(this.amazonSqs);
+		simpleMessageListenerContainer.setAmazonSqsAsync(this.amazonSqsAsync);
 		simpleMessageListenerContainer.setAutoStartup(this.autoStartup);
 
 		if (this.taskExecutor != null) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
@@ -29,7 +29,8 @@ import org.springframework.context.annotation.Import;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Import({ SqsAsyncClientConfiguration.class, SqsClientConfiguration.class, SqsConfiguration.class })
+@Import({ SqsAsyncClientConfiguration.class, SqsClientConfiguration.class,
+		SqsConfiguration.class })
 public @interface EnableSqs {
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/EnableSqs.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Import;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Import({ SqsClientConfiguration.class, SqsConfiguration.class })
+@Import({ SqsAsyncClientConfiguration.class, SqsClientConfiguration.class, SqsConfiguration.class })
 public @interface EnableSqs {
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfiguration.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.aws.messaging.config.annotation;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
@@ -36,15 +35,15 @@ import org.springframework.context.annotation.Configuration;
 public class SnsConfiguration {
 
 	@Autowired(required = false)
-	private AWSCredentialsProvider awsCredentialsProvider;
+	private AwsCredentialsProvider awsCredentialsProvider;
 
 	@Autowired(required = false)
 	private RegionProvider regionProvider;
 
-	@ConditionalOnMissingAmazonClient(AmazonSNS.class)
+	@ConditionalOnMissingAmazonClient(SnsClient.class)
 	@Bean
-	public AmazonWebserviceClientFactoryBean<AmazonSNSClient> amazonSNS() {
-		return new AmazonWebserviceClientFactoryBean<>(AmazonSNSClient.class,
+	public AmazonWebserviceClientFactoryBean<SnsClient> amazonSNS() {
+		return new AmazonWebserviceClientFactoryBean<>(SnsClient.class,
 				this.awsCredentialsProvider, this.regionProvider);
 	}
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsWebConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SnsWebConfiguration.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.aws.messaging.config.annotation;
 
 import java.util.List;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnClass;
@@ -36,7 +36,7 @@ import static org.springframework.cloud.aws.messaging.endpoint.config.Notificati
 public class SnsWebConfiguration implements WebMvcConfigurer {
 
 	@Autowired
-	private AmazonSNS amazonSns;
+	private SnsClient amazonSns;
 
 	@Override
 	public void addArgumentResolvers(

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsAsyncClientConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsAsyncClientConfiguration.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.aws.messaging.config.annotation;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Lazy;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnMissingAmazonClient(SqsClient.class)
-public class SqsClientConfiguration {
+@ConditionalOnMissingAmazonClient(SqsAsyncClient.class)
+public class SqsAsyncClientConfiguration {
 
 	@Autowired(required = false)
 	private AwsCredentialsProvider awsCredentialsProvider;
@@ -43,10 +43,16 @@ public class SqsClientConfiguration {
 
 	@Lazy
 	@Bean(destroyMethod = "close")
-	public SqsClient amazonSqs() throws Exception {
-		AmazonWebserviceClientFactoryBean<SqsClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
-			SqsClient.class, this.awsCredentialsProvider, this.regionProvider);
+	public SqsAsyncClient amazonSqsAsync() throws Exception {
+		AmazonWebserviceClientFactoryBean<SqsAsyncClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
+				SqsAsyncClient.class, this.awsCredentialsProvider, this.regionProvider);
 		clientFactoryBean.afterPropertiesSet();
+		// TODO SDK2 migration: update
+		// Important
+		// The AWS SDK for Java 2.x isn't currently compatible with the
+		// AmazonSQSBufferedAsyncClient.
+		// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-client-side-buffering-request-batching.html
+		// return new AmazonSQSBufferedAsyncClient(clientFactoryBean.getObject());
 		return clientFactoryBean.getObject();
 	}
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.aws.messaging.config.annotation;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
-import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
@@ -34,23 +32,28 @@ import org.springframework.context.annotation.Lazy;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnMissingAmazonClient(AmazonSQS.class)
+@ConditionalOnMissingAmazonClient(SqsAsyncClient.class)
 public class SqsClientConfiguration {
 
 	@Autowired(required = false)
-	private AWSCredentialsProvider awsCredentialsProvider;
+	private AwsCredentialsProvider awsCredentialsProvider;
 
 	@Autowired(required = false)
 	private RegionProvider regionProvider;
 
 	@Lazy
 	@Bean(destroyMethod = "shutdown")
-	public AmazonSQSBufferedAsyncClient amazonSQS() throws Exception {
-		AmazonWebserviceClientFactoryBean<AmazonSQSAsyncClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
-				AmazonSQSAsyncClient.class, this.awsCredentialsProvider,
-				this.regionProvider);
+	public SqsAsyncClient amazonSQS() throws Exception {
+		AmazonWebserviceClientFactoryBean<SqsAsyncClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
+				SqsAsyncClient.class, this.awsCredentialsProvider, this.regionProvider);
 		clientFactoryBean.afterPropertiesSet();
-		return new AmazonSQSBufferedAsyncClient(clientFactoryBean.getObject());
+		// TODO SDK2 migration: update
+		// Important
+		// The AWS SDK for Java 2.x isn't currently compatible with the
+		// AmazonSQSBufferedAsyncClient.
+		// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-client-side-buffering-request-batching.html
+		// return new AmazonSQSBufferedAsyncClient(clientFactoryBean.getObject());
+		return clientFactoryBean.getObject();
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsClientConfiguration.java
@@ -45,7 +45,7 @@ public class SqsClientConfiguration {
 	@Bean(destroyMethod = "close")
 	public SqsClient amazonSqs() throws Exception {
 		AmazonWebserviceClientFactoryBean<SqsClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
-			SqsClient.class, this.awsCredentialsProvider, this.regionProvider);
+				SqsClient.class, this.awsCredentialsProvider, this.regionProvider);
 		clientFactoryBean.afterPropertiesSet();
 		return clientFactoryBean.getObject();
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.messaging.config.annotation;
 
 import java.util.Arrays;
 
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -64,9 +65,12 @@ public class SqsConfiguration {
 
 	@Bean
 	public SimpleMessageListenerContainer simpleMessageListenerContainer(
-			SqsClient amazonSqs) {
+			SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
 		if (this.simpleMessageListenerContainerFactory.getAmazonSqs() == null) {
 			this.simpleMessageListenerContainerFactory.setAmazonSqs(amazonSqs);
+		}
+		if (this.simpleMessageListenerContainerFactory.getAmazonSqsAsync() == null) {
+			this.simpleMessageListenerContainerFactory.setAmazonSqsAsync(amazonSqsAsync);
 		}
 		if (this.simpleMessageListenerContainerFactory.getResourceIdResolver() == null) {
 			this.simpleMessageListenerContainerFactory
@@ -75,23 +79,26 @@ public class SqsConfiguration {
 
 		SimpleMessageListenerContainer simpleMessageListenerContainer = this.simpleMessageListenerContainerFactory
 				.createSimpleMessageListenerContainer();
-		simpleMessageListenerContainer.setMessageHandler(queueMessageHandler(amazonSqs));
+		simpleMessageListenerContainer.setMessageHandler(queueMessageHandler(amazonSqs, amazonSqsAsync));
 		return simpleMessageListenerContainer;
 	}
 
 	@Bean
-	public QueueMessageHandler queueMessageHandler(SqsClient amazonSqs) {
+	public QueueMessageHandler queueMessageHandler(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
 		if (this.simpleMessageListenerContainerFactory.getQueueMessageHandler() != null) {
 			return this.simpleMessageListenerContainerFactory.getQueueMessageHandler();
 		}
 		else {
-			return getMessageHandler(amazonSqs);
+			return getMessageHandler(amazonSqs, amazonSqsAsync);
 		}
 	}
 
-	private QueueMessageHandler getMessageHandler(SqsClient amazonSqs) {
+	private QueueMessageHandler getMessageHandler(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
 		if (this.queueMessageHandlerFactory.getAmazonSqs() == null) {
 			this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
+		}
+		if (this.queueMessageHandlerFactory.getAmazonSqsAsync() == null) {
+			this.queueMessageHandlerFactory.setAmazonSqsAsync(amazonSqsAsync);
 		}
 
 		if (CollectionUtils

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.aws.messaging.config.annotation;
 
 import java.util.Arrays;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +64,7 @@ public class SqsConfiguration {
 
 	@Bean
 	public SimpleMessageListenerContainer simpleMessageListenerContainer(
-			AmazonSQSAsync amazonSqs) {
+			SqsClient amazonSqs) {
 		if (this.simpleMessageListenerContainerFactory.getAmazonSqs() == null) {
 			this.simpleMessageListenerContainerFactory.setAmazonSqs(amazonSqs);
 		}
@@ -80,7 +80,7 @@ public class SqsConfiguration {
 	}
 
 	@Bean
-	public QueueMessageHandler queueMessageHandler(AmazonSQSAsync amazonSqs) {
+	public QueueMessageHandler queueMessageHandler(SqsClient amazonSqs) {
 		if (this.simpleMessageListenerContainerFactory.getQueueMessageHandler() != null) {
 			return this.simpleMessageListenerContainerFactory.getQueueMessageHandler();
 		}
@@ -89,7 +89,7 @@ public class SqsConfiguration {
 		}
 	}
 
-	private QueueMessageHandler getMessageHandler(AmazonSQSAsync amazonSqs) {
+	private QueueMessageHandler getMessageHandler(SqsClient amazonSqs) {
 		if (this.queueMessageHandlerFactory.getAmazonSqs() == null) {
 			this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
 		}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -79,12 +79,14 @@ public class SqsConfiguration {
 
 		SimpleMessageListenerContainer simpleMessageListenerContainer = this.simpleMessageListenerContainerFactory
 				.createSimpleMessageListenerContainer();
-		simpleMessageListenerContainer.setMessageHandler(queueMessageHandler(amazonSqs, amazonSqsAsync));
+		simpleMessageListenerContainer
+				.setMessageHandler(queueMessageHandler(amazonSqs, amazonSqsAsync));
 		return simpleMessageListenerContainer;
 	}
 
 	@Bean
-	public QueueMessageHandler queueMessageHandler(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
+	public QueueMessageHandler queueMessageHandler(SqsClient amazonSqs,
+			SqsAsyncClient amazonSqsAsync) {
 		if (this.simpleMessageListenerContainerFactory.getQueueMessageHandler() != null) {
 			return this.simpleMessageListenerContainerFactory.getQueueMessageHandler();
 		}
@@ -93,7 +95,8 @@ public class SqsConfiguration {
 		}
 	}
 
-	private QueueMessageHandler getMessageHandler(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
+	private QueueMessageHandler getMessageHandler(SqsClient amazonSqs,
+			SqsAsyncClient amazonSqsAsync) {
 		if (this.queueMessageHandlerFactory.getAmazonSqs() == null) {
 			this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
 		}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
@@ -63,7 +63,8 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParser
 	private static final String BACK_OFF_TIME = "back-off-time";
 
 	private static String getMessageHandlerBeanName(Element element,
-			ParserContext parserContext, String sqsClientBeanName, String sqsAsyncClientBeanName) {
+			ParserContext parserContext, String sqsClientBeanName,
+			String sqsAsyncClientBeanName) {
 		BeanDefinitionBuilder queueMessageHandlerDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(QueueMessageHandler.class);
 
@@ -102,7 +103,8 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParser
 	}
 
 	private static AbstractBeanDefinition createSendToHandlerMethodReturnValueHandlerBeanDefinition(
-			Element element, ParserContext parserContext, String sqsClientBeanName, String sqsAsyncClientBeanName) {
+			Element element, ParserContext parserContext, String sqsClientBeanName,
+			String sqsAsyncClientBeanName) {
 		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(SendToHandlerMethodReturnValueHandler.class);
 		if (StringUtils.hasText(element.getAttribute("send-to-message-template"))) {
@@ -220,18 +222,19 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParser
 
 		containerBuilder.addPropertyReference(
 				Conventions.attributeNameToPropertyName("amazon-sqs-async"),
-			amazonSqsAsyncClientBeanName);
+				amazonSqsAsyncClientBeanName);
 
 		String amazonSqsClientBeanName = getSqsClientBeanName(element, parserContext);
 		containerBuilder.addPropertyReference(
 				Conventions.attributeNameToPropertyName("amazon-sqs"),
-			amazonSqsClientBeanName);
+				amazonSqsClientBeanName);
 
 		containerBuilder.addPropertyReference("resourceIdResolver",
 				GlobalBeanDefinitionUtils
 						.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
-		containerBuilder.addPropertyReference("messageHandler", getMessageHandlerBeanName(
-				element, parserContext, amazonSqsClientBeanName, amazonSqsAsyncClientBeanName));
+		containerBuilder.addPropertyReference("messageHandler",
+				getMessageHandlerBeanName(element, parserContext, amazonSqsClientBeanName,
+						amazonSqsAsyncClientBeanName));
 
 		return containerBuilder.getBeanDefinition();
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
@@ -26,7 +26,6 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
-import org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils;
 import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
 import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
 import org.springframework.cloud.aws.messaging.listener.SendToHandlerMethodReturnValueHandler;
@@ -35,7 +34,8 @@ import org.springframework.core.Conventions;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
-import static org.springframework.cloud.aws.messaging.config.xml.BufferedSqsClientBeanDefinitionUtils.getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName;
+import static org.springframework.cloud.aws.messaging.config.xml.SqsClientBeanDefinitionUtils.getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName;
+import static org.springframework.cloud.aws.messaging.config.xml.SqsClientBeanDefinitionUtils.getSqsClientBeanName;
 
 /**
  * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} for the
@@ -215,16 +215,14 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParser
 					element.getAttribute(BACK_OFF_TIME));
 		}
 
-		String amazonSqsAsyncClientBeanName = getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(
+		String amazonSqsAsyncClientBeanName = getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName(
 				element, parserContext);
 
 		containerBuilder.addPropertyReference(
 				Conventions.attributeNameToPropertyName("amazon-sqs-async"),
 			amazonSqsAsyncClientBeanName);
 
-		String amazonSqsClientBeanName = XmlWebserviceConfigurationUtils
-			.getCustomClientOrDefaultClientBeanName(element, parserContext,
-				"amazon-sqs", "software.amazon.awssdk.services.sqs.SqsClient");
+		String amazonSqsClientBeanName = getSqsClientBeanName(element, parserContext);
 		containerBuilder.addPropertyReference(
 				Conventions.attributeNameToPropertyName("amazon-sqs"),
 			amazonSqsClientBeanName);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.aws.messaging.config.xml;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils;
 import org.springframework.util.StringUtils;
@@ -34,11 +33,12 @@ public final class BufferedSqsClientBeanDefinitionUtils {
 	 * SQS client class name.
 	 */
 	// @checkstyle:off
-	public static final String SQS_CLIENT_CLASS_NAME = "com.amazonaws.services.sqs.AmazonSQSAsyncClient";
+	public static final String SQS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.sqs.SqsAsyncClient";
 
 	// @checkstyle:on
 
 	// @checkstyle:off
+	// TODO SDK2 migration: update
 	static final String BUFFERED_SQS_CLIENT_CLASS_NAME = "com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient";
 
 	// @checkstyle:on
@@ -51,21 +51,22 @@ public final class BufferedSqsClientBeanDefinitionUtils {
 			Element element, ParserContext parserContext) {
 		String amazonSqsClientBeanName = XmlWebserviceConfigurationUtils
 				.getCustomClientOrDefaultClientBeanName(element, parserContext,
-						"amazon-sqs", SQS_CLIENT_CLASS_NAME);
-		if (!StringUtils.hasText(element.getAttribute("amazon-sqs"))) {
+						"amazon-sqs-async", SQS_CLIENT_CLASS_NAME);
+		if (!StringUtils.hasText(element.getAttribute("amazon-sqs-async"))) {
 			BeanDefinition clientBeanDefinition = parserContext.getRegistry()
 					.getBeanDefinition(amazonSqsClientBeanName);
-			if (!clientBeanDefinition.getBeanClassName()
-					.equals(BUFFERED_SQS_CLIENT_CLASS_NAME)) {
-				BeanDefinitionBuilder bufferedClientBeanDefinitionBuilder = BeanDefinitionBuilder
-						.rootBeanDefinition(BUFFERED_SQS_CLIENT_CLASS_NAME);
-				bufferedClientBeanDefinitionBuilder
-						.addConstructorArgValue(clientBeanDefinition);
-				parserContext.getRegistry().removeBeanDefinition(amazonSqsClientBeanName);
-				parserContext.getRegistry().registerBeanDefinition(
-						amazonSqsClientBeanName,
-						bufferedClientBeanDefinitionBuilder.getBeanDefinition());
-			}
+			// TODO SDK2 migration: re-add
+//			if (!clientBeanDefinition.getBeanClassName()
+//					.equals(BUFFERED_SQS_CLIENT_CLASS_NAME)) {
+//				BeanDefinitionBuilder bufferedClientBeanDefinitionBuilder = BeanDefinitionBuilder
+//						.rootBeanDefinition(BUFFERED_SQS_CLIENT_CLASS_NAME);
+//				bufferedClientBeanDefinitionBuilder
+//						.addConstructorArgValue(clientBeanDefinition);
+//				parserContext.getRegistry().removeBeanDefinition(amazonSqsClientBeanName);
+//				parserContext.getRegistry().registerBeanDefinition(
+//						amazonSqsClientBeanName,
+//						bufferedClientBeanDefinitionBuilder.getBeanDefinition());
+//			}
 		}
 		return amazonSqsClientBeanName;
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
@@ -40,7 +40,7 @@ class NotificationArgumentResolverBeanDefinitionParser
 			BeanDefinitionBuilder builder) {
 		builder.addConstructorArgReference(
 				getCustomClientOrDefaultClientBeanName(element, parserContext,
-						"amazon-sns", "com.amazonaws.services.sns.AmazonSNSClient"));
+						"amazon-sns", "software.amazon.awssdk.services.sns.SnsClient"));
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
@@ -35,7 +35,7 @@ public class NotificationMessagingTemplateBeanDefinitionParser
 
 	private static final String DEFAULT_DESTINATION_ATTRIBUTE = "default-destination";
 
-	private static final String SNS_CLIENT_CLASS_NAME = "com.amazonaws.services.sns.AmazonSNSClient";
+	private static final String SNS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.sns.SnsClient";
 
 	@Override
 	protected Class<?> getBeanClass(Element element) {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
@@ -22,11 +22,11 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
-import org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils;
 import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.cloud.aws.messaging.config.xml.BufferedSqsClientBeanDefinitionUtils.getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName;
+import static org.springframework.cloud.aws.messaging.config.xml.SqsClientBeanDefinitionUtils.getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName;
+import static org.springframework.cloud.aws.messaging.config.xml.SqsClientBeanDefinitionUtils.getSqsClientBeanName;
 
 /**
  * @author Alain Sahli
@@ -46,7 +46,8 @@ public class QueueMessagingTemplateBeanDefinitionParser
 	@Override
 	protected void doParse(Element element, ParserContext parserContext,
 			BeanDefinitionBuilder builder) {
-		String amazonSqsClientBeanName = getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(
+		String amazonSqsClientBeanName = getSqsClientBeanName(element, parserContext);
+		String amazonSqsAsyncClientBeanName = getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName(
 				element, parserContext);
 
 		if (StringUtils.hasText(element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE))) {
@@ -54,11 +55,8 @@ public class QueueMessagingTemplateBeanDefinitionParser
 					element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE));
 		}
 
-		// TODO SDK2 migration: remove duplication
-		builder.addConstructorArgReference(XmlWebserviceConfigurationUtils
-			.getCustomClientOrDefaultClientBeanName(element, parserContext,
-				"amazon-sqs", "software.amazon.awssdk.services.sqs.SqsClient"));
 		builder.addConstructorArgReference(amazonSqsClientBeanName);
+		builder.addConstructorArgReference(amazonSqsAsyncClientBeanName);
 		builder.addConstructorArgReference(GlobalBeanDefinitionUtils
 				.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils;
 import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
 import org.springframework.util.StringUtils;
 
@@ -53,6 +54,10 @@ public class QueueMessagingTemplateBeanDefinitionParser
 					element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE));
 		}
 
+		// TODO SDK2 migration: remove duplication
+		builder.addConstructorArgReference(XmlWebserviceConfigurationUtils
+			.getCustomClientOrDefaultClientBeanName(element, parserContext,
+				"amazon-sqs", "software.amazon.awssdk.services.sqs.SqsClient"));
 		builder.addConstructorArgReference(amazonSqsClientBeanName);
 		builder.addConstructorArgReference(GlobalBeanDefinitionUtils
 				.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
@@ -46,15 +46,16 @@ public class SqsAsyncClientBeanDefinitionParser extends AbstractBeanDefinitionPa
 			sqsAsyncClientDefinition.getPropertyValues().addPropertyValue("executor",
 					builder.getBeanDefinition());
 		}
-		if (Boolean.parseBoolean(element.getAttribute("buffered"))) {
-			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-					BufferedSqsClientBeanDefinitionUtils.BUFFERED_SQS_CLIENT_CLASS_NAME);
-			builder.addConstructorArgValue(sqsAsyncClientDefinition);
-			return builder.getBeanDefinition();
-		}
-		else {
+		// TODO SDK2 migration: re-add
+//		if (Boolean.parseBoolean(element.getAttribute("buffered"))) {
+//			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
+//					BufferedSqsClientBeanDefinitionUtils.BUFFERED_SQS_CLIENT_CLASS_NAME);
+//			builder.addConstructorArgValue(sqsAsyncClientDefinition);
+//			return builder.getBeanDefinition();
+//		}
+//		else {
 			return sqsAsyncClientDefinition;
-		}
+//		}
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
@@ -47,15 +47,15 @@ public class SqsAsyncClientBeanDefinitionParser extends AbstractBeanDefinitionPa
 					builder.getBeanDefinition());
 		}
 		// TODO SDK2 migration: re-add
-//		if (Boolean.parseBoolean(element.getAttribute("buffered"))) {
-//			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-//					BufferedSqsClientBeanDefinitionUtils.BUFFERED_SQS_CLIENT_CLASS_NAME);
-//			builder.addConstructorArgValue(sqsAsyncClientDefinition);
-//			return builder.getBeanDefinition();
-//		}
-//		else {
-			return sqsAsyncClientDefinition;
-//		}
+		// if (Boolean.parseBoolean(element.getAttribute("buffered"))) {
+		// BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
+		// BufferedSqsClientBeanDefinitionUtils.BUFFERED_SQS_CLIENT_CLASS_NAME);
+		// builder.addConstructorArgValue(sqsAsyncClientDefinition);
+		// return builder.getBeanDefinition();
+		// }
+		// else {
+		return sqsAsyncClientDefinition;
+		// }
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
@@ -38,7 +38,7 @@ public class SqsAsyncClientBeanDefinitionParser extends AbstractBeanDefinitionPa
 			ParserContext parserContext) {
 		AbstractBeanDefinition sqsAsyncClientDefinition = parseCustomClientElement(
 				element, parserContext,
-				BufferedSqsClientBeanDefinitionUtils.SQS_CLIENT_CLASS_NAME);
+				SqsClientBeanDefinitionUtils.SQS_ASYNC_CLIENT_CLASS_NAME);
 		if (StringUtils.hasText(element.getAttribute("task-executor"))) {
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
 					ShutdownSuppressingExecutorServiceAdapter.class);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsClientBeanDefinitionUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsClientBeanDefinitionUtils.java
@@ -29,7 +29,6 @@ import org.springframework.util.StringUtils;
  */
 public final class SqsClientBeanDefinitionUtils {
 
-
 	/**
 	 * SQS async client class name.
 	 */
@@ -51,10 +50,10 @@ public final class SqsClientBeanDefinitionUtils {
 	}
 
 	static String getSqsClientBeanName(Element element, ParserContext parserContext) {
-		return  XmlWebserviceConfigurationUtils
-			.getCustomClientOrDefaultClientBeanName(element, parserContext,
-				"amazon-sqs", SQS_CLIENT_CLASS_NAME);
+		return XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName(
+				element, parserContext, "amazon-sqs", SQS_CLIENT_CLASS_NAME);
 	}
+
 	static String getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName(
 			Element element, ParserContext parserContext) {
 		String amazonSqsClientBeanName = XmlWebserviceConfigurationUtils
@@ -64,17 +63,18 @@ public final class SqsClientBeanDefinitionUtils {
 			BeanDefinition clientBeanDefinition = parserContext.getRegistry()
 					.getBeanDefinition(amazonSqsClientBeanName);
 			// TODO SDK2 migration: re-add
-//			if (!clientBeanDefinition.getBeanClassName()
-//					.equals(BUFFERED_SQS_CLIENT_CLASS_NAME)) {
-//				BeanDefinitionBuilder bufferedClientBeanDefinitionBuilder = BeanDefinitionBuilder
-//						.rootBeanDefinition(BUFFERED_SQS_CLIENT_CLASS_NAME);
-//				bufferedClientBeanDefinitionBuilder
-//						.addConstructorArgValue(clientBeanDefinition);
-//				parserContext.getRegistry().removeBeanDefinition(amazonSqsClientBeanName);
-//				parserContext.getRegistry().registerBeanDefinition(
-//						amazonSqsClientBeanName,
-//						bufferedClientBeanDefinitionBuilder.getBeanDefinition());
-//			}
+			// if (!clientBeanDefinition.getBeanClassName()
+			// .equals(BUFFERED_SQS_CLIENT_CLASS_NAME)) {
+			// BeanDefinitionBuilder bufferedClientBeanDefinitionBuilder =
+			// BeanDefinitionBuilder
+			// .rootBeanDefinition(BUFFERED_SQS_CLIENT_CLASS_NAME);
+			// bufferedClientBeanDefinitionBuilder
+			// .addConstructorArgValue(clientBeanDefinition);
+			// parserContext.getRegistry().removeBeanDefinition(amazonSqsClientBeanName);
+			// parserContext.getRegistry().registerBeanDefinition(
+			// amazonSqsClientBeanName,
+			// bufferedClientBeanDefinitionBuilder.getBeanDefinition());
+			// }
 		}
 		return amazonSqsClientBeanName;
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsClientBeanDefinitionUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsClientBeanDefinitionUtils.java
@@ -27,13 +27,14 @@ import org.springframework.util.StringUtils;
  * @author Alain Sahli
  * @author Agim Emruli
  */
-public final class BufferedSqsClientBeanDefinitionUtils {
+public final class SqsClientBeanDefinitionUtils {
+
 
 	/**
-	 * SQS client class name.
+	 * SQS async client class name.
 	 */
 	// @checkstyle:off
-	public static final String SQS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.sqs.SqsAsyncClient";
+	public static final String SQS_ASYNC_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.sqs.SqsAsyncClient";
 
 	// @checkstyle:on
 
@@ -43,15 +44,22 @@ public final class BufferedSqsClientBeanDefinitionUtils {
 
 	// @checkstyle:on
 
-	private BufferedSqsClientBeanDefinitionUtils() {
+	private static final String SQS_CLIENT_CLASS_NAME = "software.amazon.awssdk.services.sqs.SqsClient";
+
+	private SqsClientBeanDefinitionUtils() {
 		// Avoid instantiation
 	}
 
-	static String getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(
+	static String getSqsClientBeanName(Element element, ParserContext parserContext) {
+		return  XmlWebserviceConfigurationUtils
+			.getCustomClientOrDefaultClientBeanName(element, parserContext,
+				"amazon-sqs", SQS_CLIENT_CLASS_NAME);
+	}
+	static String getCustomAmazonSqsAsyncClientOrDecoratedDefaultSqsAsyncClientBeanName(
 			Element element, ParserContext parserContext) {
 		String amazonSqsClientBeanName = XmlWebserviceConfigurationUtils
 				.getCustomClientOrDefaultClientBeanName(element, parserContext,
-						"amazon-sqs-async", SQS_CLIENT_CLASS_NAME);
+						"amazon-sqs-async", SQS_ASYNC_CLIENT_CLASS_NAME);
 		if (!StringUtils.hasText(element.getAttribute("amazon-sqs-async"))) {
 			BeanDefinition clientBeanDefinition = parserContext.getRegistry()
 					.getBeanDefinition(amazonSqsClientBeanName);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/NotificationMessagingTemplate.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.aws.messaging.core;
 
 import java.util.Collections;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.cloud.aws.messaging.core.support.AbstractMessageChannelMessagingSendingTemplate;
@@ -33,25 +33,25 @@ import org.springframework.messaging.core.DestinationResolver;
 public class NotificationMessagingTemplate
 		extends AbstractMessageChannelMessagingSendingTemplate<TopicMessageChannel> {
 
-	private final AmazonSNS amazonSns;
+	private final SnsClient amazonSns;
 
-	public NotificationMessagingTemplate(AmazonSNS amazonSns) {
+	public NotificationMessagingTemplate(SnsClient amazonSns) {
 		this(amazonSns, (ResourceIdResolver) null, null);
 	}
 
-	public NotificationMessagingTemplate(AmazonSNS amazonSns,
+	public NotificationMessagingTemplate(SnsClient amazonSns,
 			ResourceIdResolver resourceIdResolver) {
 		this(amazonSns, resourceIdResolver, null);
 	}
 
-	public NotificationMessagingTemplate(AmazonSNS amazonSns,
+	public NotificationMessagingTemplate(SnsClient amazonSns,
 			ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
 		super(new DynamicTopicDestinationResolver(amazonSns, resourceIdResolver));
 		this.amazonSns = amazonSns;
 		initMessageConverter(messageConverter);
 	}
 
-	public NotificationMessagingTemplate(AmazonSNS amazonSns,
+	public NotificationMessagingTemplate(SnsClient amazonSns,
 			DestinationResolver<String> destinationResolver,
 			MessageConverter messageConverter) {
 		super(destinationResolver);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannel.java
@@ -60,11 +60,13 @@ public class QueueMessageChannel extends AbstractMessageChannel
 	private static final String MESSAGE_ATTRIBUTE_NAMES = "All";
 
 	private final SqsClient amazonSqs;
+
 	private final SqsAsyncClient amazonSqsAsync;
 
 	private final String queueUrl;
 
-	public QueueMessageChannel(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync, String queueUrl) {
+	public QueueMessageChannel(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync,
+			String queueUrl) {
 		this.amazonSqs = amazonSqs;
 		this.amazonSqsAsync = amazonSqsAsync;
 		this.queueUrl = queueUrl;
@@ -127,7 +129,8 @@ public class QueueMessageChannel extends AbstractMessageChannel
 	private void sendMessageAndWaitForResult(SendMessageRequest sendMessageRequest,
 			long timeout) throws ExecutionException, TimeoutException {
 		if (timeout > 0) {
-			Future<SendMessageResponse> sendMessageFuture = this.amazonSqsAsync.sendMessage(sendMessageRequest);
+			Future<SendMessageResponse> sendMessageFuture = this.amazonSqsAsync
+					.sendMessage(sendMessageRequest);
 
 			try {
 				sendMessageFuture.get(timeout, TimeUnit.MILLISECONDS);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
@@ -71,7 +71,7 @@ public final class QueueMessageUtils {
 		Map<String, Object> messageHeaders = new HashMap<>();
 		for (Map.Entry<MessageSystemAttributeName, String> attributeKeyValuePair : message
 				.attributes().entrySet()) {
-			messageHeaders.put(attributeKeyValuePair.getKey().name(),
+			messageHeaders.put(attributeKeyValuePair.getKey().toString(),
 					attributeKeyValuePair.getValue());
 		}
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
@@ -49,30 +49,31 @@ public class QueueMessagingTemplate
 		implements DestinationResolvingMessageReceivingOperations<QueueMessageChannel> {
 
 	private final SqsClient amazonSqs;
+	private final SqsAsyncClient amazonSqsAsync;
 
-	public QueueMessagingTemplate(SqsClient amazonSqs) {
-		this(amazonSqs, (ResourceIdResolver) null, null);
+	public QueueMessagingTemplate(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
+		this(amazonSqs, amazonSqsAsync, (ResourceIdResolver) null, null);
 	}
 
 	public QueueMessagingTemplate(SqsClient amazonSqs,
-			ResourceIdResolver resourceIdResolver) {
-		this(amazonSqs, resourceIdResolver, null);
+		SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
+		this(amazonSqs, amazonSqsAsync, resourceIdResolver, null);
 	}
 
 	/**
 	 * Initializes the messaging template by configuring the resource Id resolver as well
 	 * as the message converter. Uses the {@link DynamicQueueUrlDestinationResolver} with
 	 * the default configuration to resolve destination names.
-	 * @param amazonSqs The {@link SqsAsyncClient} client, cannot be {@code null}.
+	 * @param amazonSqs The {@link SqsClient} client, cannot be {@code null}.
+	 * @param amazonSqsAsync The {@link SqsAsyncClient} client, cannot be {@code null}.
 	 * @param resourceIdResolver The {@link ResourceIdResolver} to be used for resolving
 	 * logical queue names.
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
-	 * composite converter.
 	 */
 	public QueueMessagingTemplate(SqsClient amazonSqs,
-			ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
+		SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
 		this(amazonSqs,
-				new DynamicQueueUrlDestinationResolver(amazonSqs, resourceIdResolver),
+			amazonSqsAsync, new DynamicQueueUrlDestinationResolver(amazonSqs, resourceIdResolver),
 				messageConverter);
 	}
 
@@ -80,26 +81,27 @@ public class QueueMessagingTemplate
 	 * Initializes the messaging template by configuring the destination resolver as well
 	 * as the message converter. Uses the {@link DynamicQueueUrlDestinationResolver} with
 	 * the default configuration to resolve destination names.
-	 * @param amazonSqs The {@link SqsAsyncClient} client, cannot be {@code null}.
+	 * @param amazonSqs The {@link SqsClient} client, cannot be {@code null}.
+	 * @param amazonSqsAsync The {@link SqsAsyncClient} client, cannot be {@code null}.
 	 * @param destinationResolver A destination resolver implementation to resolve queue
 	 * names into queue urls. The destination resolver will be wrapped into a
 	 * {@link org.springframework.messaging.core.CachingDestinationResolverProxy} to avoid
 	 * duplicate queue url resolutions.
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
-	 * composite converter.
 	 */
 	public QueueMessagingTemplate(SqsClient amazonSqs,
-			DestinationResolver<String> destinationResolver,
-			MessageConverter messageConverter) {
+		SqsAsyncClient amazonSqsAsync, DestinationResolver<String> destinationResolver,
+		MessageConverter messageConverter) {
 		super(destinationResolver);
 		this.amazonSqs = amazonSqs;
+		this.amazonSqsAsync = amazonSqsAsync;
 		initMessageConverter(messageConverter);
 	}
 
 	@Override
 	protected QueueMessageChannel resolveMessageChannel(
 			String physicalResourceIdentifier) {
-		return new QueueMessageChannel(this.amazonSqs, physicalResourceIdentifier);
+		return new QueueMessageChannel(this.amazonSqs, this.amazonSqsAsync, physicalResourceIdentifier);
 	}
 
 	@Override

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.aws.messaging.core;
 
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSAsync;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.cloud.aws.messaging.core.support.AbstractMessageChannelMessagingSendingTemplate;
@@ -48,13 +48,13 @@ public class QueueMessagingTemplate
 		extends AbstractMessageChannelMessagingSendingTemplate<QueueMessageChannel>
 		implements DestinationResolvingMessageReceivingOperations<QueueMessageChannel> {
 
-	private final AmazonSQSAsync amazonSqs;
+	private final SqsClient amazonSqs;
 
-	public QueueMessagingTemplate(AmazonSQSAsync amazonSqs) {
+	public QueueMessagingTemplate(SqsClient amazonSqs) {
 		this(amazonSqs, (ResourceIdResolver) null, null);
 	}
 
-	public QueueMessagingTemplate(AmazonSQSAsync amazonSqs,
+	public QueueMessagingTemplate(SqsClient amazonSqs,
 			ResourceIdResolver resourceIdResolver) {
 		this(amazonSqs, resourceIdResolver, null);
 	}
@@ -63,13 +63,13 @@ public class QueueMessagingTemplate
 	 * Initializes the messaging template by configuring the resource Id resolver as well
 	 * as the message converter. Uses the {@link DynamicQueueUrlDestinationResolver} with
 	 * the default configuration to resolve destination names.
-	 * @param amazonSqs The {@link AmazonSQS} client, cannot be {@code null}.
+	 * @param amazonSqs The {@link SqsAsyncClient} client, cannot be {@code null}.
 	 * @param resourceIdResolver The {@link ResourceIdResolver} to be used for resolving
 	 * logical queue names.
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
 	 * composite converter.
 	 */
-	public QueueMessagingTemplate(AmazonSQSAsync amazonSqs,
+	public QueueMessagingTemplate(SqsClient amazonSqs,
 			ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
 		this(amazonSqs,
 				new DynamicQueueUrlDestinationResolver(amazonSqs, resourceIdResolver),
@@ -80,7 +80,7 @@ public class QueueMessagingTemplate
 	 * Initializes the messaging template by configuring the destination resolver as well
 	 * as the message converter. Uses the {@link DynamicQueueUrlDestinationResolver} with
 	 * the default configuration to resolve destination names.
-	 * @param amazonSqs The {@link AmazonSQS} client, cannot be {@code null}.
+	 * @param amazonSqs The {@link SqsAsyncClient} client, cannot be {@code null}.
 	 * @param destinationResolver A destination resolver implementation to resolve queue
 	 * names into queue urls. The destination resolver will be wrapped into a
 	 * {@link org.springframework.messaging.core.CachingDestinationResolverProxy} to avoid
@@ -88,7 +88,7 @@ public class QueueMessagingTemplate
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
 	 * composite converter.
 	 */
-	public QueueMessagingTemplate(AmazonSQSAsync amazonSqs,
+	public QueueMessagingTemplate(SqsClient amazonSqs,
 			DestinationResolver<String> destinationResolver,
 			MessageConverter messageConverter) {
 		super(destinationResolver);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplate.java
@@ -49,14 +49,15 @@ public class QueueMessagingTemplate
 		implements DestinationResolvingMessageReceivingOperations<QueueMessageChannel> {
 
 	private final SqsClient amazonSqs;
+
 	private final SqsAsyncClient amazonSqsAsync;
 
 	public QueueMessagingTemplate(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync) {
 		this(amazonSqs, amazonSqsAsync, (ResourceIdResolver) null, null);
 	}
 
-	public QueueMessagingTemplate(SqsClient amazonSqs,
-		SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver) {
+	public QueueMessagingTemplate(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync,
+			ResourceIdResolver resourceIdResolver) {
 		this(amazonSqs, amazonSqsAsync, resourceIdResolver, null);
 	}
 
@@ -70,10 +71,10 @@ public class QueueMessagingTemplate
 	 * logical queue names.
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
 	 */
-	public QueueMessagingTemplate(SqsClient amazonSqs,
-		SqsAsyncClient amazonSqsAsync, ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
-		this(amazonSqs,
-			amazonSqsAsync, new DynamicQueueUrlDestinationResolver(amazonSqs, resourceIdResolver),
+	public QueueMessagingTemplate(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync,
+			ResourceIdResolver resourceIdResolver, MessageConverter messageConverter) {
+		this(amazonSqs, amazonSqsAsync,
+				new DynamicQueueUrlDestinationResolver(amazonSqs, resourceIdResolver),
 				messageConverter);
 	}
 
@@ -89,9 +90,9 @@ public class QueueMessagingTemplate
 	 * duplicate queue url resolutions.
 	 * @param messageConverter A {@link MessageConverter} that is going to be added to the
 	 */
-	public QueueMessagingTemplate(SqsClient amazonSqs,
-		SqsAsyncClient amazonSqsAsync, DestinationResolver<String> destinationResolver,
-		MessageConverter messageConverter) {
+	public QueueMessagingTemplate(SqsClient amazonSqs, SqsAsyncClient amazonSqsAsync,
+			DestinationResolver<String> destinationResolver,
+			MessageConverter messageConverter) {
 		super(destinationResolver);
 		this.amazonSqs = amazonSqs;
 		this.amazonSqsAsync = amazonSqsAsync;
@@ -101,7 +102,8 @@ public class QueueMessagingTemplate
 	@Override
 	protected QueueMessageChannel resolveMessageChannel(
 			String physicalResourceIdentifier) {
-		return new QueueMessageChannel(this.amazonSqs, this.amazonSqsAsync, physicalResourceIdentifier);
+		return new QueueMessageChannel(this.amazonSqs, this.amazonSqsAsync,
+				physicalResourceIdentifier);
 	}
 
 	@Override

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolver.java
@@ -16,8 +16,9 @@
 
 package org.springframework.cloud.aws.messaging.endpoint;
 
-import com.amazonaws.services.sns.AmazonSNS;
 import com.fasterxml.jackson.databind.JsonNode;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpInputMessage;
@@ -28,9 +29,9 @@ import org.springframework.http.HttpInputMessage;
 public class NotificationStatusHandlerMethodArgumentResolver
 		extends AbstractNotificationMessageHandlerMethodArgumentResolver {
 
-	private final AmazonSNS amazonSns;
+	private final SnsClient amazonSns;
 
-	public NotificationStatusHandlerMethodArgumentResolver(AmazonSNS amazonSns) {
+	public NotificationStatusHandlerMethodArgumentResolver(SnsClient amazonSns) {
 		this.amazonSns = amazonSns;
 	}
 
@@ -53,13 +54,13 @@ public class NotificationStatusHandlerMethodArgumentResolver
 
 	private static final class AmazonSnsNotificationStatus implements NotificationStatus {
 
-		private final AmazonSNS amazonSns;
+		private final SnsClient amazonSns;
 
 		private final String topicArn;
 
 		private final String confirmationToken;
 
-		private AmazonSnsNotificationStatus(AmazonSNS amazonSns, String topicArn,
+		private AmazonSnsNotificationStatus(SnsClient amazonSns, String topicArn,
 				String confirmationToken) {
 			this.amazonSns = amazonSns;
 			this.topicArn = topicArn;
@@ -68,7 +69,8 @@ public class NotificationStatusHandlerMethodArgumentResolver
 
 		@Override
 		public void confirmSubscription() {
-			this.amazonSns.confirmSubscription(this.topicArn, this.confirmationToken);
+			this.amazonSns.confirmSubscription(ConfirmSubscriptionRequest.builder()
+					.topicArn(this.topicArn).token(this.confirmationToken).build());
 		}
 
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverConfigurationUtils.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging.endpoint.config;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.cloud.aws.messaging.endpoint.NotificationMessageHandlerMethodArgumentResolver;
 import org.springframework.cloud.aws.messaging.endpoint.NotificationStatusHandlerMethodArgumentResolver;
@@ -35,7 +35,7 @@ public final class NotificationHandlerMethodArgumentResolverConfigurationUtils {
 	}
 
 	public static HandlerMethodArgumentResolver getNotificationHandlerMethodArgumentResolver(
-			AmazonSNS amazonSns) {
+			SnsClient amazonSns) {
 		HandlerMethodArgumentResolverComposite composite = new HandlerMethodArgumentResolverComposite();
 		composite.addResolver(
 				new NotificationStatusHandlerMethodArgumentResolver(amazonSns));

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBean.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBean.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.aws.messaging.endpoint.config;
 
-import com.amazonaws.services.sns.AmazonSNS;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.util.Assert;
@@ -31,9 +31,9 @@ import static org.springframework.cloud.aws.messaging.endpoint.config.Notificati
 public class NotificationHandlerMethodArgumentResolverFactoryBean
 		extends AbstractFactoryBean<HandlerMethodArgumentResolver> {
 
-	private final AmazonSNS amazonSns;
+	private final SnsClient amazonSns;
 
-	public NotificationHandlerMethodArgumentResolverFactoryBean(AmazonSNS amazonSns) {
+	public NotificationHandlerMethodArgumentResolverFactoryBean(SnsClient amazonSns) {
 		Assert.notNull(amazonSns, "AmazonSns must not be null");
 		this.amazonSns = amazonSns;
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/AbstractMessageListenerContainer.java
@@ -74,6 +74,7 @@ abstract class AbstractMessageListenerContainer
 	// setters hence there is no further synchronization
 	@SuppressWarnings("FieldAccessedSynchronizedAndUnsynchronized")
 	private SqsClient amazonSqs;
+
 	private SqsAsyncClient amazonSqsAsync;
 
 	@SuppressWarnings("FieldAccessedSynchronizedAndUnsynchronized")
@@ -145,7 +146,8 @@ abstract class AbstractMessageListenerContainer
 		this.amazonSqs = amazonSqs;
 	}
 
-	// TODO SDK2 migration: update comment depending on what to do about the buffering client
+	// TODO SDK2 migration: update comment depending on what to do about the buffering
+	// client
 	/**
 	 * Configures the mandatory {@link SqsAsyncClient} client for this instance.
 	 * <b>Note:</b>The configured instance should have a buffering amazon SQS instance

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageAcknowledgment.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageAcknowledgment.java
@@ -18,8 +18,8 @@ package org.springframework.cloud.aws.messaging.listener;
 
 import java.util.concurrent.Future;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 
 /**
  * @author Alain Sahli
@@ -27,13 +27,13 @@ import com.amazonaws.services.sqs.model.DeleteMessageRequest;
  */
 public class QueueMessageAcknowledgment implements Acknowledgment {
 
-	private final AmazonSQSAsync amazonSqsAsync;
+	private final SqsAsyncClient amazonSqsAsync;
 
 	private final String queueUrl;
 
 	private final String receiptHandle;
 
-	public QueueMessageAcknowledgment(AmazonSQSAsync amazonSqsAsync, String queueUrl,
+	public QueueMessageAcknowledgment(SqsAsyncClient amazonSqsAsync, String queueUrl,
 			String receiptHandle) {
 		this.amazonSqsAsync = amazonSqsAsync;
 		this.queueUrl = queueUrl;
@@ -42,8 +42,8 @@ public class QueueMessageAcknowledgment implements Acknowledgment {
 
 	@Override
 	public Future<?> acknowledge() {
-		return this.amazonSqsAsync.deleteMessageAsync(
-				new DeleteMessageRequest(this.queueUrl, this.receiptHandle));
+		return this.amazonSqsAsync.deleteMessage(DeleteMessageRequest.builder()
+				.queueUrl(this.queueUrl).receiptHandle(this.receiptHandle).build());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageVisibility.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageVisibility.java
@@ -18,8 +18,8 @@ package org.springframework.cloud.aws.messaging.listener;
 
 import java.util.concurrent.Future;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 
 /**
  * @author Szymon Dembek
@@ -27,13 +27,13 @@ import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
  */
 public class QueueMessageVisibility implements Visibility {
 
-	private final AmazonSQSAsync amazonSqsAsync;
+	private final SqsAsyncClient amazonSqsAsync;
 
 	private final String queueUrl;
 
 	private final String receiptHandle;
 
-	public QueueMessageVisibility(AmazonSQSAsync amazonSqsAsync, String queueUrl,
+	public QueueMessageVisibility(SqsAsyncClient amazonSqsAsync, String queueUrl,
 			String receiptHandle) {
 		this.amazonSqsAsync = amazonSqsAsync;
 		this.queueUrl = queueUrl;
@@ -42,10 +42,9 @@ public class QueueMessageVisibility implements Visibility {
 
 	@Override
 	public Future<?> extend(int seconds) {
-		return this.amazonSqsAsync
-				.changeMessageVisibilityAsync(new ChangeMessageVisibilityRequest()
-						.withQueueUrl(this.queueUrl).withReceiptHandle(this.receiptHandle)
-						.withVisibilityTimeout(seconds));
+		return this.amazonSqsAsync.changeMessageVisibility(ChangeMessageVisibilityRequest
+				.builder().queueUrl(this.queueUrl).receiptHandle(this.receiptHandle)
+				.visibilityTimeout(seconds).build());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -455,12 +455,14 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			if (this.deletionPolicy == SqsMessageDeletionPolicy.NEVER) {
 				String receiptHandle = this.message.receiptHandle();
 				QueueMessageAcknowledgment acknowledgment = new QueueMessageAcknowledgment(
-						SimpleMessageListenerContainer.this.getAmazonSqsAsync(), this.queueUrl, receiptHandle);
+						SimpleMessageListenerContainer.this.getAmazonSqsAsync(),
+						this.queueUrl, receiptHandle);
 				additionalHeaders.put(QueueMessageHandler.ACKNOWLEDGMENT, acknowledgment);
 			}
 			additionalHeaders.put(QueueMessageHandler.VISIBILITY,
-					new QueueMessageVisibility(SimpleMessageListenerContainer.this.getAmazonSqsAsync(), this.queueUrl,
-							this.message.receiptHandle()));
+					new QueueMessageVisibility(
+							SimpleMessageListenerContainer.this.getAmazonSqsAsync(),
+							this.queueUrl, this.message.receiptHandle()));
 
 			return createMessage(this.message, additionalHeaders);
 		}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -444,8 +444,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		}
 
 		private void deleteMessage(String receiptHandle) {
-			// TODO SDK2 migration: used to be async
-			getAmazonSqs().deleteMessage(DeleteMessageRequest.builder()
+			getAmazonSqsAsync().deleteMessage(DeleteMessageRequest.builder()
 					.queueUrl(this.queueUrl).receiptHandle(receiptHandle).build());
 		}
 
@@ -455,19 +454,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					this.logicalQueueName);
 			if (this.deletionPolicy == SqsMessageDeletionPolicy.NEVER) {
 				String receiptHandle = this.message.receiptHandle();
-				// TODO SDK2 migration: re-add after solving issue with clients
-				// QueueMessageAcknowledgment acknowledgment = new
-				// QueueMessageAcknowledgment(
-				// SimpleMessageListenerContainer.this.getAmazonSqsAsync(), this.queueUrl,
-				// receiptHandle);
-				// additionalHeaders.put(QueueMessageHandler.ACKNOWLEDGMENT,
-				// acknowledgment);
+				QueueMessageAcknowledgment acknowledgment = new QueueMessageAcknowledgment(
+						SimpleMessageListenerContainer.this.getAmazonSqsAsync(), this.queueUrl, receiptHandle);
+				additionalHeaders.put(QueueMessageHandler.ACKNOWLEDGMENT, acknowledgment);
 			}
-			// TODO SDK2 migration: re-add after solving issue with clients
-			// additionalHeaders.put(QueueMessageHandler.VISIBILITY,
-			// new QueueMessageVisibility(
-			// SimpleMessageListenerContainer.this.getAmazonSqsAsync(),
-			// this.queueUrl, this.message.receiptHandle()));
+			additionalHeaders.put(QueueMessageHandler.VISIBILITY,
+					new QueueMessageVisibility(SimpleMessageListenerContainer.this.getAmazonSqsAsync(), this.queueUrl,
+							this.message.receiptHandle()));
 
 			return createMessage(this.message, additionalHeaders);
 		}

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
@@ -110,11 +110,26 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type
-								type="com.amazonaws.services.sqs.AmazonSQSAsync"/>
+								type="software.amazon.awssdk.services.sqs.SqsClient"/>
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>
-						Sets the AmazonSQSAsync that is going to be used by the container
+						Sets the SQS sync client that is going to be used by the container
+						to interact with the messaging
+						(SQS) API.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-sqs-async" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="software.amazon.awssdk.services.sqs.SqsAsyncClient"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Sets the  SQS async client that is going to be used by the container
 						to interact with the messaging
 						(SQS) API.
 					</xsd:documentation>

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.aws.messaging.config.annotation;
 
 import java.util.List;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.sns.AmazonSNS;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.ServiceMetadata;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.cloud.aws.context.config.annotation.EnableContextRegion;
 import org.springframework.cloud.aws.messaging.endpoint.NotificationStatusHandlerMethodArgumentResolver;
@@ -87,7 +87,7 @@ public class SnsConfigurationTest {
 		// Arrange & Act
 		this.webApplicationContext.register(SnsConfigurationWithCredentials.class);
 		this.webApplicationContext.refresh();
-		AmazonSNS amazonSns = this.webApplicationContext.getBean(AmazonSNS.class);
+		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(amazonSns, "awsCredentialsProvider"))
@@ -121,12 +121,12 @@ public class SnsConfigurationTest {
 		// Arrange & Act
 		this.webApplicationContext.register(SnsConfigurationWithRegionProvider.class);
 		this.webApplicationContext.refresh();
-		AmazonSNS amazonSns = this.webApplicationContext.getBean(AmazonSNS.class);
+		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
 				.isEqualTo("https://"
-						+ Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sns"));
+						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	private NotificationStatusHandlerMethodArgumentResolver getNotificationStatusHandlerMethodArgumentResolver(
@@ -151,11 +151,11 @@ public class SnsConfigurationTest {
 	@EnableSns
 	protected static class SnsConfigurationWithCredentials {
 
-		public static final AWSCredentialsProvider AWS_CREDENTIALS_PROVIDER = mock(
-				AWSCredentialsProvider.class);
+		public static final AwsCredentialsProvider AWS_CREDENTIALS_PROVIDER = mock(
+				AwsCredentialsProvider.class);
 
 		@Bean
-		public AWSCredentialsProvider awsCredentialsProvider() {
+		public AwsCredentialsProvider awsCredentialsProvider() {
 			return AWS_CREDENTIALS_PROVIDER;
 		}
 
@@ -165,10 +165,10 @@ public class SnsConfigurationTest {
 	@EnableSns
 	protected static class SnsConfigurationWithCustomAmazonClient {
 
-		public static final AmazonSNS AMAZON_SNS = mock(AmazonSNS.class);
+		public static final SnsClient AMAZON_SNS = mock(SnsClient.class);
 
 		@Bean
-		public AmazonSNS amazonSNS() {
+		public SnsClient amazonSNS() {
 			return AMAZON_SNS;
 		}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
@@ -93,7 +93,8 @@ public class SnsConfigurationTest {
 		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSns, "clientConfiguration");
 		assertThat(clientConfiguration.option(AwsClientOption.CREDENTIALS_PROVIDER))
 				.isEqualTo(SnsConfigurationWithCredentials.AWS_CREDENTIALS_PROVIDER);
 	}
@@ -128,9 +129,11 @@ public class SnsConfigurationTest {
 		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSns, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-				.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	private NotificationStatusHandlerMethodArgumentResolver getNotificationStatusHandlerMethodArgumentResolver(

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SnsConfigurationTest.java
@@ -21,6 +21,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.services.sns.SnsClient;
@@ -90,7 +93,8 @@ public class SnsConfigurationTest {
 		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(amazonSns, "awsCredentialsProvider"))
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		assertThat(clientConfiguration.option(AwsClientOption.CREDENTIALS_PROVIDER))
 				.isEqualTo(SnsConfigurationWithCredentials.AWS_CREDENTIALS_PROVIDER);
 	}
 
@@ -124,9 +128,9 @@ public class SnsConfigurationTest {
 		SnsClient amazonSns = this.webApplicationContext.getBean(SnsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
-				.isEqualTo("https://"
-						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
+				.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	private NotificationStatusHandlerMethodArgumentResolver getNotificationStatusHandlerMethodArgumentResolver(

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
@@ -82,13 +82,20 @@ public class SqsConfigurationTest {
 		QueueMessagingTemplate messagingTemplate = (QueueMessagingTemplate) ReflectionTestUtils
 				.getField(sendToReturnValueHandler, "messageTemplate");
 
-		SqsAsyncClient amazonSqsAsync = (SqsAsyncClient) ReflectionTestUtils.getField(messagingTemplate, "amazonSqsAsync");
-		SdkClientConfiguration clientConfigurationAmazonSqsAsync = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqsAsync, "clientConfiguration");
-		assertThat(clientConfigurationAmazonSqsAsync.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
+		SqsAsyncClient amazonSqsAsync = (SqsAsyncClient) ReflectionTestUtils
+				.getField(messagingTemplate, "amazonSqsAsync");
+		SdkClientConfiguration clientConfigurationAmazonSqsAsync = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqsAsync, "clientConfiguration");
+		assertThat(clientConfigurationAmazonSqsAsync
+				.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
 
-		SqsClient amazonSqs = (SqsClient) ReflectionTestUtils.getField(messagingTemplate, "amazonSqs");
-		SdkClientConfiguration clientConfigurationAmazonSqs = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
-		assertThat(clientConfigurationAmazonSqs.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
+		SqsClient amazonSqs = (SqsClient) ReflectionTestUtils.getField(messagingTemplate,
+				"amazonSqs");
+		SdkClientConfiguration clientConfigurationAmazonSqs = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
+		assertThat(
+				clientConfigurationAmazonSqs.option(AwsClientOption.CREDENTIALS_PROVIDER))
+						.isNotNull();
 	}
 
 	@Test
@@ -211,10 +218,11 @@ public class SqsConfigurationTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = applicationContext.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
-		assertThat(
-			DefaultCredentialsProvider.class.isInstance(clientConfiguration.option(AwsClientOption.CREDENTIALS_PROVIDER)))
-			.isTrue();
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
+		assertThat(DefaultCredentialsProvider.class.isInstance(
+				clientConfiguration.option(AwsClientOption.CREDENTIALS_PROVIDER)))
+						.isTrue();
 	}
 
 	@Test
@@ -225,9 +233,11 @@ public class SqsConfigurationTest {
 		SqsAsyncClient amazonSqs = applicationContext.getBean(SqsAsyncClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
 	}
 
 	@EnableSqs

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
@@ -82,9 +82,13 @@ public class SqsConfigurationTest {
 		QueueMessagingTemplate messagingTemplate = (QueueMessagingTemplate) ReflectionTestUtils
 				.getField(sendToReturnValueHandler, "messageTemplate");
 
-		SqsAsyncClient amazonSqs = (SqsAsyncClient) ReflectionTestUtils.getField(messagingTemplate, "amazonSqs");
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
-		assertThat(clientConfiguration.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
+		SqsAsyncClient amazonSqsAsync = (SqsAsyncClient) ReflectionTestUtils.getField(messagingTemplate, "amazonSqsAsync");
+		SdkClientConfiguration clientConfigurationAmazonSqsAsync = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqsAsync, "clientConfiguration");
+		assertThat(clientConfigurationAmazonSqsAsync.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
+
+		SqsClient amazonSqs = (SqsClient) ReflectionTestUtils.getField(messagingTemplate, "amazonSqs");
+		SdkClientConfiguration clientConfigurationAmazonSqs = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		assertThat(clientConfigurationAmazonSqs.option(AwsClientOption.CREDENTIALS_PROVIDER)).isNotNull();
 	}
 
 	@Test
@@ -223,7 +227,7 @@ public class SqsConfigurationTest {
 		// Assert
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
 	}
 
 	@EnableSqs
@@ -250,7 +254,7 @@ public class SqsConfigurationTest {
 		}
 
 		@Bean
-		public SqsClient amazonSQS() {
+		public SqsClient amazonSqs() {
 			return CUSTOM_SQS_CLIENT;
 		}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
@@ -298,9 +298,11 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
 
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
 
 	}
 
@@ -320,9 +322,11 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
 
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 	@Test
@@ -334,9 +338,11 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = applicationContext.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_1));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
@@ -142,10 +142,14 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 				.getBeanDefinition(SimpleMessageListenerContainer.class.getName() + "#0");
 		assertThat(abstractContainerDefinition).isNotNull();
 
-		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(3);
+		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(4);
 		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
 				.getPropertyValue("amazonSqs").getValue()).getBeanName())
 						.isEqualTo("myClient");
+		// TODO SDK2 migration: uncomment and extend test
+//		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
+//				.getPropertyValue("amazonSqsAsync").getValue()).getBeanName())
+//						.isEqualTo("myClientAsync");
 	}
 
 	@Test
@@ -167,13 +171,15 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 				.getBeanDefinition(SimpleMessageListenerContainer.class.getName() + "#0");
 		assertThat(abstractContainerDefinition).isNotNull();
 
-		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(4);
+		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(5);
 		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
 				.getPropertyValue("taskExecutor").getValue()).getBeanName())
 						.isEqualTo("executor");
 
 		SqsAsyncClient asyncClient = beanFactory.getBean(SqsAsyncClient.class);
 		assertThat(asyncClient).isNotNull();
+		SqsClient client = beanFactory.getBean(SqsClient.class);
+		assertThat(client).isNotNull();
 	}
 
 	@Test
@@ -293,7 +299,7 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
 
 	}
 
@@ -315,7 +321,7 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 	@Test
@@ -329,7 +335,7 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 		SqsAsyncClient amazonSqs = applicationContext.getBean(SqsAsyncClient.class);
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_1));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_1));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
@@ -135,7 +135,9 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-custom-amazon-sqs.xml", getClass()));
 
 		// Assert
-		BeanDefinition sqsAsync = registry.getBeanDefinition("myClient");
+		BeanDefinition sqs = registry.getBeanDefinition("myClient");
+		assertThat(sqs).isNotNull();
+		BeanDefinition sqsAsync = registry.getBeanDefinition("myClientAsync");
 		assertThat(sqsAsync).isNotNull();
 
 		BeanDefinition abstractContainerDefinition = registry
@@ -146,10 +148,9 @@ public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
 		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
 				.getPropertyValue("amazonSqs").getValue()).getBeanName())
 						.isEqualTo("myClient");
-		// TODO SDK2 migration: uncomment and extend test
-//		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
-//				.getPropertyValue("amazonSqsAsync").getValue()).getBeanName())
-//						.isEqualTo("myClientAsync");
+		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
+				.getPropertyValue("amazonSqsAsync").getValue()).getBeanName())
+						.isEqualTo("myClientAsync");
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
@@ -65,9 +65,11 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(snsClient, "clientConfiguration");
-		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT)).isEqualTo(
-			new URI("https", ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1).toString(), null, null));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(snsClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT))
+				.isEqualTo(new URI("https", ServiceMetadata.of("sns")
+						.endpointFor(Region.EU_WEST_1).toString(), null, null));
 	}
 
 	// @checkstyle:off
@@ -83,9 +85,11 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(snsClient, "clientConfiguration");
-		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT)).isEqualTo(
-				new URI("https", ServiceMetadata.of("sns").endpointFor(Region.US_WEST_2).toString(), null, null));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(snsClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT))
+				.isEqualTo(new URI("https", ServiceMetadata.of("sns")
+						.endpointFor(Region.US_WEST_2).toString(), null, null));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
@@ -18,10 +18,10 @@ package org.springframework.cloud.aws.messaging.config.xml;
 
 import java.net.URI;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.sns.AmazonSNSClient;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.ServiceMetadata;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -47,8 +47,7 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 
 		// Assert
 		assertThat(argumentResolver).isNotNull();
-		assertThat(context.containsBean(getBeanName(AmazonSNSClient.class.getName())))
-				.isTrue();
+		assertThat(context.containsBean(getBeanName(SnsClient.class.getName()))).isTrue();
 	}
 
 	// @checkstyle:off
@@ -61,12 +60,13 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegion.xml", getClass());
 
 		// Act
-		AmazonSNSClient snsClient = context.getBean(AmazonSNSClient.class);
+		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint")).isEqualTo(new URI(
-				"https", Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sns"),
-				null, null));
+				"https",
+				ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1).toString(), null,
+				null));
 	}
 
 	// @checkstyle:off
@@ -79,12 +79,13 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customRegionProvider.xml", getClass());
 
 		// Act
-		AmazonSNSClient snsClient = context.getBean(AmazonSNSClient.class);
+		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
 		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint")).isEqualTo(new URI(
-				"https", Region.getRegion(Regions.US_WEST_2).getServiceEndpoint("sns"),
-				null, null));
+				"https",
+				ServiceMetadata.of("sns").endpointFor(Region.US_WEST_2).toString(), null,
+				null));
 	}
 
 	@Test
@@ -95,12 +96,11 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-customSnsClient.xml", getClass());
 
 		// Act
-		AmazonSNSClient snsClient = context.getBean("customSnsClient",
-				AmazonSNSClient.class);
+		SnsClient snsClient = context.getBean("customSnsClient", SnsClient.class);
 
 		// Assert
 		assertThat(snsClient).isNotNull();
-		assertThat(context.containsBean(getBeanName(AmazonSNSClient.class.getName())))
+		assertThat(context.containsBean(getBeanName(SnsClient.class.getName())))
 				.isFalse();
 	}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.aws.messaging.config.xml;
 import java.net.URI;
 
 import org.junit.Test;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.services.sns.SnsClient;
@@ -63,10 +65,9 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint")).isEqualTo(new URI(
-				"https",
-				ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1).toString(), null,
-				null));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(snsClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT)).isEqualTo(
+			new URI("https", ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1).toString(), null, null));
 	}
 
 	// @checkstyle:off
@@ -82,10 +83,9 @@ public class NotificationArgumentResolverBeanDefinitionParserTest {
 		SnsClient snsClient = context.getBean(SnsClient.class);
 
 		// Assert
-		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint")).isEqualTo(new URI(
-				"https",
-				ServiceMetadata.of("sns").endpointFor(Region.US_WEST_2).toString(), null,
-				null));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(snsClient, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT)).isEqualTo(
+				new URI("https", ServiceMetadata.of("sns").endpointFor(Region.US_WEST_2).toString(), null, null));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.aws.messaging.config.xml;
 import java.util.List;
 
 import org.junit.Test;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.services.sns.SnsClient;
@@ -151,9 +153,9 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SnsClient amazonSns = registry.getBean(SnsClient.class);
-		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
-				.isEqualTo("https://"
-						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
+			.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	@Test
@@ -169,9 +171,9 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SnsClient amazonSns = registry.getBean(SnsClient.class);
-		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
-				.isEqualTo("https://"
-						+ ServiceMetadata.of("sns").endpointFor(Region.CN_NORTH_1));
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
+			.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.CN_NORTH_1));
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
@@ -18,10 +18,10 @@ package org.springframework.cloud.aws.messaging.config.xml;
 
 import java.util.List;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.sns.AmazonSNSClient;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.ServiceMetadata;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -60,7 +60,7 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 				.getBean(NotificationMessagingTemplate.class);
 		assertThat(
 				ReflectionTestUtils.getField(notificationMessagingTemplate, "amazonSns"))
-						.isSameAs(registry.getBean(AmazonSNSClient.class));
+						.isSameAs(registry.getBean(SnsClient.class));
 
 		Object cachingDestinationResolverProxy = ReflectionTestUtils
 				.getField(notificationMessagingTemplate, "destinationResolver");
@@ -150,10 +150,10 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-custom-region.xml", getClass()));
 
 		// Assert
-		AmazonSNSClient amazonSns = registry.getBean(AmazonSNSClient.class);
+		SnsClient amazonSns = registry.getBean(SnsClient.class);
 		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
 				.isEqualTo("https://"
-						+ Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sns"));
+						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	@Test
@@ -168,10 +168,10 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
 
 		// Assert
-		AmazonSNSClient amazonSns = registry.getBean(AmazonSNSClient.class);
+		SnsClient amazonSns = registry.getBean(SnsClient.class);
 		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
 				.isEqualTo("https://"
-						+ Region.getRegion(Regions.CN_NORTH_1).getServiceEndpoint("sns"));
+						+ ServiceMetadata.of("sns").endpointFor(Region.CN_NORTH_1));
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
@@ -153,9 +153,11 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SnsClient amazonSns = registry.getBean(SnsClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSns, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sns").endpointFor(Region.EU_WEST_1));
 	}
 
 	@Test
@@ -171,9 +173,11 @@ public class NotificationMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SnsClient amazonSns = registry.getBean(SnsClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSns, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSns, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sns").endpointFor(Region.CN_NORTH_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sns").endpointFor(Region.CN_NORTH_1));
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
@@ -177,7 +177,7 @@ public class QueueMessagingTemplateBeanDefinitionParserTest {
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.SA_EAST_1));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.SA_EAST_1));
 	}
 
 	@Test
@@ -195,7 +195,7 @@ public class QueueMessagingTemplateBeanDefinitionParserTest {
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo(ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
+			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
@@ -175,9 +175,11 @@ public class QueueMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.SA_EAST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.SA_EAST_1));
 	}
 
 	@Test
@@ -193,9 +195,11 @@ public class QueueMessagingTemplateBeanDefinitionParserTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 	@Test

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
@@ -53,7 +53,6 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 		assertThat(asyncClient).isNotNull();
 		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(asyncClient, "clientConfiguration");
 		ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
-		// //TODO SDK2 migration: default value is now 8, s. SdkDefaultClientBuilder.resolveAsyncFutureCompletionExecutor() Check of it used to be 50
 		assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(8);
 	}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
@@ -49,15 +49,17 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-minimal.xml", getClass()));
 
 		// Assert
-		SqsAsyncClient asyncClient = beanFactory.getBean("customClient", SqsAsyncClient.class);
+		SqsAsyncClient asyncClient = beanFactory.getBean("customClient",
+				SqsAsyncClient.class);
 		assertThat(asyncClient).isNotNull();
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(asyncClient, "clientConfiguration");
-		ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(asyncClient, "clientConfiguration");
+		ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) clientConfiguration
+				.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
 		assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(8);
 	}
 
-
-	//TODO SDK2 migration: re-visit after solving issue with clients
+	// TODO SDK2 migration: re-visit after solving issue with clients
 	@Test
 	public void parseInternal_notBuffered_createsAsyncClientWithoutBufferedDecorator()
 			throws Exception {
@@ -70,7 +72,8 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-not-buffered.xml", getClass()));
 
 		// Assert
-		SqsAsyncClient asyncClient = beanFactory.getBean("customClient", SqsAsyncClient.class);
+		SqsAsyncClient asyncClient = beanFactory.getBean("customClient",
+				SqsAsyncClient.class);
 		assertThat(asyncClient).isNotNull();
 		assertThat(SqsAsyncClient.class.isInstance(asyncClient)).isTrue();
 	}
@@ -87,11 +90,15 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 				getClass().getSimpleName() + "-custom-task-executor.xml", getClass()));
 
 		// Assert
-		SqsAsyncClient asyncClient = beanFactory.getBean("customClient", SqsAsyncClient.class);
+		SqsAsyncClient asyncClient = beanFactory.getBean("customClient",
+				SqsAsyncClient.class);
 		assertThat(asyncClient).isNotNull();
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(asyncClient, "clientConfiguration");
-		Executor executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
-		ShutdownSuppressingExecutorServiceAdapter customExecutor = (ShutdownSuppressingExecutorServiceAdapter) ReflectionTestUtils.getField(executor, "executor");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(asyncClient, "clientConfiguration");
+		Executor executor = clientConfiguration
+				.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+		ShutdownSuppressingExecutorServiceAdapter customExecutor = (ShutdownSuppressingExecutorServiceAdapter) ReflectionTestUtils
+				.getField(executor, "executor");
 		assertThat(ReflectionTestUtils.getField(customExecutor, "taskExecutor"))
 				.isSameAs(beanFactory.getBean("myThreadPoolTaskExecutor"));
 	}
@@ -109,9 +116,11 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.EU_WEST_1));
 	}
 
 	@Test
@@ -127,9 +136,11 @@ public class SqsAsyncClientBeanDefinitionParserTest {
 
 		// Assert
 		SqsAsyncClient amazonSqs = registry.getBean(SqsAsyncClient.class);
-		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils.getField(amazonSqs, "clientConfiguration");
+		SdkClientConfiguration clientConfiguration = (SdkClientConfiguration) ReflectionTestUtils
+				.getField(amazonSqs, "clientConfiguration");
 		assertThat(clientConfiguration.option(SdkClientOption.ENDPOINT).toString())
-			.isEqualTo("https://" + ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
+				.isEqualTo("https://"
+						+ ServiceMetadata.of("sqs").endpointFor(Region.AP_SOUTHEAST_2));
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessageChannelTest.java
@@ -83,8 +83,8 @@ public class QueueMessageChannelTest {
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
 				.build();
-		MessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+		MessageChannel messageChannel = new QueueMessageChannel(amazonSqs, amazonSqsAsync,
+				"http://testQueue");
 
 		// Act
 		boolean sent = messageChannel.send(stringMessage);
@@ -105,8 +105,8 @@ public class QueueMessageChannelTest {
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
 				.build();
-		MessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+		MessageChannel messageChannel = new QueueMessageChannel(amazonSqs, amazonSqsAsync,
+				"http://testQueue");
 		when(amazonSqs.sendMessage(SendMessageRequest.builder()
 				.queueUrl("http://testQueue").messageBody("message content")
 				.delaySeconds(0).messageAttributes(isNotNull()).build())).thenThrow(
@@ -127,7 +127,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		String mimeTypeAsString = new MimeType("test", "plain", Charset.forName("UTF-8"))
 				.toString();
 		Message<String> message = MessageBuilder.withPayload("Hello")
@@ -155,7 +155,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		MimeType mimeType = new MimeType("test", "plain", Charset.forName("UTF-8"));
 		Message<String> message = MessageBuilder.withPayload("Hello")
 				.setHeader(MessageHeaders.CONTENT_TYPE, mimeType).build();
@@ -191,7 +191,7 @@ public class QueueMessageChannelTest {
 								.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
@@ -218,7 +218,7 @@ public class QueueMessageChannelTest {
 								.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive(2);
@@ -241,7 +241,7 @@ public class QueueMessageChannelTest {
 								.messages(Collections.emptyList()).build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive(2);
@@ -263,7 +263,7 @@ public class QueueMessageChannelTest {
 								.messages(Collections.emptyList()).build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive(0);
@@ -296,7 +296,7 @@ public class QueueMessageChannelTest {
 								.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
@@ -313,7 +313,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		String headerValue = "Header value";
 		String headerName = "MyHeader";
 		Message<String> message = MessageBuilder.withPayload("Hello")
@@ -359,7 +359,7 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
@@ -375,7 +375,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		double doubleValue = 1234.56;
 		long longValue = 1234L;
 		int integerValue = 1234;
@@ -496,7 +496,7 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
@@ -543,7 +543,7 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		messageChannel.receive();
@@ -577,7 +577,7 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		messageChannel.receive();
@@ -590,7 +590,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		ByteBuffer headerValue = ByteBuffer.wrap("My binary data!".getBytes());
 		String headerName = "MyHeader";
 		Message<String> message = MessageBuilder.withPayload("Hello")
@@ -638,13 +638,15 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
 
 		// Assert
-		assertThat(((SdkBytes)receivedMessage.getHeaders().get(headerName)).asByteBuffer()).isEqualTo(headerValue);
+		assertThat(
+				((SdkBytes) receivedMessage.getHeaders().get(headerName)).asByteBuffer())
+						.isEqualTo(headerValue);
 	}
 
 	@Test
@@ -653,7 +655,7 @@ public class QueueMessageChannelTest {
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessageChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello").build();
 		UUID uuid = (UUID) message.getHeaders().get(MessageHeaders.ID);
 
@@ -695,7 +697,7 @@ public class QueueMessageChannelTest {
 						.build());
 
 		PollableChannel messageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		Message<?> receivedMessage = messageChannel.receive();
@@ -716,9 +718,10 @@ public class QueueMessageChannelTest {
 				.thenReturn(SendMessageResponse.builder().build());
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
-		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class))).thenReturn(future);
+		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class)))
+				.thenReturn(future);
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		boolean result = queueMessageChannel
@@ -738,9 +741,10 @@ public class QueueMessageChannelTest {
 		when(future.get(1000, TimeUnit.MILLISECONDS)).thenThrow(new TimeoutException());
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
-		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class))).thenReturn(future);
+		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class)))
+				.thenReturn(future);
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Act
 		boolean result = queueMessageChannel
@@ -760,9 +764,10 @@ public class QueueMessageChannelTest {
 				.thenThrow(new ExecutionException(new Exception("foo")));
 		SqsClient amazonSqs = mock(SqsClient.class);
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
-		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class))).thenReturn(future);
+		when(amazonSqsAsync.sendMessage(any(SendMessageRequest.class)))
+				.thenReturn(future);
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 
 		// Assert
 		this.expectedException.expect(MessageDeliveryException.class);
@@ -786,7 +791,7 @@ public class QueueMessageChannelTest {
 				.thenReturn(SendMessageResponse.builder().build());
 
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello")
 				.setHeader(SqsMessageHeaders.SQS_DELAY_HEADER, 15).build();
 
@@ -814,7 +819,7 @@ public class QueueMessageChannelTest {
 				.thenReturn(SendMessageResponse.builder().build());
 
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello").build();
 
 		// Act
@@ -841,7 +846,7 @@ public class QueueMessageChannelTest {
 				.thenReturn(SendMessageResponse.builder().build());
 
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello")
 				.setHeader(SqsMessageHeaders.SQS_GROUP_ID_HEADER, "id-5").build();
 
@@ -871,7 +876,7 @@ public class QueueMessageChannelTest {
 				.thenReturn(SendMessageResponse.builder().build());
 
 		QueueMessageChannel queueMessageChannel = new QueueMessageChannel(amazonSqs,
-			amazonSqsAsync, "http://testQueue");
+				amazonSqsAsync, "http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello")
 				.setHeader(SqsMessageHeaders.SQS_DEDUPLICATION_ID_HEADER, "id-5").build();
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
@@ -54,8 +55,9 @@ public class QueueMessagingTemplateTest {
 	@Test(expected = IllegalStateException.class)
 	public void send_withoutDefaultDestination_throwAnException() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
 				.build();
@@ -65,8 +67,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void send_withDefaultDestination_usesDefaultDestination() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
@@ -83,8 +86,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void send_withDestination_usesDestination() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
 				.build();
@@ -100,9 +104,10 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void send_withCustomDestinationResolveAndDestination_usesDestination() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs,
-				(DestinationResolver<String>) name -> name.toUpperCase(Locale.ENGLISH),
+			amazonSqsAsync, (DestinationResolver<String>) name -> name.toUpperCase(Locale.ENGLISH),
 				null);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
@@ -119,8 +124,9 @@ public class QueueMessagingTemplateTest {
 	@Test(expected = IllegalStateException.class)
 	public void receive_withoutDefaultDestination_throwsAnException() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		queueMessagingTemplate.receive();
 	}
@@ -128,8 +134,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void receive_withDefaultDestination_useDefaultDestination() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
 
 		queueMessagingTemplate.receive();
@@ -144,8 +151,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void receive_withDestination_usesDestination() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		queueMessagingTemplate.receive("my-queue");
 
@@ -159,8 +167,9 @@ public class QueueMessagingTemplateTest {
 	@Test(expected = IllegalStateException.class)
 	public void receiveAndConvert_withoutDefaultDestination_throwsAnException() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		queueMessagingTemplate.receiveAndConvert(String.class);
 	}
@@ -168,8 +177,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void receiveAndConvert_withDefaultDestination_usesDefaultDestinationAndConvertsMessage() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
 
 		String message = queueMessagingTemplate.receiveAndConvert(String.class);
@@ -180,8 +190,9 @@ public class QueueMessagingTemplateTest {
 	@Test
 	public void receiveAndConvert_withDestination_usesDestinationAndConvertsMessage() {
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		String message = queueMessagingTemplate.receiveAndConvert("my-queue",
 				String.class);
@@ -196,7 +207,7 @@ public class QueueMessagingTemplateTest {
 
 		// Act
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				createAmazonSqs(), (ResourceIdResolver) null, simpleMessageConverter);
+				createAmazonSqs(), mock(SqsAsyncClient.class), (ResourceIdResolver) null, simpleMessageConverter);
 
 		// Assert
 		assertThat(
@@ -213,6 +224,7 @@ public class QueueMessagingTemplateTest {
 
 		// Arrange
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
@@ -221,7 +233,7 @@ public class QueueMessagingTemplateTest {
 		simpleMessageConverter.setObjectMapper(objectMapper);
 
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs, (ResourceIdResolver) null, simpleMessageConverter);
+				amazonSqs, amazonSqsAsync, (ResourceIdResolver) null, simpleMessageConverter);
 
 		// Act
 		queueMessagingTemplate.convertAndSend("test",
@@ -246,11 +258,12 @@ public class QueueMessagingTemplateTest {
 
 		// Arrange
 		SqsClient amazonSqs = createAmazonSqs();
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
+				amazonSqs, amazonSqsAsync);
 
 		// Act
 		queueMessagingTemplate.convertAndSend("test",
@@ -271,6 +284,7 @@ public class QueueMessagingTemplateTest {
 
 	private SqsClient createAmazonSqs() {
 		SqsClient amazonSqs = mock(SqsClient.class);
+		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 
 		GetQueueUrlResponse queueUrl = GetQueueUrlResponse.builder()
 				.queueUrl("https://queue-url.com").build();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -106,8 +106,8 @@ public class QueueMessagingTemplateTest {
 		SqsClient amazonSqs = createAmazonSqs();
 		SqsAsyncClient amazonSqsAsync = mock(SqsAsyncClient.class);
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs,
-			amazonSqsAsync, (DestinationResolver<String>) name -> name.toUpperCase(Locale.ENGLISH),
+				amazonSqs, amazonSqsAsync,
+				(DestinationResolver<String>) name -> name.toUpperCase(Locale.ENGLISH),
 				null);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("message content")
@@ -207,7 +207,8 @@ public class QueueMessagingTemplateTest {
 
 		// Act
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				createAmazonSqs(), mock(SqsAsyncClient.class), (ResourceIdResolver) null, simpleMessageConverter);
+				createAmazonSqs(), mock(SqsAsyncClient.class), (ResourceIdResolver) null,
+				simpleMessageConverter);
 
 		// Assert
 		assertThat(
@@ -233,7 +234,8 @@ public class QueueMessagingTemplateTest {
 		simpleMessageConverter.setObjectMapper(objectMapper);
 
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs, amazonSqsAsync, (ResourceIdResolver) null, simpleMessageConverter);
+				amazonSqs, amazonSqsAsync, (ResourceIdResolver) null,
+				simpleMessageConverter);
 
 		// Act
 		queueMessagingTemplate.convertAndSend("test",

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -20,16 +20,16 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Locale;
 
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
-import com.amazonaws.services.sqs.model.GetQueueUrlResult;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
@@ -53,7 +53,7 @@ public class QueueMessagingTemplateTest {
 
 	@Test(expected = IllegalStateException.class)
 	public void send_withoutDefaultDestination_throwAnException() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -64,7 +64,7 @@ public class QueueMessagingTemplateTest {
 
 	@Test
 	public void send_withDefaultDestination_usesDefaultDestination() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
@@ -76,13 +76,13 @@ public class QueueMessagingTemplateTest {
 		ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
+		assertThat(sendMessageRequestArgumentCaptor.getValue().queueUrl())
 				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
 	public void send_withDestination_usesDestination() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -93,13 +93,13 @@ public class QueueMessagingTemplateTest {
 		ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
+		assertThat(sendMessageRequestArgumentCaptor.getValue().queueUrl())
 				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
 	public void send_withCustomDestinationResolveAndDestination_usesDestination() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs,
 				(DestinationResolver<String>) name -> name.toUpperCase(Locale.ENGLISH),
@@ -112,13 +112,13 @@ public class QueueMessagingTemplateTest {
 		ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
+		assertThat(sendMessageRequestArgumentCaptor.getValue().queueUrl())
 				.isEqualTo("MYQUEUE");
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void receive_withoutDefaultDestination_throwsAnException() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -127,7 +127,7 @@ public class QueueMessagingTemplateTest {
 
 	@Test
 	public void receive_withDefaultDestination_useDefaultDestination() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
@@ -137,13 +137,13 @@ public class QueueMessagingTemplateTest {
 		ArgumentCaptor<ReceiveMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(ReceiveMessageRequest.class);
 		verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
+		assertThat(sendMessageRequestArgumentCaptor.getValue().queueUrl())
 				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test
 	public void receive_withDestination_usesDestination() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -152,13 +152,13 @@ public class QueueMessagingTemplateTest {
 		ArgumentCaptor<ReceiveMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(ReceiveMessageRequest.class);
 		verify(amazonSqs).receiveMessage(sendMessageRequestArgumentCaptor.capture());
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
+		assertThat(sendMessageRequestArgumentCaptor.getValue().queueUrl())
 				.isEqualTo("https://queue-url.com");
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void receiveAndConvert_withoutDefaultDestination_throwsAnException() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -167,7 +167,7 @@ public class QueueMessagingTemplateTest {
 
 	@Test
 	public void receiveAndConvert_withDefaultDestination_usesDefaultDestinationAndConvertsMessage() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 		queueMessagingTemplate.setDefaultDestinationName("my-queue");
@@ -179,7 +179,7 @@ public class QueueMessagingTemplateTest {
 
 	@Test
 	public void receiveAndConvert_withDestination_usesDestinationAndConvertsMessage() {
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
 				amazonSqs);
 
@@ -212,7 +212,7 @@ public class QueueMessagingTemplateTest {
 			throws IOException {
 
 		// Arrange
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
@@ -232,7 +232,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		TestPerson testPerson = objectMapper.readValue(
-				sendMessageRequestArgumentCaptor.getValue().getMessageBody(),
+				sendMessageRequestArgumentCaptor.getValue().messageBody(),
 				TestPerson.class);
 
 		assertThat(testPerson.getFirstName()).isEqualTo("Agim");
@@ -245,7 +245,7 @@ public class QueueMessagingTemplateTest {
 			throws IOException {
 
 		// Arrange
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
+		SqsClient amazonSqs = createAmazonSqs();
 
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
@@ -261,7 +261,7 @@ public class QueueMessagingTemplateTest {
 				.forClass(SendMessageRequest.class);
 		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		TestPerson testPerson = objectMapper.readValue(
-				sendMessageRequestArgumentCaptor.getValue().getMessageBody(),
+				sendMessageRequestArgumentCaptor.getValue().messageBody(),
 				TestPerson.class);
 
 		assertThat(testPerson.getFirstName()).isEqualTo("Agim");
@@ -269,17 +269,17 @@ public class QueueMessagingTemplateTest {
 		assertThat(testPerson.getActiveSince()).isEqualTo(LocalDate.of(2017, 1, 1));
 	}
 
-	private AmazonSQSAsync createAmazonSqs() {
-		AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
+	private SqsClient createAmazonSqs() {
+		SqsClient amazonSqs = mock(SqsClient.class);
 
-		GetQueueUrlResult queueUrl = new GetQueueUrlResult();
-		queueUrl.setQueueUrl("https://queue-url.com");
+		GetQueueUrlResponse queueUrl = GetQueueUrlResponse.builder()
+				.queueUrl("https://queue-url.com").build();
 		when(amazonSqs.getQueueUrl(any(GetQueueUrlRequest.class))).thenReturn(queueUrl);
 
-		ReceiveMessageResult receiveMessageResult = new ReceiveMessageResult();
-		com.amazonaws.services.sqs.model.Message message = new com.amazonaws.services.sqs.model.Message();
-		message.setBody("My message");
-		receiveMessageResult.withMessages(message);
+		ReceiveMessageResponse receiveMessageResult = ReceiveMessageResponse.builder()
+				.messages(software.amazon.awssdk.services.sqs.model.Message.builder()
+						.body("My message").build())
+				.build();
 		when(amazonSqs.receiveMessage(any(ReceiveMessageRequest.class)))
 				.thenReturn(receiveMessageResult);
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
@@ -22,12 +22,12 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
 
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.model.MessageAttributeValue;
-import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -49,7 +49,7 @@ public class TopicMessageChannelTest {
 	@Test
 	public void sendMessage_validTextMessageAndSubject_returnsTrue() throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("Message content")
 				.setHeader(TopicMessageChannel.NOTIFICATION_SUBJECT_HEADER, "Subject")
@@ -60,9 +60,9 @@ public class TopicMessageChannelTest {
 		boolean sent = messageChannel.send(stringMessage);
 
 		// Assert
-		verify(amazonSns, only())
-				.publish(new PublishRequest("topicArn", "Message content", "Subject")
-						.withMessageAttributes(isNotNull()));
+		verify(amazonSns, only()).publish(
+				PublishRequest.builder().topicArn("topicArn").message("Message content")
+						.subject("Subject").messageAttributes(isNotNull()).build());
 		assertThat(sent).isTrue();
 	}
 
@@ -70,7 +70,7 @@ public class TopicMessageChannelTest {
 	public void sendMessage_validTextMessageWithoutSubject_returnsTrue()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("Message content")
 				.build();
@@ -80,9 +80,9 @@ public class TopicMessageChannelTest {
 		boolean sent = messageChannel.send(stringMessage);
 
 		// Assert
-		verify(amazonSns, only())
-				.publish(new PublishRequest("topicArn", "Message content", null)
-						.withMessageAttributes(isNotNull()));
+		verify(amazonSns, only()).publish(
+				PublishRequest.builder().topicArn("topicArn").message("Message content")
+						.subject(null).messageAttributes(isNotNull()).build());
 		assertThat(sent).isTrue();
 	}
 
@@ -90,7 +90,7 @@ public class TopicMessageChannelTest {
 	public void sendMessage_validTextMessageAndTimeout_timeoutIsIgnored()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 
 		Message<String> stringMessage = MessageBuilder.withPayload("Message content")
 				.build();
@@ -100,9 +100,9 @@ public class TopicMessageChannelTest {
 		boolean sent = messageChannel.send(stringMessage, 10);
 
 		// Assert
-		verify(amazonSns, only())
-				.publish(new PublishRequest("topicArn", "Message content", null)
-						.withMessageAttributes(isNotNull()));
+		verify(amazonSns, only()).publish(
+				PublishRequest.builder().topicArn("topicArn").message("Message content")
+						.subject(null).messageAttributes(isNotNull()).build());
 		assertThat(sent).isTrue();
 	}
 
@@ -110,11 +110,11 @@ public class TopicMessageChannelTest {
 	public void sendMessage_withStringMessageHeader_shouldBeSentAsTopicMessageAttribute()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor
 				.forClass(PublishRequest.class);
 		when(amazonSns.publish(publishRequestArgumentCaptor.capture()))
-				.thenReturn(new PublishResult());
+				.thenReturn(PublishResponse.builder().build());
 
 		String headerValue = "Header value";
 		String headerName = "MyHeader";
@@ -127,22 +127,21 @@ public class TopicMessageChannelTest {
 
 		// Assert
 		assertThat(sent).isTrue();
-		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
-				.get(headerName).getStringValue()).isEqualTo(headerValue);
-		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
-				.get(headerName).getDataType())
-						.isEqualTo(MessageAttributeDataTypes.STRING);
+		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
+				.get(headerName).stringValue()).isEqualTo(headerValue);
+		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
+				.get(headerName).dataType()).isEqualTo(MessageAttributeDataTypes.STRING);
 	}
 
 	@Test
 	public void sendMessage_withNumericMessageHeaders_shouldBeSentAsTopicMessageAttributes()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor
 				.forClass(PublishRequest.class);
 		when(amazonSns.publish(publishRequestArgumentCaptor.capture()))
-				.thenReturn(new PublishResult());
+				.thenReturn(PublishResponse.builder().build());
 
 		double doubleValue = 1234.56;
 		long longValue = 1234L;
@@ -167,38 +166,38 @@ public class TopicMessageChannelTest {
 		// Assert
 		assertThat(sent).isTrue();
 		Map<String, MessageAttributeValue> messageAttributes = publishRequestArgumentCaptor
-				.getValue().getMessageAttributes();
-		assertThat(messageAttributes.get("double").getDataType())
+				.getValue().messageAttributes();
+		assertThat(messageAttributes.get("double").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Double");
-		assertThat(messageAttributes.get("double").getStringValue())
+		assertThat(messageAttributes.get("double").stringValue())
 				.isEqualTo(String.valueOf(doubleValue));
-		assertThat(messageAttributes.get("long").getDataType())
+		assertThat(messageAttributes.get("long").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Long");
-		assertThat(messageAttributes.get("long").getStringValue())
+		assertThat(messageAttributes.get("long").stringValue())
 				.isEqualTo(String.valueOf(longValue));
-		assertThat(messageAttributes.get("integer").getDataType())
+		assertThat(messageAttributes.get("integer").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Integer");
-		assertThat(messageAttributes.get("integer").getStringValue())
+		assertThat(messageAttributes.get("integer").stringValue())
 				.isEqualTo(String.valueOf(integerValue));
-		assertThat(messageAttributes.get("byte").getDataType())
+		assertThat(messageAttributes.get("byte").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Byte");
-		assertThat(messageAttributes.get("byte").getStringValue())
+		assertThat(messageAttributes.get("byte").stringValue())
 				.isEqualTo(String.valueOf(byteValue));
-		assertThat(messageAttributes.get("short").getDataType())
+		assertThat(messageAttributes.get("short").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Short");
-		assertThat(messageAttributes.get("short").getStringValue())
+		assertThat(messageAttributes.get("short").stringValue())
 				.isEqualTo(String.valueOf(shortValue));
-		assertThat(messageAttributes.get("float").getDataType())
+		assertThat(messageAttributes.get("float").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.lang.Float");
-		assertThat(messageAttributes.get("float").getStringValue())
+		assertThat(messageAttributes.get("float").stringValue())
 				.isEqualTo(String.valueOf(floatValue));
-		assertThat(messageAttributes.get("bigInteger").getDataType())
+		assertThat(messageAttributes.get("bigInteger").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.math.BigInteger");
-		assertThat(messageAttributes.get("bigInteger").getStringValue())
+		assertThat(messageAttributes.get("bigInteger").stringValue())
 				.isEqualTo(String.valueOf(bigIntegerValue));
-		assertThat(messageAttributes.get("bigDecimal").getDataType())
+		assertThat(messageAttributes.get("bigDecimal").dataType())
 				.isEqualTo(MessageAttributeDataTypes.NUMBER + ".java.math.BigDecimal");
-		assertThat(messageAttributes.get("bigDecimal").getStringValue())
+		assertThat(messageAttributes.get("bigDecimal").stringValue())
 				.isEqualTo(String.valueOf(bigDecimalValue));
 	}
 
@@ -206,11 +205,11 @@ public class TopicMessageChannelTest {
 	public void sendMessage_withBinaryMessageHeader_shouldBeSentAsBinaryMessageAttribute()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		ArgumentCaptor<PublishRequest> publishRequestArgumentCaptor = ArgumentCaptor
 				.forClass(PublishRequest.class);
 		when(amazonSns.publish(publishRequestArgumentCaptor.capture()))
-				.thenReturn(new PublishResult());
+				.thenReturn(PublishResponse.builder().build());
 
 		ByteBuffer headerValue = ByteBuffer.wrap("My binary data!".getBytes());
 		String headerName = "MyHeader";
@@ -223,17 +222,16 @@ public class TopicMessageChannelTest {
 
 		// Assert
 		assertThat(sent).isTrue();
-		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
-				.get(headerName).getBinaryValue()).isEqualTo(headerValue);
-		assertThat(publishRequestArgumentCaptor.getValue().getMessageAttributes()
-				.get(headerName).getDataType())
-						.isEqualTo(MessageAttributeDataTypes.BINARY);
+		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
+				.get(headerName).binaryValue()).isEqualTo(headerValue);
+		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
+				.get(headerName).dataType()).isEqualTo(MessageAttributeDataTypes.BINARY);
 	}
 
 	@Test
 	public void sendMessage_withUuidAsId_shouldConvertUuidToString() throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		TopicMessageChannel messageChannel = new TopicMessageChannel(amazonSns,
 				"http://testQueue");
 		Message<String> message = MessageBuilder.withPayload("Hello").build();
@@ -242,15 +240,15 @@ public class TopicMessageChannelTest {
 		ArgumentCaptor<PublishRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
 				.forClass(PublishRequest.class);
 		when(amazonSns.publish(sendMessageRequestArgumentCaptor.capture()))
-				.thenReturn(new PublishResult());
+				.thenReturn(PublishResponse.builder().build());
 
 		// Act
 		boolean sent = messageChannel.send(message);
 
 		// Assert
 		assertThat(sent).isTrue();
-		assertThat(sendMessageRequestArgumentCaptor.getValue().getMessageAttributes()
-				.get(MessageHeaders.ID).getStringValue()).isEqualTo(uuid.toString());
+		assertThat(sendMessageRequestArgumentCaptor.getValue().messageAttributes()
+				.get(MessageHeaders.ID).stringValue()).isEqualTo(uuid.toString());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/TopicMessageChannelTest.java
@@ -223,7 +223,7 @@ public class TopicMessageChannelTest {
 		// Assert
 		assertThat(sent).isTrue();
 		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
-				.get(headerName).binaryValue()).isEqualTo(headerValue);
+				.get(headerName).binaryValue().asByteBuffer()).isEqualTo(headerValue);
 		assertThat(publishRequestArgumentCaptor.getValue().messageAttributes()
 				.get(headerName).dataType()).isEqualTo(MessageAttributeDataTypes.BINARY);
 	}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.aws.messaging.endpoint;
 
-import com.amazonaws.services.sns.AmazonSNS;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -49,7 +50,7 @@ public class ComplexNotificationEndpointControllerTest {
 	private WebApplicationContext context;
 
 	@Autowired
-	private AmazonSNS amazonSnsMock;
+	private SnsClient amazonSnsMock;
 
 	@Autowired
 	private ComplexNotificationTestController notificationTestController;
@@ -77,12 +78,14 @@ public class ComplexNotificationEndpointControllerTest {
 				.andExpect(status().isNoContent());
 
 		// Assert
-		verify(this.amazonSnsMock, times(1)).confirmSubscription(
-				"arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
-				"111111111111111111111111111111111111111111111111111111"
-						+ "1111111111111111111111111111111111111111111111111111"
-						+ "1111111111111111111111111111111111111111111111111111"
-						+ "1111111111111111111111111111111111111111111111111111");
+		verify(this.amazonSnsMock, times(1))
+				.confirmSubscription(ConfirmSubscriptionRequest.builder()
+						.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+						.token("111111111111111111111111111111111111111111111111111111"
+								+ "1111111111111111111111111111111111111111111111111111"
+								+ "1111111111111111111111111111111111111111111111111111"
+								+ "1111111111111111111111111111111111111111111111111111")
+						.build());
 	}
 
 	// @checkstyle:off
@@ -127,13 +130,15 @@ public class ComplexNotificationEndpointControllerTest {
 				.andExpect(status().isNoContent());
 
 		// Assert
-		verify(this.amazonSnsMock, times(1)).confirmSubscription(
-				"arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
-				"2336412f37fb687f5d51e6e241d638b05824e9e2f6713b42abaeb86"
-						+ "07743f5ba91d34edd2b9dabe2f1616ed77c0f8801ee79911d34dc"
-						+ "a3d210c228af87bd5d9597bf0d6093a1464e03af6650e992ecf546"
-						+ "05e020f04ad3d47796045c9f24d902e72e811a1ad59852cad453f4"
-						+ "0bddfb45");
+		verify(this.amazonSnsMock, times(1))
+				.confirmSubscription(ConfirmSubscriptionRequest.builder()
+						.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+						.token("2336412f37fb687f5d51e6e241d638b05824e9e2f6713b42abaeb86"
+								+ "07743f5ba91d34edd2b9dabe2f1616ed77c0f8801ee79911d34dc"
+								+ "a3d210c228af87bd5d9597bf0d6093a1464e03af6650e992ecf546"
+								+ "05e020f04ad3d47796045c9f24d902e72e811a1ad59852cad453f4"
+								+ "0bddfb45")
+						.build());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.aws.messaging.endpoint;
 
-import com.amazonaws.services.sns.AmazonSNS;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -49,7 +50,7 @@ public class NotificationEndpointControllerTest {
 	private WebApplicationContext context;
 
 	@Autowired
-	private AmazonSNS amazonSnsMock;
+	private SnsClient amazonSnsMock;
 
 	@Autowired
 	private NotificationTestController notificationTestController;
@@ -77,12 +78,14 @@ public class NotificationEndpointControllerTest {
 				.andExpect(status().isNoContent());
 
 		// Assert
-		verify(this.amazonSnsMock, times(1)).confirmSubscription(
-				"arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
-				"111111111111111111111111111111111111111111111111111111"
-						+ "11111111111111111111111111111111111111111111111111111"
-						+ "111111111111111111111111111111111111111111111111111111"
-						+ "1111111111111111111111111111111111111111111111111");
+		verify(this.amazonSnsMock, times(1))
+				.confirmSubscription(ConfirmSubscriptionRequest.builder()
+						.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+						.token("111111111111111111111111111111111111111111111111111111"
+								+ "11111111111111111111111111111111111111111111111111111"
+								+ "111111111111111111111111111111111111111111111111111111"
+								+ "1111111111111111111111111111111111111111111111111")
+						.build());
 	}
 
 	@Test
@@ -121,12 +124,14 @@ public class NotificationEndpointControllerTest {
 				.andExpect(status().isNoContent());
 
 		// Assert
-		verify(this.amazonSnsMock, times(1)).confirmSubscription(
-				"arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
-				"2336412f37fb687f5d51e6e241d638b05824e9e2f6713b42abaeb"
-						+ "8607743f5ba91d34edd2b9dabe2f1616ed77c0f8801ee79911d3"
-						+ "4dca3d210c228af87bd5d9597bf0d6093a1464e03af6650e992ecf"
-						+ "54605e020f04ad3d47796045c9f24d902e72e811a1ad59852cad453f40bddfb45");
+		verify(this.amazonSnsMock, times(1))
+				.confirmSubscription(ConfirmSubscriptionRequest.builder()
+						.topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+						.token("2336412f37fb687f5d51e6e241d638b05824e9e2f6713b42abaeb"
+								+ "8607743f5ba91d34edd2b9dabe2f1616ed77c0f8801ee79911d3"
+								+ "4dca3d210c228af87bd5d9597bf0d6093a1464e03af6650e992ecf"
+								+ "54605e020f04ad3d47796045c9f24d902e72e811a1ad59852cad453f40bddfb45")
+						.build());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolverTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/NotificationStatusHandlerMethodArgumentResolverTest.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.aws.messaging.endpoint;
 
-import com.amazonaws.services.sns.AmazonSNS;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.io.ClassPathResource;
@@ -44,7 +45,7 @@ public class NotificationStatusHandlerMethodArgumentResolverTest {
 		this.expectedException.expect(IllegalArgumentException.class);
 		this.expectedException.expectMessage("NotificationStatus is only available");
 
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		NotificationStatusHandlerMethodArgumentResolver resolver = new NotificationStatusHandlerMethodArgumentResolver(
 				amazonSns);
 
@@ -70,7 +71,7 @@ public class NotificationStatusHandlerMethodArgumentResolverTest {
 	public void resolveArgument_subscriptionRequest_createsValidSubscriptionStatus()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		NotificationStatusHandlerMethodArgumentResolver resolver = new NotificationStatusHandlerMethodArgumentResolver(
 				amazonSns);
 
@@ -93,13 +94,14 @@ public class NotificationStatusHandlerMethodArgumentResolverTest {
 		// Assert
 		assertThat(resolvedArgument instanceof NotificationStatus).isTrue();
 		((NotificationStatus) resolvedArgument).confirmSubscription();
-		verify(amazonSns, times(1)).confirmSubscription(
-				"arn:aws:sns:eu-west-1:111111111111:mySampleTopic",
-				"1111111111111111111111111111111111111111111111"
+		verify(amazonSns, times(1)).confirmSubscription(ConfirmSubscriptionRequest
+				.builder().topicArn("arn:aws:sns:eu-west-1:111111111111:mySampleTopic")
+				.token("1111111111111111111111111111111111111111111111"
 						+ "1111111111111111111111111111111111111111111"
 						+ "1111111111111111111111111111111111111111111"
 						+ "1111111111111111111111111111111111111111111"
-						+ "11111111111111111111111111111111111");
+						+ "11111111111111111111111111111111111")
+				.build());
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBeanTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/endpoint/config/NotificationHandlerMethodArgumentResolverFactoryBeanTest.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.aws.messaging.endpoint.config;
 
-import com.amazonaws.services.sns.AmazonSNS;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.services.sns.SnsClient;
 
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodArgumentResolverComposite;
@@ -36,7 +36,7 @@ public class NotificationHandlerMethodArgumentResolverFactoryBeanTest {
 	public void getObjectType_defaultConfiguration_returnsHandlerMethodArgumentResolverType()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		NotificationHandlerMethodArgumentResolverFactoryBean factoryBean;
 		factoryBean = new NotificationHandlerMethodArgumentResolverFactoryBean(amazonSns);
 
@@ -51,7 +51,7 @@ public class NotificationHandlerMethodArgumentResolverFactoryBeanTest {
 	public void getObject_withDefaultConfiguration_createCompositeResolverWithAllDelegatedResolvers()
 			throws Exception {
 		// Arrange
-		AmazonSNS amazonSns = mock(AmazonSNS.class);
+		SnsClient amazonSns = mock(SnsClient.class);
 		NotificationHandlerMethodArgumentResolverFactoryBean factoryBean;
 		factoryBean = new NotificationHandlerMethodArgumentResolverFactoryBean(amazonSns);
 		factoryBean.afterPropertiesSet();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/MessageListenerContainerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
@@ -61,6 +62,7 @@ public class MessageListenerContainerTest {
 	public void testAfterPropertiesSetIsSettingActiveFlag() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 
@@ -86,6 +88,7 @@ public class MessageListenerContainerTest {
 
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 
 		container.afterPropertiesSet();
@@ -95,6 +98,7 @@ public class MessageListenerContainerTest {
 	public void testDestinationResolverIsCreatedIfNull() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 		container.afterPropertiesSet();
@@ -110,6 +114,7 @@ public class MessageListenerContainerTest {
 	public void testDisposableBeanResetActiveFlag() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 
@@ -131,6 +136,7 @@ public class MessageListenerContainerTest {
 	public void testCustomDestinationResolverSet() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 
@@ -187,7 +193,9 @@ public class MessageListenerContainerTest {
 	public void testIsActive() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		SqsAsyncClient mockAsync = mock(SqsAsyncClient.class);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
+		container.setAmazonSqsAsync(mockAsync);
 		container.setAmazonSqs(mock);
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 
@@ -213,7 +221,9 @@ public class MessageListenerContainerTest {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
+		SqsAsyncClient mockAsync = mock(SqsAsyncClient.class);
 		QueueMessageHandler messageHandler = new QueueMessageHandler();
+		container.setAmazonSqsAsync(mockAsync);
 		container.setAmazonSqs(mock);
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 		container.setMessageHandler(messageHandler);
@@ -252,6 +262,8 @@ public class MessageListenerContainerTest {
 	public void receiveMessageRequests_withMultipleElements_created() throws Exception {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 
+		SqsAsyncClient mockAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(mockAsync);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(mock);
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -318,6 +330,8 @@ public class MessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(mock);
 		container.setMessageHandler(mock(QueueMessageHandler.class));
@@ -355,6 +369,8 @@ public class MessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient mockAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(mockAsync);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(mock);
 		container.setMessageHandler(mock(QueueMessageHandler.class));
@@ -393,6 +409,8 @@ public class MessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient mockAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(mockAsync);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(mock);
 		container.setMessageHandler(mock(QueueMessageHandler.class));
@@ -435,6 +453,8 @@ public class MessageListenerContainerTest {
 		AbstractMessageListenerContainer container = new StubAbstractMessageListenerContainer();
 		Logger loggerMock = container.getLogger();
 
+		SqsAsyncClient sqsAsyncMock = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsyncMock);
 		SqsClient mock = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(mock);
 		StaticApplicationContext applicationContext = new StaticApplicationContext();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -451,8 +451,7 @@ public class SimpleMessageListenerContainerTest {
 		container.stop();
 
 		verify(messageHandler).handleMessage(this.stringMessageCaptor.capture());
-		//TODO SDK2 migration: why is this now uppercase? used to be SenderId
-		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SENDER_ID"))
+		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SenderId"))
 				.isEqualTo("ID");
 
 	}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -33,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
@@ -150,6 +151,7 @@ public class SimpleMessageListenerContainerTest {
 	public void testWithDefaultTaskExecutorAndNoBeanName() throws Exception {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 
@@ -166,6 +168,7 @@ public class SimpleMessageListenerContainerTest {
 	public void testWithDefaultTaskExecutorAndBeanName() throws Exception {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 		container.setBeanName("testContainerName");
@@ -189,6 +192,7 @@ public class SimpleMessageListenerContainerTest {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 
 		QueueMessageHandler mockedHandler = mock(QueueMessageHandler.class);
+		SqsAsyncClient mockedSqsAsync = mock(SqsAsyncClient.class);
 		SqsClient mockedSqs = mock(SqsClient.class, withSettings().stubOnly());
 
 		when(mockedSqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
@@ -198,6 +202,7 @@ public class SimpleMessageListenerContainerTest {
 		when(mockedHandler.getHandlerMethods()).thenReturn(messageHandlerMethods);
 
 		container.setMaxNumberOfMessages(testedMaxNumberOfMessages);
+		container.setAmazonSqsAsync(mockedSqsAsync);
 		container.setAmazonSqs(mockedSqs);
 		container.setMessageHandler(mockedHandler);
 
@@ -218,6 +223,7 @@ public class SimpleMessageListenerContainerTest {
 		SimpleAsyncTaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
 		container.setTaskExecutor(taskExecutor);
 
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 		container.setBeanName("testContainerName");
@@ -230,6 +236,8 @@ public class SimpleMessageListenerContainerTest {
 	public void testSimpleReceiveMessage() throws Exception {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 
@@ -284,6 +292,8 @@ public class SimpleMessageListenerContainerTest {
 		SimpleAsyncTaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
 		container.setTaskExecutor(taskExecutor);
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 
@@ -326,6 +336,8 @@ public class SimpleMessageListenerContainerTest {
 				super.executeMessage(stringMessage);
 			}
 		};
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 
@@ -397,6 +409,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 
@@ -437,7 +451,8 @@ public class SimpleMessageListenerContainerTest {
 		container.stop();
 
 		verify(messageHandler).handleMessage(this.stringMessageCaptor.capture());
-		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SenderId"))
+		//TODO SDK2 migration: why is this now uppercase? used to be SenderId
+		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SENDER_ID"))
 				.isEqualTo("ID");
 
 	}
@@ -447,6 +462,8 @@ public class SimpleMessageListenerContainerTest {
 			throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer simpleMessageListenerContainer = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		simpleMessageListenerContainer.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		simpleMessageListenerContainer.setAmazonSqs(sqs);
 		QueueMessageHandler messageHandler = mock(QueueMessageHandler.class);
@@ -466,6 +483,8 @@ public class SimpleMessageListenerContainerTest {
 	public void afterPropertiesSet_whenCalled_taskExecutorIsActive() throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 		QueueMessageHandler messageHandler = mock(QueueMessageHandler.class);
@@ -495,6 +514,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 
@@ -574,6 +595,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -603,7 +626,7 @@ public class SimpleMessageListenerContainerTest {
 		// Assert
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder().queueUrl(
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder().queueUrl(
 				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com")
 				.receiptHandle("ReceiptHandle").build()));
 	}
@@ -623,6 +646,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -662,7 +687,7 @@ public class SimpleMessageListenerContainerTest {
 		// Assert
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://executeMessage_executionThrowsExceptionAnd"
 						+ "QueueHasAllDeletionPolicy_shouldRemoveMessageFromQueue.amazonaws.com")
 				.receiptHandle("ReceiptHandle").build()));
@@ -683,6 +708,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -732,6 +759,7 @@ public class SimpleMessageListenerContainerTest {
 	public void doStop_containerNotRunning_shouldNotThrowAnException() throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(mock(QueueMessageHandler.class));
 		container.setAutoStartup(false);
@@ -746,6 +774,8 @@ public class SimpleMessageListenerContainerTest {
 			throws Exception {
 		// Arrange
 		Level previous = disableLogging();
+
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
 
 		SqsClient amazonSqs = mock(SqsClient.class, withSettings().stubOnly());
 		when(amazonSqs.receiveMessage(any(ReceiveMessageRequest.class)))
@@ -781,6 +811,7 @@ public class SimpleMessageListenerContainerTest {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setBackOffTime(0);
 		container.setAmazonSqs(amazonSqs);
+		container.setAmazonSqsAsync(sqsAsync);
 		container.setMessageHandler(messageHandler);
 		container.setAutoStartup(false);
 		container.afterPropertiesSet();
@@ -809,6 +840,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -849,7 +882,7 @@ public class SimpleMessageListenerContainerTest {
 		testMessageListenerWithManualDeletionPolicy.getCountDownLatch().await(1L,
 				TimeUnit.SECONDS);
 		testMessageListenerWithManualDeletionPolicy.acknowledge();
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://receiveMessage_withMessageListenerMethodAnd"
 						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com")
 				.receiptHandle("ReceiptHandle").build()));
@@ -871,6 +904,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -902,14 +937,14 @@ public class SimpleMessageListenerContainerTest {
 		// Assert
 		countDownLatch.await(1L, TimeUnit.SECONDS);
 		// TODO SDK2 migration: improve
-		verify(sqs, never())
+		verify(sqsAsync, never())
 				.changeMessageVisibility(any(ChangeMessageVisibilityRequest.class));
 		TestMessageListenerWithVisibilityProlong testMessageListenerWithVisibilityProlong = applicationContext
 				.getBean(TestMessageListenerWithVisibilityProlong.class);
 		testMessageListenerWithVisibilityProlong.getCountDownLatch().await(1L,
 				TimeUnit.SECONDS);
 		testMessageListenerWithVisibilityProlong.extend(5);
-		verify(sqs, times(1)).changeMessageVisibility(eq(ChangeMessageVisibilityRequest
+		verify(sqsAsync, times(1)).changeMessageVisibility(eq(ChangeMessageVisibilityRequest
 				.builder()
 				.queueUrl("https://receiveMessage_withMessageListenerMethodAnd"
 						+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com")
@@ -924,6 +959,8 @@ public class SimpleMessageListenerContainerTest {
 		Level previous = disableLogging();
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class);
 		container.setAmazonSqs(sqs);
 
@@ -985,29 +1022,28 @@ public class SimpleMessageListenerContainerTest {
 				.getBean(TestMessageListenerWithAllPossibleDeletionPolicies.class);
 		assertThat(bean.getCountdownLatch().await(1L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://alwaysSuccess.amazonaws.com")
 				.receiptHandle("alwaysSuccess").build()));
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://alwaysError.amazonaws.com")
 				.receiptHandle("alwaysError").build()));
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://onSuccessSuccess.amazonaws.com")
 				.receiptHandle("onSuccessSuccess").build()));
-		verify(sqs, never()).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, never()).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://onSuccessError.amazonaws.com")
 				.receiptHandle("onSuccessError").build()));
-		verify(sqs, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://noRedriveSuccess.amazonaws.com")
 				.receiptHandle("noRedriveSuccess").build()));
-		verify(sqs, never()).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, never()).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://noRedriveError.amazonaws.com")
 				.receiptHandle("noRedriveError").build()));
-		// TODO SDK2 migration: improve
-		verify(sqs, never()).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, never()).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://neverSuccess.amazonaws.com")
 				.receiptHandle("neverSuccess").build()));
-		verify(sqs, never()).deleteMessage(eq(DeleteMessageRequest.builder()
+		verify(sqsAsync, never()).deleteMessage(eq(DeleteMessageRequest.builder()
 				.queueUrl("https://neverError.amazonaws.com").receiptHandle("neverError")
 				.build()));
 
@@ -1025,6 +1061,8 @@ public class SimpleMessageListenerContainerTest {
 				AnotherTestMessageListener.class);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(0);
@@ -1076,10 +1114,28 @@ public class SimpleMessageListenerContainerTest {
 				AnotherTestMessageListener.class);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		// TODO SDK2 migration: find a solution for clients
-		// MockAmazonSqsAsyncClient sqs = new MockAmazonSqsAsyncClient();
-		SqsClient sqs = mock(SqsClient.class);
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		SqsClient sqs = mock(SqsClient.class);
+		when(sqs.getQueueUrl(any(GetQueueUrlRequest.class))).then((Answer<GetQueueUrlResponse>) invocation -> {
+			GetQueueUrlRequest getQueueUrlRequest = invocation.getArgument(0);
+			return GetQueueUrlResponse.builder().queueUrl("http://" + getQueueUrlRequest.queueName() + ".amazonaws.com")
+					.build();
+		});
+		when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+				.thenReturn(GetQueueAttributesResponse.builder().build());
+		when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).then((Answer<ReceiveMessageResponse>) invocation -> {
+			ReceiveMessageRequest receiveMessageRequest = invocation.getArgument(0);
+			if ("http://testQueue.amazonaws.com".equals(receiveMessageRequest.queueUrl())) {
+				return ReceiveMessageResponse.builder()
+						.messages(Message.builder().body("Hello").receiptHandle("ReceiptHandle").build()).build();
+			}
+			else {
+				return ReceiveMessageResponse.builder().build();
+			}
+		});
+
+		container.setAmazonSqsAsync(sqsAsync);
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(0);
 
@@ -1094,9 +1150,6 @@ public class SimpleMessageListenerContainerTest {
 
 		assertThat(container.isRunning("testQueue")).isFalse();
 		assertThat(container.isRunning("anotherTestQueue")).isTrue();
-
-		// TODO SDK2 migration: enable after solving issue with clients
-		// sqs.setReceiveMessageEnabled(true);
 
 		// Act
 		container.start("testQueue");
@@ -1121,6 +1174,7 @@ public class SimpleMessageListenerContainerTest {
 	public void stop_withQueueNameThatDoesNotExist_throwsAnException() throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(new QueueMessageHandler());
 		container.afterPropertiesSet();
@@ -1135,6 +1189,7 @@ public class SimpleMessageListenerContainerTest {
 	public void start_withQueueNameThatDoesNotExist_throwAnException() throws Exception {
 		// Arrange
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setAmazonSqsAsync(mock(SqsAsyncClient.class));
 		container.setAmazonSqs(mock(SqsClient.class, withSettings().stubOnly()));
 		container.setMessageHandler(new QueueMessageHandler());
 
@@ -1155,11 +1210,13 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListener.class);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 
 		when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
 				.thenReturn(ReceiveMessageResponse.builder().build());
 
+		container.setAmazonSqsAsync(sqsAsync);
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(0);
 
@@ -1196,6 +1253,8 @@ public class SimpleMessageListenerContainerTest {
 				TestMessageListener.class);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(0);
@@ -1232,6 +1291,8 @@ public class SimpleMessageListenerContainerTest {
 				LongRunningListenerMethod.class);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(0);
@@ -1302,6 +1363,8 @@ public class SimpleMessageListenerContainerTest {
 			}
 		};
 
+		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
+		container.setAmazonSqsAsync(sqsAsync);
 		SqsClient sqs = mock(SqsClient.class, withSettings().stubOnly());
 		container.setAmazonSqs(sqs);
 		container.setBackOffTime(100);
@@ -1358,51 +1421,6 @@ public class SimpleMessageListenerContainerTest {
 				.isTrue();
 	}
 
-	// TODO SDK2 migration: find a solution for clients
-	// // This class is needed because it does not seem to work when using mockito to mock
-	// // those requests
-	// private static final class MockAmazonSqsAsyncClient
-	// extends AmazonSQSBufferedAsyncClient {
-	//
-	// private volatile boolean receiveMessageEnabled;
-	//
-	// private MockAmazonSqsAsyncClient() {
-	// super(null);
-	// }
-	//
-	// @Override
-	// public GetQueueUrlResponse getQueueUrl(GetQueueUrlRequest getQueueUrlRequest)
-	// throws AmazonClientException {
-	// return new GetQueueUrlResult().withQueueUrl(
-	// "http://" + getQueueUrlRequest.getQueueName() + ".amazonaws.com");
-	// }
-	//
-	// @Override
-	// public GetQueueAttributesResult getQueueAttributes(
-	// GetQueueAttributesRequest getQueueAttributesRequest)
-	// throws AmazonClientException {
-	// return new GetQueueAttributesResult();
-	// }
-	//
-	// @Override
-	// public ReceiveMessageResult receiveMessage(
-	// ReceiveMessageRequest receiveMessageRequest)
-	// throws AmazonClientException {
-	// if ("http://testQueue.amazonaws.com".equals(
-	// receiveMessageRequest.getQueueUrl()) && this.receiveMessageEnabled) {
-	// return ReceiveMessageResponse.builder().withMessages(new Message()
-	// .body("Hello").receiptHandle("ReceiptHandle"));
-	// }
-	// else {
-	// return ReceiveMessageResponse.builder();
-	// }
-	// }
-	//
-	// public void setReceiveMessageEnabled(boolean receiveMessageEnabled) {
-	// this.receiveMessageEnabled = receiveMessageEnabled;
-	// }
-	//
-	// }
 
 	private static class TestMessageListener {
 
@@ -1485,13 +1503,19 @@ public class SimpleMessageListenerContainerTest {
 	protected static class SqsTestConfig {
 
 		@Bean
-		public SqsClient amazonSQS() {
+		public SqsClient amazonSqs() {
 			SqsClient mockAmazonSQS = mock(SqsClient.class, withSettings().stubOnly());
 			mockGetQueueUrl(mockAmazonSQS, "testQueue", "http://testQueue.amazonaws.com");
 			when(mockAmazonSQS.receiveMessage(any(ReceiveMessageRequest.class)))
 					.thenReturn(ReceiveMessageResponse.builder().build());
 			when(mockAmazonSQS.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 					.thenReturn(GetQueueAttributesResponse.builder().build());
+			return mockAmazonSQS;
+		}
+
+		@Bean
+		public SqsAsyncClient amazonSqsAsync() {
+			SqsAsyncClient mockAmazonSQS = mock(SqsAsyncClient.class, withSettings().stubOnly());
 			return mockAmazonSQS;
 		}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -871,11 +871,7 @@ public class SimpleMessageListenerContainerTest {
 
 		// Assert
 		countDownLatch.await(1L, TimeUnit.SECONDS);
-		// TODO SDK2 migration: improve
-		verify(sqs, never()).deleteMessage(eq(DeleteMessageRequest.builder()
-				.queueUrl("https://receiveMessage_withMessageListenerMethodAnd"
-						+ "NeverDeletionPolicy_waitsForAcknowledgmentBeforeDeletion.amazonaws.com")
-				.receiptHandle("ReceiptHandle").build()));
+		verify(sqs, never()).deleteMessage(any(DeleteMessageRequest.class));
 		TestMessageListenerWithManualDeletionPolicy testMessageListenerWithManualDeletionPolicy = applicationContext
 				.getBean(TestMessageListenerWithManualDeletionPolicy.class);
 		testMessageListenerWithManualDeletionPolicy.getCountDownLatch().await(1L,
@@ -935,7 +931,6 @@ public class SimpleMessageListenerContainerTest {
 
 		// Assert
 		countDownLatch.await(1L, TimeUnit.SECONDS);
-		// TODO SDK2 migration: improve
 		verify(sqsAsync, never())
 				.changeMessageVisibility(any(ChangeMessageVisibilityRequest.class));
 		TestMessageListenerWithVisibilityProlong testMessageListenerWithVisibilityProlong = applicationContext

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -625,8 +625,9 @@ public class SimpleMessageListenerContainerTest {
 		// Assert
 		assertThat(countDownLatch.await(2L, TimeUnit.SECONDS)).isTrue();
 		container.stop();
-		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder().queueUrl(
-				"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com")
+		verify(sqsAsync, times(1)).deleteMessage(eq(DeleteMessageRequest.builder()
+				.queueUrl(
+						"https://executeMessage_successfulExecution_shouldRemoveMessageFromQueue.amazonaws.com")
 				.receiptHandle("ReceiptHandle").build()));
 	}
 
@@ -938,11 +939,11 @@ public class SimpleMessageListenerContainerTest {
 		testMessageListenerWithVisibilityProlong.getCountDownLatch().await(1L,
 				TimeUnit.SECONDS);
 		testMessageListenerWithVisibilityProlong.extend(5);
-		verify(sqsAsync, times(1)).changeMessageVisibility(eq(ChangeMessageVisibilityRequest
-				.builder()
-				.queueUrl("https://receiveMessage_withMessageListenerMethodAnd"
-						+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com")
-				.receiptHandle("ReceiptHandle").visibilityTimeout(5).build()));
+		verify(sqsAsync, times(1))
+				.changeMessageVisibility(eq(ChangeMessageVisibilityRequest.builder()
+						.queueUrl("https://receiveMessage_withMessageListenerMethodAnd"
+								+ "VisibilityProlonging_callsChangeMessageVisibility.amazonaws.com")
+						.receiptHandle("ReceiptHandle").visibilityTimeout(5).build()));
 		container.stop();
 	}
 
@@ -1111,23 +1112,29 @@ public class SimpleMessageListenerContainerTest {
 
 		SqsAsyncClient sqsAsync = mock(SqsAsyncClient.class);
 		SqsClient sqs = mock(SqsClient.class);
-		when(sqs.getQueueUrl(any(GetQueueUrlRequest.class))).then((Answer<GetQueueUrlResponse>) invocation -> {
-			GetQueueUrlRequest getQueueUrlRequest = invocation.getArgument(0);
-			return GetQueueUrlResponse.builder().queueUrl("http://" + getQueueUrlRequest.queueName() + ".amazonaws.com")
-					.build();
-		});
+		when(sqs.getQueueUrl(any(GetQueueUrlRequest.class)))
+				.then((Answer<GetQueueUrlResponse>) invocation -> {
+					GetQueueUrlRequest getQueueUrlRequest = invocation.getArgument(0);
+					return GetQueueUrlResponse.builder().queueUrl(
+							"http://" + getQueueUrlRequest.queueName() + ".amazonaws.com")
+							.build();
+				});
 		when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 				.thenReturn(GetQueueAttributesResponse.builder().build());
-		when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).then((Answer<ReceiveMessageResponse>) invocation -> {
-			ReceiveMessageRequest receiveMessageRequest = invocation.getArgument(0);
-			if ("http://testQueue.amazonaws.com".equals(receiveMessageRequest.queueUrl())) {
-				return ReceiveMessageResponse.builder()
-						.messages(Message.builder().body("Hello").receiptHandle("ReceiptHandle").build()).build();
-			}
-			else {
-				return ReceiveMessageResponse.builder().build();
-			}
-		});
+		when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
+				.then((Answer<ReceiveMessageResponse>) invocation -> {
+					ReceiveMessageRequest receiveMessageRequest = invocation
+							.getArgument(0);
+					if ("http://testQueue.amazonaws.com"
+							.equals(receiveMessageRequest.queueUrl())) {
+						return ReceiveMessageResponse.builder().messages(Message.builder()
+								.body("Hello").receiptHandle("ReceiptHandle").build())
+								.build();
+					}
+					else {
+						return ReceiveMessageResponse.builder().build();
+					}
+				});
 
 		container.setAmazonSqsAsync(sqsAsync);
 		container.setAmazonSqs(sqs);
@@ -1415,7 +1422,6 @@ public class SimpleMessageListenerContainerTest {
 				.isTrue();
 	}
 
-
 	private static class TestMessageListener {
 
 		private final CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -1509,7 +1515,8 @@ public class SimpleMessageListenerContainerTest {
 
 		@Bean
 		public SqsAsyncClient amazonSqsAsync() {
-			SqsAsyncClient mockAmazonSQS = mock(SqsAsyncClient.class, withSettings().stubOnly());
+			SqsAsyncClient mockAmazonSQS = mock(SqsAsyncClient.class,
+					withSettings().stubOnly());
 			return mockAmazonSQS;
 		}
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -26,7 +26,7 @@
 	   					   http://www.springframework.org/schema/cloud/aws/context
 	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
-	<bean id="myClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient"/>
+	<bean id="myClient" class="software.amazon.awssdk.services.sqs.SqsAsyncClient" factory-method="create"/>
 
 	<aws-messaging:annotation-driven-queue-listener amazon-sqs="myClient"/>
 

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -26,9 +26,10 @@
 	   					   http://www.springframework.org/schema/cloud/aws/context
 	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
 
-	<bean id="myClient" class="software.amazon.awssdk.services.sqs.SqsAsyncClient" factory-method="create"/>
+	<bean id="myClient" class="software.amazon.awssdk.services.sqs.SqsClient" factory-method="create"/>
+	<bean id="myClientAsync" class="software.amazon.awssdk.services.sqs.SqsAsyncClient" factory-method="create"/>
 
-	<aws-messaging:annotation-driven-queue-listener amazon-sqs="myClient"/>
+	<aws-messaging:annotation-driven-queue-listener amazon-sqs-async="myClientAsync" amazon-sqs="myClient"/>
 
 	<aws-context:context-credentials>
 		<aws-context:instance-profile-credentials/>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
@@ -33,5 +33,5 @@
 	<aws-messaging:notification-argument-resolver id="notificationArgumentResolver"
 												  amazon-sns="customSnsClient"/>
 
-	<bean id="customSnsClient" class="com.amazonaws.services.sns.AmazonSNSClient"/>
+	<bean id="customSnsClient" class="software.amazon.awssdk.services.sns.SnsClient" factory-method="create"/>
 </beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
@@ -36,7 +36,7 @@
 												  amazon-sns="amazonSns"/>
 
 	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>
+		<constructor-arg value="software.amazon.awssdk.services.sns.SnsClient"/>
 	</bean>
 
 	<bean

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
@@ -35,7 +35,7 @@
 												  amazon-sns="amazonSns"/>
 
 	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>
+		<constructor-arg value="software.amazon.awssdk.services.sns.SnsClient"/>
 	</bean>
 
 	<bean

--- a/spring-cloud-aws-parameter-store-config/pom.xml
+++ b/spring-cloud-aws-parameter-store-config/pom.xml
@@ -46,8 +46,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ssm</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ssm</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -21,9 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.awssdk.services.ssm.SsmClient;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
@@ -45,7 +45,7 @@ import org.springframework.util.ReflectionUtils;
  */
 public class AwsParamStorePropertySourceLocator implements PropertySourceLocator {
 
-	private AWSSimpleSystemsManagement ssmClient;
+	private SsmClient ssmClient;
 
 	private AwsParamStoreProperties properties;
 
@@ -53,7 +53,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 	private Log logger = LogFactory.getLog(getClass());
 
-	public AwsParamStorePropertySourceLocator(AWSSimpleSystemsManagement ssmClient,
+	public AwsParamStorePropertySourceLocator(SsmClient ssmClient,
 			AwsParamStoreProperties properties) {
 		this.ssmClient = ssmClient;
 		this.properties = properties;

--- a/spring-cloud-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceTest.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.aws.paramstore;
 
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
-import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
 import org.junit.Test;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse;
+import software.amazon.awssdk.services.ssm.model.Parameter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,26 +29,29 @@ import static org.mockito.Mockito.when;
 
 public class AwsParamStorePropertySourceTest {
 
-	private AWSSimpleSystemsManagement ssmClient = mock(AWSSimpleSystemsManagement.class);
+	private SsmClient ssmClient = mock(SsmClient.class);
 
 	private AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(
 			"/config/myservice/", ssmClient);
 
 	@Test
 	public void followsNextToken() {
-		GetParametersByPathResult firstResult = new GetParametersByPathResult()
-				.withNextToken("next").withParameters(
-						new Parameter().withName("/config/myservice/key1")
-								.withValue("value1"),
-						new Parameter().withName("/config/myservice/key2")
-								.withValue("value2"));
+		GetParametersByPathResponse firstResult = GetParametersByPathResponse.builder()
+				.nextToken("next")
+				.parameters(
+						Parameter.builder().name("/config/myservice/key1").value("value1")
+								.build(),
+						Parameter.builder().name("/config/myservice/key2").value("value2")
+								.build())
+				.build();
 
-		GetParametersByPathResult nextResult = new GetParametersByPathResult()
-				.withParameters(
-						new Parameter().withName("/config/myservice/key3")
-								.withValue("value3"),
-						new Parameter().withName("/config/myservice/key4")
-								.withValue("value4"));
+		GetParametersByPathResponse nextResult = GetParametersByPathResponse.builder()
+				.parameters(
+						Parameter.builder().name("/config/myservice/key3").value("value3")
+								.build(),
+						Parameter.builder().name("/config/myservice/key4").value("value4")
+								.build())
+				.build();
 
 		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
 				.thenReturn(firstResult, nextResult);

--- a/spring-cloud-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-aws-secrets-manager-config/pom.xml
@@ -46,8 +46,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>secretsmanager</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -21,9 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
@@ -43,7 +43,7 @@ import org.springframework.util.ReflectionUtils;
  */
 public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLocator {
 
-	private AWSSecretsManager smClient;
+	private SecretsManagerClient smClient;
 
 	private AwsSecretsManagerProperties properties;
 
@@ -51,7 +51,7 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 
 	private Log logger = LogFactory.getLog(getClass());
 
-	public AwsSecretsManagerPropertySourceLocator(AWSSecretsManager smClient,
+	public AwsSecretsManagerPropertySourceLocator(SecretsManagerClient smClient,
 			AwsSecretsManagerProperties properties) {
 		this.smClient = smClient;
 		this.properties = properties;

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.aws.secretsmanager;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import org.junit.Test;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,15 +28,15 @@ import static org.mockito.Mockito.when;
 
 public class AwsSecretsManagerPropertySourceTest {
 
-	private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
+	private SecretsManagerClient smClient = mock(SecretsManagerClient.class);
 
 	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(
 			"/config/myservice", smClient);
 
 	@Test
 	public void shouldParseSecretValue() {
-		GetSecretValueResult secretValueResult = new GetSecretValueResult();
-		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		GetSecretValueResponse secretValueResult = GetSecretValueResponse.builder()
+				.secretString("{\"key1\": \"value1\", \"key2\": \"value2\"}").build();
 
 		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
 				.thenReturn(secretValueResult);

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
@@ -16,8 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.paramstore;
 
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import software.amazon.awssdk.services.ssm.SsmClient;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -37,22 +36,21 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AwsParamStoreProperties.class)
-@ConditionalOnClass({ AWSSimpleSystemsManagement.class,
-		AwsParamStorePropertySourceLocator.class })
+@ConditionalOnClass({ SsmClient.class, AwsParamStorePropertySourceLocator.class })
 @ConditionalOnProperty(prefix = AwsParamStoreProperties.CONFIG_PREFIX, name = "enabled",
 		matchIfMissing = true)
 public class AwsParamStoreBootstrapConfiguration {
 
 	@Bean
 	AwsParamStorePropertySourceLocator awsParamStorePropertySourceLocator(
-			AWSSimpleSystemsManagement ssmClient, AwsParamStoreProperties properties) {
+			SsmClient ssmClient, AwsParamStoreProperties properties) {
 		return new AwsParamStorePropertySourceLocator(ssmClient, properties);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	AWSSimpleSystemsManagement ssmClient() {
-		return AWSSimpleSystemsManagementClientBuilder.defaultClient();
+	SsmClient ssmClient() {
+		return SsmClient.create();
 	}
 
 }

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -16,8 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.secretsmanager;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -37,7 +36,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AwsSecretsManagerProperties.class)
-@ConditionalOnClass({ AWSSecretsManager.class,
+@ConditionalOnClass({ SecretsManagerClient.class,
 		AwsSecretsManagerPropertySourceLocator.class })
 @ConditionalOnProperty(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX,
 		name = "enabled", matchIfMissing = true)
@@ -45,14 +44,14 @@ public class AwsSecretsManagerBootstrapConfiguration {
 
 	@Bean
 	AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(
-			AWSSecretsManager smClient, AwsSecretsManagerProperties properties) {
+			SecretsManagerClient smClient, AwsSecretsManagerProperties properties) {
 		return new AwsSecretsManagerPropertySourceLocator(smClient, properties);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	AWSSecretsManager smClient() {
-		return AWSSecretsManagerClientBuilder.defaultClient();
+	SecretsManagerClient smClient() {
+		return SecretsManagerClient.create();
 	}
 
 }


### PR DESCRIPTION
Upgraded AWS SDK to version 2.0 according to the [changelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md). 

There are some potential blockers where I would like to get some feedback on:

# Potential Blockers
## 1. AmazonSQSBufferedAsyncClient not supported
The [AmazonSQSBufferedAsyncClient](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/buffered/AmazonSQSBufferedAsyncClient.html) is no longer supported according to the [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-client-side-buffering-request-batching.html):

> The AWS SDK for Java 2.x isn't currently compatible with the AmazonSQSBufferedAsyncClient. 

There already is a ticket in the AWS SDK GitHub but it's still open: https://github.com/aws/aws-sdk-java-v2/issues/848 resp. https://github.com/aws/aws-sdk-java-v2/issues/165

Not really sure what to do... I mean as a last resort I could copy all the classes from the old SDK and update them I'd rather not...

## 2. No common interface for Sync and Async client
The 1.x SDK had a common interface for the sync and async client. This is no longer the case. 

Previously, the user could configure either the async or the sync client and pass it to certain framework classes, e.g. `NotificationMessagingTemplate`. This won't be possible anymore. As a first step I would suggest to only accept one client (either sync or async - depending on which methods are used) in all customizable classes. As a next step, the classes could be duplicated to accept both clients (if needed).

Initially I thought that it was also previously possible to replace the autoconfigured sync client with the async client. But I think that was not possible because of the way the [ConditionalOnMissingAmazonClient](https://github.com/spring-cloud/spring-cloud-aws/blob/master/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/annotation/ConditionalOnMissingAmazonClient.java) works. Can you confirm this @alainsahli ?


## 3. Messaging: Sync and Async client used
The messaging module currently uses the async client and calls sync and async methods on it. This is no longer possible in the new SDK. You need to use the sync client for sync methods and the async client for async methods. I see the following options with the new SDK:
- Keep functionality the same by adding both clients and using the respective one (I implemented it like this for now)
- Use async methods everywhere
- Use sync methods everywhere

Please let me know what you think @spencergibb @OlgaMaciaszek 


# Things to do
- [x] Upgrade libraries and fix compile errors
- [ ] Discuss and resolve potential blockers
  - [ ] AmazonSQSBufferedAsyncClient
  - [ ] No common interface
  - [ ] Both clients used in messaging
- [x] Resolve other remaining TODOs in code (non straightforward compile errors)
- [x] Run and fix all unit tests
  - [x] core
  - [x] context
  - [x] jdbc
  - [x] messaging
  - [x] autoconfigure
- [ ] Integration Tests
  - [x] Upgrade libraries and adapt to new SDK
  - [ ] Run and fix all issues that are found
- [ ] Manual testing of everything not covered by integration tests
- [ ] Review changelog if there are more changes in addition to the obvious ones that need to be considered
- [ ] (Optional) Prettify code e.g. rename `describeStacksResult` variable to `describeStacksResponse` (all `Result` class names were changed to `Response`)
- [ ] Update documentation

