### PR TITLE
Fix parameterstore to be not eager

### DIFF
--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -66,6 +66,9 @@ public class AwsParamStoreProperties {
 	/** Is AWS Parameter Store support enabled. */
 	private boolean enabled = true;
 
+	/** Is use only application name for resource location*/
+	private boolean onlyApplicationNameLocator = true;
+
 	public String getPrefix() {
 		return prefix;
 	}
@@ -112,6 +115,14 @@ public class AwsParamStoreProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public boolean isOnlyApplicationNameLocator() {
+		return onlyApplicationNameLocator;
+	}
+
+	public void setOnlyApplicationNameLocator(boolean onlyApplicationNameLocator) {
+		this.onlyApplicationNameLocator = onlyApplicationNameLocator;
 	}
 
 }

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -81,13 +81,18 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 		String prefix = this.properties.getPrefix();
 
-		String defaultContext = prefix + "/" + this.properties.getDefaultContext();
-		this.contexts.add(defaultContext + "/");
-		addProfiles(this.contexts, defaultContext, profiles);
+		if (!this.properties.isOnlyApplicationNameLocator() && !this.properties.getDefaultContext().equals(appName)) {
+			String defaultContext = prefix + "/" + this.properties.getDefaultContext();
+			this.contexts.add(defaultContext + "/");
+			addProfiles(this.contexts, defaultContext, profiles);
+		}
 
 		String baseContext = prefix + "/" + appName;
 		this.contexts.add(baseContext + "/");
-		addProfiles(this.contexts, baseContext, profiles);
+
+		if (!this.properties.isOnlyApplicationNameLocator()) {
+			addProfiles(this.contexts, baseContext, profiles);
+		}
 
 		Collections.reverse(this.contexts);
 


### PR DESCRIPTION
* Added onlyApplicationNameLocator to handle cases when we want to use only application name without environment setup
* Added check if application name and default value for locator path are same not to duplicate requests to SSM