### PR TITLE
Issue 553: AWS region should be retrieved considering multiple strategies.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfigurationTest.java
@@ -22,7 +22,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.DynamicRegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -45,7 +45,7 @@ public class ContextRegionProviderAutoConfigurationTest {
 	}
 
 	@Test
-	public void regionProvider_autoDetectionConfigured_Ec2metaDataRegionProviderConfigured()
+	public void regionProvider_autoDetectionConfigured_dynamicRegionProviderConfigured()
 			throws Exception {
 		// Arrange
 		this.context = new AnnotationConfigApplicationContext();
@@ -56,11 +56,11 @@ public class ContextRegionProviderAutoConfigurationTest {
 		this.context.refresh();
 
 		// Assert
-		assertThat(this.context.getBean(Ec2MetadataRegionProvider.class)).isNotNull();
+		assertThat(this.context.getBean(DynamicRegionProvider.class)).isNotNull();
 	}
 
 	@Test
-	public void regionProvider_autoDetectionConfigured_emptyStaticRegionConfigured_Ec2metaDataRegionProviderConfigured()
+	public void regionProvider_autoDetectionConfigured_emptyStaticRegionConfigured_dynamicRegionProviderConfigured()
 			throws Exception {
 		// Arrange
 		this.context = new AnnotationConfigApplicationContext();
@@ -72,7 +72,7 @@ public class ContextRegionProviderAutoConfigurationTest {
 		this.context.refresh();
 
 		// Assert
-		assertThat(this.context.getBean(Ec2MetadataRegionProvider.class)).isNotNull();
+		assertThat(this.context.getBean(DynamicRegionProvider.class)).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.cloud.aws.core.credentials.CredentialsProviderFactoryBean;
-import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.DynamicRegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.util.StringUtils;
 
@@ -65,7 +65,7 @@ public final class ContextConfigurationUtils {
 
 		if (autoDetect) {
 			beanDefinition = BeanDefinitionBuilder
-					.genericBeanDefinition(Ec2MetadataRegionProvider.class)
+					.genericBeanDefinition(DynamicRegionProvider.class)
 					.getBeanDefinition();
 		}
 		else if (StringUtils.hasText(configuredRegion)) {

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.core.region.DynamicRegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider;
@@ -86,13 +88,13 @@ public class ContextRegionBeanDefinitionParser extends AbstractBeanDefinitionPar
 		}
 		else if (StringUtils.hasText(element.getAttribute("region"))) {
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-					"org.springframework.cloud.aws.core.region.StaticRegionProvider");
+				StaticRegionProvider.class.getName());
 			builder.addConstructorArgValue(element.getAttribute("region"));
 			return builder.getBeanDefinition();
 		}
 		else if (isAutoDetect(element)) {
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-					"org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider");
+				DynamicRegionProvider.class.getName());
 			return builder.getBeanDefinition();
 		}
 		return null;

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrarTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.DynamicRegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -75,8 +75,8 @@ public class ContextRegionConfigurationRegistrarTest {
 				ApplicationConfigurationWithDynamicRegionProvider.class);
 
 		// Act
-		Ec2MetadataRegionProvider staticRegionProvider = this.context
-				.getBean(Ec2MetadataRegionProvider.class);
+		DynamicRegionProvider staticRegionProvider = this.context
+				.getBean(DynamicRegionProvider.class);
 
 		// Assert
 		assertThat(staticRegionProvider).isNotNull();

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
-import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.DynamicRegionProvider;
 import org.springframework.cloud.aws.core.region.RegionProvider;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -92,7 +92,7 @@ public class ContextRegionBeanDefinitionParserTest {
 	}
 
 	@Test
-	public void parse_autoDetectRegion_returnEc2MetadataRegionProvider()
+	public void parse_autoDetectRegion_returnDynamicRegionProvider()
 			throws Exception {
 		// Arrange
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
@@ -105,7 +105,7 @@ public class ContextRegionBeanDefinitionParserTest {
 
 		// Assert
 		assertThat(myRegionProvider).isNotNull();
-		assertThat(myRegionProvider instanceof Ec2MetadataRegionProvider).isTrue();
+		assertThat(myRegionProvider instanceof DynamicRegionProvider).isTrue();
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/DynamicRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/DynamicRegionProvider.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.aws.core.region;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.regions.AwsRegionProvider;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+
+/**
+ * Dynamic {@link RegionProvider} implementation that retrieves the region using {@link DefaultAwsRegionProviderChain}.
+ *
+ * @author Oleksandr Hladun
+ * @since 2.2.3
+ */
+public class DynamicRegionProvider implements RegionProvider {
+
+	private final AwsRegionProvider awsRegionProvider;
+
+	public DynamicRegionProvider() {
+		this.awsRegionProvider = new DefaultAwsRegionProviderChain();
+	}
+
+	@Override
+	public Region getRegion() {
+		try {
+			return RegionUtils.getRegion(awsRegionProvider.getRegion());
+		}
+		catch (SdkClientException e) {
+			throw new IllegalStateException("Unable to retrieve the region", e);
+		}
+	}
+}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/region/Ec2MetadataRegionProvider.java
@@ -29,9 +29,11 @@ import org.springframework.util.Assert;
  * dynamically retrieves the region with the EC2 meta-data. This implementation allows
  * application to run against their region without any further configuration.
  *
+ * @deprecated since 2.2.3 in favor of {@link DynamicRegionProvider}
  * @author Agim Emruli
  * @author Gleb Schukin
  */
+@Deprecated
 public class Ec2MetadataRegionProvider implements RegionProvider {
 
 	@Override

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/DynamicRegionProviderTests.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/region/DynamicRegionProviderTests.java
@@ -1,0 +1,34 @@
+package org.springframework.cloud.aws.core.region;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static com.amazonaws.SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class DynamicRegionProviderTests {
+
+	private static final String UNABLE_TO_RETRIEVE_THE_REGION = "Unable to retrieve the region";
+
+	private final RegionProvider regionProvider = new DynamicRegionProvider();
+
+	@Test
+	void shouldFailWhenTheRegionIsNotProvided() {
+		IllegalStateException exception = Assertions
+			.assertThrows(IllegalStateException.class, regionProvider::getRegion);
+
+		assertThat(exception.getMessage(), is(UNABLE_TO_RETRIEVE_THE_REGION));
+	}
+
+	@Test
+	void shouldRetrieveTheRegionWhenItsProvided() {
+		System.setProperty(AWS_REGION_SYSTEM_PROPERTY, Regions.EU_WEST_1.getName());
+
+		Region region = regionProvider.getRegion();
+
+		assertThat(region.getName(), is(Regions.EU_WEST_1.getName()));
+	}
+}


### PR DESCRIPTION
Currently, spring cloud aws uses `Ec2MetadataRegionProvider` for dynamic region lookup.
However, this solution doesn't work in some cases such https://github.com/spring-cloud/spring-cloud-aws/issues/553
We should consider using  `com.amazonaws.regions.DefaultAwsRegionProviderChain` that provides multiple strategies for the region lookup