### PR TITLE
Use default AWS SDK credentials and region providers by default

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -21,9 +21,7 @@
 |cloud.aws.loader.core-pool-size | 1 | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
 |cloud.aws.loader.max-pool-size |  | The maximum pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
 |cloud.aws.loader.queue-capacity |  | The maximum queue capacity for backed up S3 requests. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
-|cloud.aws.region.auto | true | Enables automatic region detection based on the EC2 meta data service.
 |cloud.aws.region.static |  | 
-|cloud.aws.region.use-default-aws-region-chain | false | Whether default AWS SDK region provider chain should be used when auto is set to true.
 |cloud.aws.stack.auto | true | Enables the automatic stack name detection for the application.
 |cloud.aws.stack.name |  | The name of the manually configured stack name that will be used to retrieve the resources.
 

--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -14,11 +14,10 @@
 |aws.secretsmanager.prefix | /secret | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
 |aws.secretsmanager.profile-separator | _ | 
 |cloud.aws.credentials.access-key |  | The access key to be used with a static provider.
-|cloud.aws.credentials.instance-profile | true | Configures an instance profile credentials provider with no further configuration.
+|cloud.aws.credentials.instance-profile | false | Configures an instance profile credentials provider with no further configuration.
 |cloud.aws.credentials.profile-name |  | The AWS profile name.
 |cloud.aws.credentials.profile-path |  | The AWS profile path.
 |cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
-|cloud.aws.credentials.use-default-aws-credentials-chain | true | Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain.
 |cloud.aws.loader.core-pool-size | 1 | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
 |cloud.aws.loader.max-pool-size |  | The maximum pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
 |cloud.aws.loader.queue-capacity |  | The maximum queue capacity for backed up S3 requests. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)

--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -18,7 +18,7 @@
 |cloud.aws.credentials.profile-name |  | The AWS profile name.
 |cloud.aws.credentials.profile-path |  | The AWS profile path.
 |cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
-|cloud.aws.credentials.use-default-aws-credentials-chain | false | Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain.
+|cloud.aws.credentials.use-default-aws-credentials-chain | true | Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain.
 |cloud.aws.loader.core-pool-size | 1 | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
 |cloud.aws.loader.max-pool-size |  | The maximum pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
 |cloud.aws.loader.queue-capacity |  | The maximum queue capacity for backed up S3 requests. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -305,14 +305,17 @@ only configure classes that are available in the Spring Boot application's class
 ===== Configuring credentials
 Spring Boot provides a standard way to define properties with property file or YAML configuration files. Spring Cloud
 AWS provides support to configure the credential information with the Spring Boot application configuration files.
-Spring Cloud AWS provides the following properties to configure the credentials setup for the whole application.
 
-Unless `cloud.aws.credentials.use-default-aws-credentials-chain` is set to `true`, Spring Cloud AWS configures following
+By default Spring Cloud AWS configures https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html[DefaultAWSCredentialsProviderChain] to resolve AWS credentials.
+
+If `cloud.aws.credentials.use-default-aws-credentials-chain` is set to `false`, Spring Cloud AWS configures following
 credentials chain:
 
 1. `AWSStaticCredentialsProvider` if `cloud.aws.credentials.access-key` is provided
 2. `EC2ContainerCredentialsProviderWrapper` unless `cloud.aws.credentials.instance-profile` is set to `false`
 3. `ProfileCredentialsProvider`
+
+Spring Cloud AWS provides the following properties to configure the credentials setup for the whole application.
 
 [cols="3*", options="header"]
 |===

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -308,12 +308,11 @@ AWS provides support to configure the credential information with the Spring Boo
 
 By default Spring Cloud AWS configures https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html[DefaultAWSCredentialsProviderChain] to resolve AWS credentials.
 
-If `cloud.aws.credentials.use-default-aws-credentials-chain` is set to `false`, Spring Cloud AWS configures following
-credentials chain:
+If other credentials providers are configured, https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html[DefaultAWSCredentialsProviderChain] is not used and Spring Cloud AWS configures following credentials chain:
 
 1. `AWSStaticCredentialsProvider` if `cloud.aws.credentials.access-key` is provided
-2. `EC2ContainerCredentialsProviderWrapper` unless `cloud.aws.credentials.instance-profile` is set to `false`
-3. `ProfileCredentialsProvider`
+2. `EC2ContainerCredentialsProviderWrapper` if `cloud.aws.credentials.instance-profile` is set to `true`
+3. `ProfileCredentialsProvider` if `cloud.aws.credentials.profile-name` is provided
 
 Spring Cloud AWS provides the following properties to configure the credentials setup for the whole application.
 
@@ -342,15 +341,11 @@ Spring Cloud AWS provides the following properties to configure the credentials 
 |cloud.aws.credentials.profile-path
 |`~/.aws/credentials`
 |The file path where the profile configuration file is located. Defaults to `~/.aws/credentials` if value is not provided
-
-|cloud.aws.credentials.use-default-aws-credentials-chain
-|true
-|Use the DefaultAWSCredentials Chain instead of configuring a custom credentials chain
 |===
 
 ===== Configuring region
 Like for the credentials, the Spring Cloud AWS module also supports the configuration of the region inside the Spring
-Boot configuration files. The region can be automatically detected or explicitly configured (e.g. in case of local tests
+Boot configuration files. The region can be automatically detected using https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/regions/DefaultAwsRegionProviderChain.html[DefaultAwsRegionProviderChain] or explicitly configured (e.g. in case of local tests
 against the AWS cloud).
 
 The properties to configure the region are shown below
@@ -360,14 +355,6 @@ The properties to configure the region are shown below
 |property
 |example
 |description
-
-|cloud.aws.region.auto
-|true
-|Enables automatic region detection based on the EC2 meta data service
-
-|cloud.aws.region.use-default-aws-region-chain
-|true
-|Use the DefaultAWSRegion Chain instead of configuring a custom region chain
 
 |cloud.aws.region.static
 |eu-west-1

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -16,20 +16,17 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.aws.autoconfigure.context.properties.AwsRegionProperties;
-import org.springframework.context.EnvironmentAware;
+import org.springframework.cloud.aws.core.region.DefaultAwsRegionProviderChainDelegate;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.env.Environment;
-import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
-import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerRegionProvider;
 
 /**
  * Region auto configuration, based on <a
@@ -38,58 +35,21 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
  *
  * @author Agim Emruli
  * @author Petromir Dzhunev
+ * @author Maciej Walkowiak
  */
 @Configuration(proxyBeanMethods = false)
-@Import(ContextRegionProviderAutoConfiguration.Registrar.class)
+@EnableConfigurationProperties(AwsRegionProperties.class)
 public class ContextRegionProviderAutoConfiguration {
 
-	/**
-	 * The prefix used for AWS region related properties.
-	 */
-	public static final String AWS_REGION_PROPERTIES_PREFIX = "cloud.aws.region";
-
-	/**
-	 * Bind AWS region related properties to a property instance.
-	 * @return An {@link AwsRegionProperties} instance
-	 */
-	@Bean
-	@ConfigurationProperties(prefix = AWS_REGION_PROPERTIES_PREFIX)
-	public AwsRegionProperties awsRegionProperties() {
-		return new AwsRegionProperties();
-	}
-
-	static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
-
-		private Environment environment;
-
-		@Override
-		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
-				BeanDefinitionRegistry registry) {
-			// Do not register region provider if already existing
-			if (registry.containsBeanDefinition(REGION_PROVIDER_BEAN_NAME)) {
-				return;
-			}
-
-			boolean useDefaultRegionChain = this.environment.getProperty(
-					AWS_REGION_PROPERTIES_PREFIX + ".use-default-aws-region-chain",
-					Boolean.class, false);
-
-			String staticRegion = this.environment
-					.getProperty(AWS_REGION_PROPERTIES_PREFIX + ".static");
-
-			boolean autoDetect = this.environment.getProperty(
-					AWS_REGION_PROPERTIES_PREFIX + ".auto", Boolean.class, true)
-					&& !StringUtils.hasText(staticRegion);
-
-			registerRegionProvider(registry, autoDetect, useDefaultRegionChain,
-					staticRegion);
+	@ConditionalOnMissingBean(name = REGION_PROVIDER_BEAN_NAME)
+	@Bean(name = REGION_PROVIDER_BEAN_NAME)
+	RegionProvider regionProvider(AwsRegionProperties properties) {
+		if (StringUtils.hasText(properties.getStatic())) {
+			return new StaticRegionProvider(properties.getStatic());
 		}
-
-		@Override
-		public void setEnvironment(Environment environment) {
-			this.environment = environment;
+		else {
+			return new DefaultAwsRegionProviderChainDelegate();
 		}
-
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
 
 import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 /**
  * Properties related to AWS credentials.
  *
@@ -25,6 +27,7 @@ import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
  * @since 2.0.2
  * @see org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration
  */
+@ConfigurationProperties(prefix = "cloud.aws.credentials")
 public class AwsCredentialsProperties {
 
 	/**
@@ -46,7 +49,7 @@ public class AwsCredentialsProperties {
 	 * Use the DefaultAWSCredentials Chain instead of configuring a custom credentials
 	 * chain.
 	 */
-	private boolean useDefaultAwsCredentialsChain;
+	private boolean useDefaultAwsCredentialsChain = true;
 
 	/**
 	 * The AWS profile name.

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsProperties.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
-import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -43,18 +41,12 @@ public class AwsCredentialsProperties {
 	/**
 	 * Configures an instance profile credentials provider with no further configuration.
 	 */
-	private boolean instanceProfile = true;
-
-	/**
-	 * Use the DefaultAWSCredentials Chain instead of configuring a custom credentials
-	 * chain.
-	 */
-	private boolean useDefaultAwsCredentialsChain = true;
+	private boolean instanceProfile = false;
 
 	/**
 	 * The AWS profile name.
 	 */
-	private String profileName = AwsProfileNameLoader.DEFAULT_PROFILE_NAME;
+	private String profileName;
 
 	/**
 	 * The AWS profile path.
@@ -83,14 +75,6 @@ public class AwsCredentialsProperties {
 
 	public void setInstanceProfile(boolean instanceProfile) {
 		this.instanceProfile = instanceProfile;
-	}
-
-	public boolean isUseDefaultAwsCredentialsChain() {
-		return this.useDefaultAwsCredentialsChain;
-	}
-
-	public void setUseDefaultAwsCredentialsChain(boolean useDefaultAwsCredentialsChain) {
-		this.useDefaultAwsCredentialsChain = useDefaultAwsCredentialsChain;
 	}
 
 	public String getProfileName() {

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.aws.autoconfigure.context.properties;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 /**
  * Properties related to AWS region configuration.
  *
@@ -24,18 +26,8 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
  * @since 2.0.2
  * @see org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration
  */
+@ConfigurationProperties(prefix = "cloud.aws.region")
 public class AwsRegionProperties {
-
-	/**
-	 * Enables automatic region detection based on the EC2 meta data service.
-	 */
-	private boolean auto = true;
-
-	/**
-	 * Whether default AWS SDK region provider chain should be used when auto is set to
-	 * true.
-	 */
-	private boolean useDefaultAwsRegionChain;
 
 	/**
 	 * Configures a static region for the application. Possible regions are (currently)
@@ -44,14 +36,6 @@ public class AwsRegionProperties {
 	 * configured with own region meta data.
 	 */
 	private String staticRegion;
-
-	public boolean isAuto() {
-		return this.auto;
-	}
-
-	public void setAuto(boolean auto) {
-		this.auto = auto;
-	}
 
 	public String getStatic() {
 		return this.staticRegion;
@@ -65,14 +49,6 @@ public class AwsRegionProperties {
 		// creating a bean definition. Leaving for now.
 		// - tgianos 11/26/2018
 		this.staticRegion = staticRegion;
-	}
-
-	public boolean isUseDefaultAwsRegionChain() {
-		return useDefaultAwsRegionChain;
-	}
-
-	public void setUseDefaultAwsRegionChain(boolean useDefaultAwsRegionChain) {
-		this.useDefaultAwsRegionChain = useDefaultAwsRegionChain;
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -26,372 +26,165 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import org.apache.http.client.CredentialsProvider;
-import org.junit.After;
 import org.junit.Test;
 
-import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Tests for {@link ContextCredentialsAutoConfiguration}.
+ *
  * @author Agim Emruli
+ * @author Maciej Walkowiak
  */
 public class ContextCredentialsAutoConfigurationTest {
 
-	private AnnotationConfigApplicationContext context;
-
-	@After
-	public void tearDown() throws Exception {
-		if (this.context != null) {
-			this.context.close();
-		}
-	}
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(ContextCredentialsAutoConfiguration.class));
 
 	// @checkstyle:off
 	@Test
-	public void credentialsProvider_noExplicitCredentialsProviderConfigured_configuresDefaultAwsCredentialsProviderChainWithInstanceProfile()
-			throws Exception {
+	public void credentialsProvider_noExplicitCredentialsProviderConfigured_configuresDefaultAwsCredentialsProviderChain() {
 		// @checkstyle:on
-		// Arrange
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
+		this.contextRunner.run((context) -> {
+			AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+					AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+					AWSCredentialsProvider.class);
+			assertThat(awsCredentialsProvider).isNotNull()
+					.isInstanceOf(DefaultAWSCredentialsProviderChain.class);
+		});
 
-		// Act
-		this.context.refresh();
-
-		// Assert
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-	}
-
-	// @checkstyle:off
-	@Test
-	public void credentialsProvider_propertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider_existAccessKeyAndSecretKey() {
-		// @checkstyle:on
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues
-				.of("cloud.aws.credentials.accessKey:testAccessKey",
-						"cloud.aws.credentials.secretKey:testSecretKey",
-						"cloud.aws.credentials.useDefaultAwsCredentialsChain:true")
-				.applyTo(this.context);
-		this.context.refresh();
-
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("testAccessKey");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
-				.isEqualTo("testSecretKey");
-	}
-
-	@Test
-	public void credentialsProvider_dashSeparatedPropertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider_existAccessKeyAndSecretKey() {
-		// @checkstyle:on
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues
-				.of("cloud.aws.credentials.access-key:testAccessKey",
-						"cloud.aws.credentials.secret-key:testSecretKey",
-						"cloud.aws.credentials.use-default-aws-credentials-chain:true")
-				.applyTo(this.context);
-		this.context.refresh();
-
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("testAccessKey");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
-				.isEqualTo("testSecretKey");
 	}
 
 	@Test
 	public void credentialsProvider_propertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.useDefaultAwsCredentialsChain:true")
-				.applyTo(this.context);
-		this.context.refresh();
+		this.contextRunner
+				.withPropertyValues(
+						"cloud.aws.credentials.use-default-aws-credentials-chain:true")
+				.run((context -> {
+					AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+							AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+							AWSCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
 
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		assertThat(awsCredentialsProvider.getClass()
-				.isAssignableFrom(DefaultAWSCredentialsProviderChain.class)).isTrue();
-	}
-
-	@Test
-	public void credentialsProvider_dashSeparatedPropertyToUseDefaultIsSet_configuresDefaultAwsCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues
-				.of("cloud.aws.credentials.use-default-aws-credentials-chain:true")
-				.applyTo(this.context);
-		this.context.refresh();
-
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		assertThat(awsCredentialsProvider.getClass()
-				.isAssignableFrom(DefaultAWSCredentialsProviderChain.class)).isTrue();
+					assertThat(awsCredentialsProvider)
+							.isInstanceOf(DefaultAWSCredentialsProviderChain.class);
+				}));
 	}
 
 	// @checkstyle:off
 	@Test
 	public void credentialsProvider_accessKeyAndSecretKeyConfigured_configuresStaticCredentialsProviderWithAccessAndSecretKey() {
 		// @checkstyle:on
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.accessKey:foo",
-				"cloud.aws.credentials.secretKey:bar").applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProviderChain.class);
-		assertThat(awsCredentialsProvider).isNotNull();
+		this.contextRunner.withPropertyValues(
+				"cloud.aws.credentials.use-default-aws-credentials-chain:false",
+				"cloud.aws.credentials.accessKey:foo",
+				"cloud.aws.credentials.secretKey:bar").run((context) -> {
+					AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+							AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+							AWSCredentialsProviderChain.class);
+					assertThat(awsCredentialsProvider).isNotNull();
+					assertThat(
+							awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
+									.isEqualTo("foo");
+					assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
+							.isEqualTo("bar");
 
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("foo");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
-				.isEqualTo("bar");
-
-	}
-
-	// @checkstyle:off
-	@Test
-	public void credentialsProvider_dashSeparatedAccessKeyAndSecretKeyConfigured_configuresStaticCredentialsProviderWithAccessAndSecretKey() {
-		// @checkstyle:on
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.access-key:foo",
-				"cloud.aws.credentials.secret-key:bar").applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProviderChain.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(AWSStaticCredentialsProvider.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-
-		assertThat(awsCredentialsProvider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("foo");
-		assertThat(awsCredentialsProvider.getCredentials().getAWSSecretKey())
-				.isEqualTo("bar");
-
+					@SuppressWarnings("unchecked")
+					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(3);
+					assertThat(credentialsProviders.get(0))
+							.isInstanceOf(AWSStaticCredentialsProvider.class);
+					assertThat(credentialsProviders.get(1))
+							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
+					assertThat(credentialsProviders.get(2))
+							.isInstanceOf(ProfileCredentialsProvider.class);
+				});
 	}
 
 	@Test
 	public void credentialsProvider_instanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.instanceProfile")
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
+		this.contextRunner.withPropertyValues(
+				"cloud.aws.credentials.use-default-aws-credentials-chain:false",
+				"cloud.aws.credentials.instance-profile:true").run((context) -> {
+					AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+							AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+							AWSCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
 
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-	}
-
-	@Test
-	public void credentialsProvider_dashSeparatedInstanceProfileConfigured_configuresInstanceProfileCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.instance-profile")
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
+					@SuppressWarnings("unchecked")
+					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(2);
+					assertThat(credentialsProviders.get(0))
+							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
+					assertThat(credentialsProviders.get(1))
+							.isInstanceOf(ProfileCredentialsProvider.class);
+				});
 	}
 
 	@Test
 	public void credentialsProvider_profileNameConfigured_configuresProfileCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.profileName:test")
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
+		this.contextRunner.withPropertyValues(
+				"cloud.aws.credentials.use-default-aws-credentials-chain:false",
+				"cloud.aws.credentials.profile-name:test").run((context) -> {
+					AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+							AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+							AWSCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
 
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-
-		assertThat(
-				ReflectionTestUtils.getField(credentialsProviders.get(1), "profileName"))
-						.isEqualTo("test");
-	}
-
-	@Test
-	public void credentialsProvider_dashSeparatedProfileNameConfigured_configuresProfileCredentialsProvider() {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues.of("cloud.aws.credentials.profile-name:test")
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-
-		assertThat(
-				ReflectionTestUtils.getField(credentialsProviders.get(1), "profileName"))
-						.isEqualTo("test");
+					@SuppressWarnings("unchecked")
+					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(2);
+					assertThat(credentialsProviders.get(0))
+							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
+					assertThat(credentialsProviders.get(1))
+							.isInstanceOf(ProfileCredentialsProvider.class);
+					assertThat(ReflectionTestUtils.getField(credentialsProviders.get(1),
+							"profileName")).isEqualTo("test");
+				});
 	}
 
 	@Test
 	public void credentialsProvider_profileNameAndPathConfigured_configuresProfileCredentialsProvider()
 			throws IOException {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues
-				.of("cloud.aws.credentials.profileName:customProfile",
+		this.contextRunner
+				.withPropertyValues(
+						"cloud.aws.credentials.use-default-aws-credentials-chain:false",
+						"cloud.aws.credentials.profileName:customProfile",
 						"cloud.aws.credentials.profilePath:" + new ClassPathResource(
 								getClass().getSimpleName() + "-profile", getClass())
 										.getFile().getAbsolutePath())
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
+				.run((context) -> {
+					AWSCredentialsProvider awsCredentialsProvider = context.getBean(
+							AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
+							AWSCredentialsProvider.class);
+					assertThat(awsCredentialsProvider).isNotNull();
 
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
+					@SuppressWarnings("unchecked")
+					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+							.getField(awsCredentialsProvider, "credentialsProviders");
+					assertThat(credentialsProviders).hasSize(2);
+					assertThat(credentialsProviders.get(0))
+							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
+					assertThat(credentialsProviders.get(1))
+							.isInstanceOf(ProfileCredentialsProvider.class);
 
-		ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
-				.get(1);
-		assertThat(provider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("testAccessKey");
-		assertThat(provider.getCredentials().getAWSSecretKey())
-				.isEqualTo("testSecretKey");
-	}
-
-	@Test
-	public void credentialsProvider_dashSeparatedProfileNameAndPathConfigured_configuresProfileCredentialsProvider()
-			throws IOException {
-		this.context = new AnnotationConfigApplicationContext();
-		this.context.register(ContextCredentialsAutoConfiguration.class);
-		TestPropertyValues
-				.of("cloud.aws.credentials.profile-name:customProfile",
-						"cloud.aws.credentials.profile-path:" + new ClassPathResource(
-								getClass().getSimpleName() + "-profile", getClass())
-										.getFile().getAbsolutePath())
-				.applyTo(this.context);
-		this.context.refresh();
-		AWSCredentialsProvider awsCredentialsProvider = this.context.getBean(
-				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME,
-				AWSCredentialsProvider.class);
-		assertThat(awsCredentialsProvider).isNotNull();
-
-		@SuppressWarnings("unchecked")
-		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
-				.getField(awsCredentialsProvider, "credentialsProviders");
-		assertThat(credentialsProviders.size()).isEqualTo(2);
-		assertThat(EC2ContainerCredentialsProviderWrapper.class
-				.isInstance(credentialsProviders.get(0))).isTrue();
-		assertThat(
-				ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(1)))
-						.isTrue();
-
-		ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
-				.get(1);
-		assertThat(provider.getCredentials().getAWSAccessKeyId())
-				.isEqualTo("testAccessKey");
-		assertThat(provider.getCredentials().getAWSSecretKey())
-				.isEqualTo("testSecretKey");
+					ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
+							.get(1);
+					assertThat(provider.getCredentials().getAWSAccessKeyId())
+							.isEqualTo("testAccessKey");
+					assertThat(provider.getCredentials().getAWSSecretKey())
+							.isEqualTo("testSecretKey");
+				});
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextCredentialsAutoConfigurationTest.java
@@ -99,13 +99,8 @@ public class ContextCredentialsAutoConfigurationTest {
 					@SuppressWarnings("unchecked")
 					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
 							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(3);
-					assertThat(credentialsProviders.get(0))
-							.isInstanceOf(AWSStaticCredentialsProvider.class);
-					assertThat(credentialsProviders.get(1))
-							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
-					assertThat(credentialsProviders.get(2))
-							.isInstanceOf(ProfileCredentialsProvider.class);
+					assertThat(credentialsProviders).hasSize(1)
+							.hasOnlyElementsOfType(AWSStaticCredentialsProvider.class);
 				});
 	}
 
@@ -122,11 +117,8 @@ public class ContextCredentialsAutoConfigurationTest {
 					@SuppressWarnings("unchecked")
 					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
 							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(2);
-					assertThat(credentialsProviders.get(0))
-							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
-					assertThat(credentialsProviders.get(1))
-							.isInstanceOf(ProfileCredentialsProvider.class);
+					assertThat(credentialsProviders).hasSize(1).hasOnlyElementsOfType(
+							EC2ContainerCredentialsProviderWrapper.class);
 				});
 	}
 
@@ -143,12 +135,9 @@ public class ContextCredentialsAutoConfigurationTest {
 					@SuppressWarnings("unchecked")
 					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
 							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(2);
-					assertThat(credentialsProviders.get(0))
-							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
-					assertThat(credentialsProviders.get(1))
-							.isInstanceOf(ProfileCredentialsProvider.class);
-					assertThat(ReflectionTestUtils.getField(credentialsProviders.get(1),
+					assertThat(credentialsProviders).hasSize(1)
+							.hasOnlyElementsOfType(ProfileCredentialsProvider.class);
+					assertThat(ReflectionTestUtils.getField(credentialsProviders.get(0),
 							"profileName")).isEqualTo("test");
 				});
 	}
@@ -172,14 +161,11 @@ public class ContextCredentialsAutoConfigurationTest {
 					@SuppressWarnings("unchecked")
 					List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
 							.getField(awsCredentialsProvider, "credentialsProviders");
-					assertThat(credentialsProviders).hasSize(2);
-					assertThat(credentialsProviders.get(0))
-							.isInstanceOf(EC2ContainerCredentialsProviderWrapper.class);
-					assertThat(credentialsProviders.get(1))
-							.isInstanceOf(ProfileCredentialsProvider.class);
+					assertThat(credentialsProviders).hasSize(1)
+							.hasOnlyElementsOfType(ProfileCredentialsProvider.class);
 
 					ProfileCredentialsProvider provider = (ProfileCredentialsProvider) credentialsProviders
-							.get(1);
+							.get(0);
 					assertThat(provider.getCredentials().getAWSAccessKeyId())
 							.isEqualTo("testAccessKey");
 					assertThat(provider.getCredentials().getAWSSecretKey())

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.aws.autoconfigure.context.properties;
 
 import java.util.UUID;
 
-import com.amazonaws.auth.profile.internal.AwsProfileNameLoader;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link AwsCredentialsProperties}.
  *
  * @author Tom Gianos
+ * @author Maciej Walkowiak
  * @since 2.0.2
  */
 public class AwsCredentialsPropertiesTest {
@@ -64,28 +64,17 @@ public class AwsCredentialsPropertiesTest {
 	@Test
 	public void instanceProfileCanBeSet() {
 		assertThat(this.properties.isInstanceProfile())
-				.as("Instance profile default expected to be true").isTrue();
+				.as("Instance profile default expected to be false").isFalse();
 
-		this.properties.setInstanceProfile(false);
+		this.properties.setInstanceProfile(true);
 		assertThat(this.properties.isInstanceProfile())
-				.as("Instance profile should have been assigned").isFalse();
-	}
-
-	@Test
-	public void useDefaultAwsCredentialsChainCanBeSet() {
-		assertThat(this.properties.isUseDefaultAwsCredentialsChain())
-				.as("useDefaultAwsCredentialsChain default expected to be true").isTrue();
-
-		this.properties.setUseDefaultAwsCredentialsChain(false);
-		assertThat(this.properties.isUseDefaultAwsCredentialsChain())
-				.as("useDefaultAwsCredentialsChain should have been assigned").isFalse();
+				.as("Instance profile should have been assigned").isTrue();
 	}
 
 	@Test
 	public void profileNameCanBeSet() {
 		assertThat(this.properties.getProfileName())
-				.as("Default profile name expected to be set")
-				.isEqualTo(AwsProfileNameLoader.DEFAULT_PROFILE_NAME);
+				.as("Default profile name is not expected to be set").isEqualTo(null);
 
 		String newProfileName = UUID.randomUUID().toString();
 		this.properties.setProfileName(newProfileName);

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsCredentialsPropertiesTest.java
@@ -74,12 +74,11 @@ public class AwsCredentialsPropertiesTest {
 	@Test
 	public void useDefaultAwsCredentialsChainCanBeSet() {
 		assertThat(this.properties.isUseDefaultAwsCredentialsChain())
-				.as("useDefaultAwsCredentialsChain default expected to be false")
-				.isFalse();
+				.as("useDefaultAwsCredentialsChain default expected to be true").isTrue();
 
-		this.properties.setUseDefaultAwsCredentialsChain(true);
+		this.properties.setUseDefaultAwsCredentialsChain(false);
 		assertThat(this.properties.isUseDefaultAwsCredentialsChain())
-				.as("useDefaultAwsCredentialsChain should have been assigned").isTrue();
+				.as("useDefaultAwsCredentialsChain should have been assigned").isFalse();
 	}
 
 	@Test

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/properties/AwsRegionPropertiesTest.java
@@ -38,16 +38,6 @@ public class AwsRegionPropertiesTest {
 	}
 
 	@Test
-	public void autoCanBeSet() {
-		assertThat(this.properties.isAuto()).as("Default value of auto should be true")
-				.isTrue();
-
-		this.properties.setAuto(false);
-		assertThat(this.properties.isAuto())
-				.as("Auto should have been reassigned as false").isFalse();
-	}
-
-	@Test
 	public void staticRegionCanBeSet() {
 		assertThat(this.properties.getStatic())
 				.as("Static region value should have default of null").isNull();

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.aws.context.config.support;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
@@ -86,17 +85,6 @@ public final class ContextConfigurationUtils {
 				registry);
 		AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider(registry,
 				REGION_PROVIDER_BEAN_NAME);
-	}
-
-	public static void registerDefaultAWSCredentialsProvider(
-			BeanDefinitionRegistry registry) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.rootBeanDefinition(DefaultAWSCredentialsProviderChain.class);
-		registry.registerBeanDefinition(
-				CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME,
-				builder.getBeanDefinition());
-		AmazonWebserviceClientConfigurationUtils.replaceDefaultCredentialsProvider(
-				registry, CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME);
 	}
 
 	public static void registerCredentialsProvider(BeanDefinitionRegistry registry,


### PR DESCRIPTION
Unless other credentials provider configured, Spring Cloud AWS will use now default AWS region chain. Similar in region auto-configuration.

If user decides to opt-out from defaults, all credentials provider have to be now explicitly configured, there are no default values that I believe makes it easier to reason about what is happening under the hood.