### PR TITLE
Issue 483: `SimpleStorageResource.getURL` should encode s3 object key

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -139,8 +141,10 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 	@Override
 	public URL getURL() throws IOException {
 		Region region = this.amazonS3.getRegion().toAWSRegion();
+		String encodedObjectName = URLEncoder.encode(this.objectName,
+				StandardCharsets.UTF_8.toString());
 		return new URL("https", region.getServiceEndpoint(AmazonS3Client.S3_SERVICE_NAME),
-				"/" + this.bucketName + "/" + this.objectName);
+				"/" + this.bucketName + "/" + encodedObjectName);
 	}
 
 	@Override

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.Date;
 
@@ -295,6 +296,17 @@ public class SimpleStorageResourceTest {
 		outputStream.close();
 
 		// Assert
+	}
+
+	@Test
+	public void getUri_encodes_objectName() throws Exception {
+		AmazonS3 s3 = mock(AmazonS3.class);
+		when(s3.getRegion()).thenReturn(Region.US_West_2);
+		SimpleStorageResource resource = new SimpleStorageResource(s3, "bucketName",
+				"some/[objectName]", new SyncTaskExecutor());
+
+		assertThat(resource.getURI()).isEqualTo(new URI(
+				"https://s3.us-west-2.amazonaws.com/bucketName/some%2F%5BobjectName%5D"));
 	}
 
 }


### PR DESCRIPTION
Resolves the issue https://github.com/spring-cloud/spring-cloud-aws/issues/483