### PR TITLE
Feature/gh 542

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.aws.messaging.listener;
 
-import static org.springframework.cloud.aws.messaging.core.QueueMessageUtils.createMessage;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,15 +25,17 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import static org.springframework.cloud.aws.messaging.core.QueueMessageUtils.createMessage;
 
 /**
  * @author Agim Emruli

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
@@ -50,7 +50,7 @@ public class TaskExecutorBuilder {
 	}
 
 	/**
-	 * Initialized the member variables with an existing {@ThreadPoolTaskExecutor}
+	 * Initialized the member variables with an existing {@ThreadPoolTaskExecutor}.
 	 */
 	public TaskExecutorBuilder(ThreadPoolTaskExecutor taskExecutor) {
 
@@ -65,9 +65,9 @@ public class TaskExecutorBuilder {
 	 * {@link org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer}.
 	 * So the behavior before this class is not changed.
 	 * @param messageListenerContainer implementation to extract information to calculate
-	 *     pool size information
+	 * pool size information
 	 * @param threadNamePrefix which is required and constructed by the
-	 *     _messageListenerContainer_
+	 * _messageListenerContainer_
 	 * @return The instance of this builder to manipulate the values
 	 */
 	public TaskExecutorBuilder fromMessageListenerContainer(

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
@@ -50,6 +50,17 @@ public class TaskExecutorBuilder {
 	}
 
 	/**
+	 * Initialized the member variables with an existing {@ThreadPoolTaskExecutor}
+	 */
+	public TaskExecutorBuilder(ThreadPoolTaskExecutor taskExecutor) {
+
+		this();
+		this.maxPoolSize = taskExecutor.getMaxPoolSize();
+		this.corePoolSize = taskExecutor.getCorePoolSize();
+		this.threadNamePrefix = taskExecutor.getThreadNamePrefix();
+	}
+
+	/**
 	 * Set the member variables with input form
 	 * {@link org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer}.
 	 * So the behavior before this class is not changed.

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
@@ -22,7 +22,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Kevin Gath
- * @since 2.3
+ * @since 1.0
  */
 public class TaskExecutorBuilder {
 

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.listener;
+
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.util.Assert;
+
+/**
+ * @author Kevin Gath
+ * @since 2.3
+ */
+public class TaskExecutorBuilder {
+
+	private static final int WORKER_THREADS = 2;
+
+	private int queueCapacity;
+
+	private int maxPoolSize;
+
+	private int corePoolSize;
+
+	private String threadNamePrefix;
+
+	/**
+	 * Initialized the member variables with default values.
+	 */
+	public TaskExecutorBuilder() {
+		// No use of a thread pool executor queue to avoid retaining message to long in
+		// memory
+		this.queueCapacity = 0;
+
+		this.maxPoolSize = 1;
+		this.corePoolSize = 1;
+		this.threadNamePrefix = "thread";
+	}
+
+	/**
+	 * Set the member variables with input form
+	 * {@link org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer}.
+	 * So the behavior before this class is not changed.
+	 * @param messageListenerContainer implementation to extract information to calculate
+	 *     pool size information
+	 * @param threadNamePrefix which is required and constructed by the
+	 *     _messageListenerContainer_
+	 * @return The instance of this builder to manipulate the values
+	 */
+	public TaskExecutorBuilder fromMessageListenerContainer(
+			AbstractMessageListenerContainer messageListenerContainer,
+			String threadNamePrefix) {
+		int spinningThreads = messageListenerContainer.getRegisteredQueues().size();
+		int maxNumberOfMessagePerBatch = messageListenerContainer
+				.getMaxNumberOfMessages() != null
+						? messageListenerContainer.getMaxNumberOfMessages()
+						: AbstractMessageListenerContainer.DEFAULT_MAX_NUMBER_OF_MESSAGES;
+
+		if (spinningThreads > 0) {
+			this.maxPoolSize = spinningThreads * (maxNumberOfMessagePerBatch + 1);
+			this.corePoolSize = spinningThreads * WORKER_THREADS;
+		}
+		this.threadNamePrefix = threadNamePrefix;
+
+		return this;
+	}
+
+	public TaskExecutorBuilder withQueueCapacity(int queueCapacity) {
+		Assert.state(queueCapacity >= 0, "The queue capacity should not be negative");
+		this.queueCapacity = queueCapacity;
+		return this;
+	}
+
+	public TaskExecutorBuilder withSize(int corePoolSize, int maxPoolSize) {
+		Assert.state(corePoolSize >= 1, "The max core size has to be at least one");
+		Assert.state(maxPoolSize >= corePoolSize,
+				"The max pool size must be greater or equals than the core pool size");
+		this.maxPoolSize = maxPoolSize;
+		this.corePoolSize = corePoolSize;
+		return this;
+	}
+
+	public TaskExecutorBuilder withThreadNamePrefix(String threadNamePrefix) {
+		Assert.notNull(threadNamePrefix, "The prefix has not to be null");
+		this.threadNamePrefix = threadNamePrefix;
+		return this;
+	}
+
+	public AsyncTaskExecutor build() {
+		ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+		threadPoolTaskExecutor.setThreadNamePrefix(threadNamePrefix);
+		threadPoolTaskExecutor.setCorePoolSize(corePoolSize);
+		threadPoolTaskExecutor.setMaxPoolSize(maxPoolSize);
+		threadPoolTaskExecutor.setQueueCapacity(queueCapacity);
+		threadPoolTaskExecutor.afterPropertiesSet();
+		return threadPoolTaskExecutor;
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -16,6 +16,19 @@
 
 package org.springframework.cloud.aws.messaging.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,6 +92,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 
 /**
  * @author Agim Emruli
@@ -1465,8 +1482,7 @@ class SimpleMessageListenerContainerTest {
 	private static class TestMessageListenerThatThrowsAnExceptionWithAllExceptOnRedriveDeletionPolicy {
 
 		@SuppressWarnings("UnusedDeclaration")
-		@SqsListener(value = "testQueue",
-				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "testQueue", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void handleMessage(String message) {
 			throw new RuntimeException();
 		}
@@ -1505,8 +1521,7 @@ class SimpleMessageListenerContainerTest {
 		private Visibility visibility;
 
 		@RuntimeUse
-		@SqsListener(value = "testQueue",
-				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "testQueue", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void manualSuccess(String message, Visibility visibility) {
 			this.visibility = visibility;
 			this.countDownLatch.countDown();
@@ -1550,60 +1565,52 @@ class SimpleMessageListenerContainerTest {
 		private final CountDownLatch countdownLatch = new CountDownLatch(8);
 
 		@RuntimeUse
-		@SqsListener(value = "alwaysSuccess",
-				deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
+		@SqsListener(value = "alwaysSuccess", deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
 		private void alwaysSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "alwaysError",
-				deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
+		@SqsListener(value = "alwaysError", deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
 		private void alwaysError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "onSuccessSuccess",
-				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "onSuccessSuccess", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void onSuccessSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "onSuccessError",
-				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "onSuccessError", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void onSuccessError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "noRedriveSuccess",
-				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "noRedriveSuccess", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void noRedriveSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "noRedriveError",
-				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "noRedriveError", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void noRedriveError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "neverSuccess",
-				deletionPolicy = SqsMessageDeletionPolicy.NEVER)
+		@SqsListener(value = "neverSuccess", deletionPolicy = SqsMessageDeletionPolicy.NEVER)
 		private void neverSuccess(String message, Acknowledgment acknowledgment) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "neverError",
-				deletionPolicy = SqsMessageDeletionPolicy.NEVER)
+		@SqsListener(value = "neverError", deletionPolicy = SqsMessageDeletionPolicy.NEVER)
 		private void neverError(String message, Acknowledgment acknowledgment) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -240,6 +240,8 @@ class SimpleMessageListenerContainerTest {
 		assertThat(container.getTaskExecutor()).isEqualTo(taskExecutor);
 	}
 
+
+
 	@Test
 	void testSimpleReceiveMessage() throws Exception {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -16,19 +16,6 @@
 
 package org.springframework.cloud.aws.messaging.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,10 +79,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.MockitoAnnotations.initMocks;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
 
 /**
  * @author Agim Emruli
@@ -1484,7 +1467,8 @@ class SimpleMessageListenerContainerTest {
 	private static class TestMessageListenerThatThrowsAnExceptionWithAllExceptOnRedriveDeletionPolicy {
 
 		@SuppressWarnings("UnusedDeclaration")
-		@SqsListener(value = "testQueue", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "testQueue",
+				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void handleMessage(String message) {
 			throw new RuntimeException();
 		}
@@ -1523,7 +1507,8 @@ class SimpleMessageListenerContainerTest {
 		private Visibility visibility;
 
 		@RuntimeUse
-		@SqsListener(value = "testQueue", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "testQueue",
+				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void manualSuccess(String message, Visibility visibility) {
 			this.visibility = visibility;
 			this.countDownLatch.countDown();
@@ -1567,52 +1552,60 @@ class SimpleMessageListenerContainerTest {
 		private final CountDownLatch countdownLatch = new CountDownLatch(8);
 
 		@RuntimeUse
-		@SqsListener(value = "alwaysSuccess", deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
+		@SqsListener(value = "alwaysSuccess",
+				deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
 		private void alwaysSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "alwaysError", deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
+		@SqsListener(value = "alwaysError",
+				deletionPolicy = SqsMessageDeletionPolicy.ALWAYS)
 		private void alwaysError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "onSuccessSuccess", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "onSuccessSuccess",
+				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void onSuccessSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "onSuccessError", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+		@SqsListener(value = "onSuccessError",
+				deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
 		private void onSuccessError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "noRedriveSuccess", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "noRedriveSuccess",
+				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void noRedriveSuccess(String message) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "noRedriveError", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
+		@SqsListener(value = "noRedriveError",
+				deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
 		private void noRedriveError(String message) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "neverSuccess", deletionPolicy = SqsMessageDeletionPolicy.NEVER)
+		@SqsListener(value = "neverSuccess",
+				deletionPolicy = SqsMessageDeletionPolicy.NEVER)
 		private void neverSuccess(String message, Acknowledgment acknowledgment) {
 			this.countdownLatch.countDown();
 		}
 
 		@RuntimeUse
-		@SqsListener(value = "neverError", deletionPolicy = SqsMessageDeletionPolicy.NEVER)
+		@SqsListener(value = "neverError",
+				deletionPolicy = SqsMessageDeletionPolicy.NEVER)
 		private void neverError(String message, Acknowledgment acknowledgment) {
 			this.countdownLatch.countDown();
 			throw new RuntimeException("BOOM!");

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilderTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilderTest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.aws.messaging.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +25,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Kevin Gath
@@ -69,13 +69,14 @@ public class TaskExecutorBuilderTest {
 
 			assertThat(build).isNotNull();
 		}
+
 	}
 
 	@Nested
 	class withSize {
 
 		@ParameterizedTest
-		@CsvSource({ "-1, 2", "0, 2", "5, 2", "5, 0", "5, -2", })
+		@CsvSource({ "-1, 2", "0, 2", "5, 2", "5, 0", "5, -2" })
 		public void assertionFails(int corePoolSize, int maxPoolSize) {
 			TaskExecutorBuilder builder = new TaskExecutorBuilder();
 
@@ -94,5 +95,7 @@ public class TaskExecutorBuilderTest {
 
 			assertThat(build).isNotNull();
 		}
+
 	}
+
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilderTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/TaskExecutorBuilderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * @author Kevin Gath
+ * @since 1.0
+ */
+public class TaskExecutorBuilderTest {
+
+	@Test
+	public void threadNamePrefix_noDashIsAdded() {
+		TaskExecutorBuilder builder = new TaskExecutorBuilder();
+
+		ThreadPoolTaskExecutor build = (ThreadPoolTaskExecutor) builder
+				.withThreadNamePrefix("testPrefix").build();
+
+		assertThat(build).isNotNull()
+				.matches(b -> b.getThreadNamePrefix().equals("testPrefix"));
+	}
+
+	@Nested
+	class withQueueCapacity {
+
+		@Test
+		public void setNegative_assertionFails() {
+			TaskExecutorBuilder builder = new TaskExecutorBuilder();
+
+			builder.withQueueCapacity(-1);
+
+			Throwable thrown = Assertions.catchThrowable(builder::build);
+
+			assertThat(thrown).isInstanceOf(IllegalStateException.class)
+					.hasMessage("The queue capacity should not be negative");
+		}
+
+		@ParameterizedTest
+		@ValueSource(ints = { 0, 1, 5, 10 })
+		public void isAllowed(int capacity) {
+			TaskExecutorBuilder builder = new TaskExecutorBuilder();
+
+			AsyncTaskExecutor build = builder.withQueueCapacity(capacity).build();
+
+			assertThat(build).isNotNull();
+		}
+	}
+
+	@Nested
+	class withSize {
+
+		@ParameterizedTest
+		@CsvSource({ "-1, 2", "0, 2", "5, 2", "5, 0", "5, -2", })
+		public void assertionFails(int corePoolSize, int maxPoolSize) {
+			TaskExecutorBuilder builder = new TaskExecutorBuilder();
+
+			Throwable thrown = Assertions
+					.catchThrowable(() -> builder.withSize(corePoolSize, maxPoolSize));
+
+			assertThat(thrown).isInstanceOf(IllegalStateException.class);
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "1, 2", "1, 1" })
+		public void isAllowed(int capacity) {
+			TaskExecutorBuilder builder = new TaskExecutorBuilder();
+
+			AsyncTaskExecutor build = builder.withQueueCapacity(capacity).build();
+
+			assertThat(build).isNotNull();
+		}
+	}
+}


### PR DESCRIPTION
The issuer in #542 wanted to manipulate the default properties of TaskExecuter. So it is possible to set a new one with help of a builder class. The logic which was implemented in 
_SimpleMessageListenerContainer_ was moved into this builder class, so the user must not implement it twice.