### PR TITLE
2.2.x - Map "SentTimestamp" to SqsMessageHeaders #296  

### DIFF
--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.aws.messaging;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.cloud.aws.messaging.core.SqsMessageHeaders;
 import org.springframework.cloud.aws.messaging.listener.Acknowledgment;
 import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
@@ -42,10 +47,6 @@ import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Agim Emruli
@@ -85,6 +86,10 @@ public abstract class QueueListenerTest extends AbstractContainerTest {
 		// Assert
 		assertTrue(this.messageListener.getCountDownLatch().await(15, TimeUnit.SECONDS));
 		assertEquals("Hello world!", this.messageListener.getReceivedMessages().get(0));
+		assertEquals(1, this.messageListener.getApproximateReceiveCount().longValue());
+		assertNotNull(this.messageListener.getApproximateFirstReceiveTimestamp());
+		assertNotNull(this.messageListener.getSentTimestamp());
+		assertNotNull(this.messageListener.getTimestamp());
 	}
 
 	@Test
@@ -183,17 +188,30 @@ public abstract class QueueListenerTest extends AbstractContainerTest {
 
 		private String senderId;
 
+		private Long timestamp;
+
+		private Long sentTimestamp;
+
+		private Long approximateFirstReceiveTimestamp;
+
+		private Long approximateReceiveCount;
+
 		private Map<String, Object> allHeaders;
 
 		@RuntimeUse
 		@SqsListener("QueueListenerTest")
 		public void receiveMessage(String message,
 				@Header(value = "SenderId", required = false) String senderId,
-				@Headers Map<String, Object> allHeaders) {
+				@Headers Map<String, Object> allHeaders, SqsMessageHeaders asSqsHeaders) {
 			LOGGER.debug("Received message with content {}", message);
 			this.receivedMessages.add(message);
 			this.senderId = senderId;
 			this.allHeaders = allHeaders;
+			this.approximateReceiveCount = asSqsHeaders.getApproximateReceiveCount();
+			this.approximateFirstReceiveTimestamp = asSqsHeaders
+					.getApproximateFirstReceiveTimestamp();
+			this.timestamp = asSqsHeaders.getSentTimestamp();
+			this.sentTimestamp = asSqsHeaders.getSentTimestamp();
 			this.getCountDownLatch().countDown();
 		}
 
@@ -211,6 +229,22 @@ public abstract class QueueListenerTest extends AbstractContainerTest {
 
 		public String getSenderId() {
 			return this.senderId;
+		}
+
+		public Long getTimestamp() {
+			return timestamp;
+		}
+
+		public Long getSentTimestamp() {
+			return sentTimestamp;
+		}
+
+		public Long getApproximateFirstReceiveTimestamp() {
+			return approximateFirstReceiveTimestamp;
+		}
+
+		public Long getApproximateReceiveCount() {
+			return approximateReceiveCount;
 		}
 
 		public Map<String, Object> getAllHeaders() {

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/messaging/QueueListenerTest.java
@@ -90,6 +90,7 @@ public abstract class QueueListenerTest extends AbstractContainerTest {
 		assertNotNull(this.messageListener.getApproximateFirstReceiveTimestamp());
 		assertNotNull(this.messageListener.getSentTimestamp());
 		assertNotNull(this.messageListener.getTimestamp());
+		assertEquals(this.messageListener.getTimestamp(), this.messageListener.getSentTimestamp());
 	}
 
 	@Test
@@ -210,7 +211,7 @@ public abstract class QueueListenerTest extends AbstractContainerTest {
 			this.approximateReceiveCount = asSqsHeaders.getApproximateReceiveCount();
 			this.approximateFirstReceiveTimestamp = asSqsHeaders
 					.getApproximateFirstReceiveTimestamp();
-			this.timestamp = asSqsHeaders.getSentTimestamp();
+			this.timestamp = asSqsHeaders.getTimestamp();
 			this.sentTimestamp = asSqsHeaders.getSentTimestamp();
 			this.getCountDownLatch().countDown();
 		}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,14 +65,6 @@ public class SqsMessageHeaders extends MessageHeaders {
 
 	public SqsMessageHeaders(Map<String, Object> headers) {
 		super(headers, getId(headers), getTimestamp(headers));
-	}
-
-	public static SqsMessageHeaders createFrom(SqsMessageHeaders other,
-			Map<String, Object> newHeaders) {
-		for (String key : newHeaders.keySet()) {
-			other.getRawHeaders().put(key, newHeaders.get(key));
-		}
-		return other;
 	}
 
 	public Long getApproximateFirstReceiveTimestamp() {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -63,21 +63,23 @@ public class SqsMessageHeaders extends MessageHeaders {
 	 */
 	public static final String SQS_SENT_TIMESTAMP = "SentTimestamp";
 
-
 	public SqsMessageHeaders(Map<String, Object> headers) {
 		super(headers, getId(headers), getTimestamp(headers));
 	}
 
-	public static SqsMessageHeaders createFrom(SqsMessageHeaders other, Map<String,Object> newHeaders) {
-		for (String key : newHeaders.keySet())  {
+	public static SqsMessageHeaders createFrom(SqsMessageHeaders other,
+			Map<String, Object> newHeaders) {
+		for (String key : newHeaders.keySet()) {
 			other.getRawHeaders().put(key, newHeaders.get(key));
 		}
 		return other;
 	}
 
 	public Long getApproximateFirstReceiveTimestamp() {
-		return containsKey(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP) ? Long.parseLong(Objects
-			.requireNonNull(get(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class))) : null;
+		return containsKey(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP)
+				? Long.parseLong(Objects.requireNonNull(
+						get(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class)))
+				: null;
 	}
 
 	public Long getSentTimestamp() {
@@ -85,17 +87,21 @@ public class SqsMessageHeaders extends MessageHeaders {
 	}
 
 	public Long getApproximateReceiveCount() {
-		return containsKey(SQS_APPROXIMATE_RECEIVE_COUNT) ? Long.parseLong(Objects
-			.requireNonNull(get(SQS_APPROXIMATE_RECEIVE_COUNT, String.class))) : null;
+		return containsKey(SQS_APPROXIMATE_RECEIVE_COUNT)
+				? Long.parseLong(Objects
+						.requireNonNull(get(SQS_APPROXIMATE_RECEIVE_COUNT, String.class)))
+				: null;
 	}
 
 	private static Long getTimestamp(Map<String, Object> headers) {
-		return headers.containsKey(SQS_SENT_TIMESTAMP) ? Long.parseLong(Objects
-			.requireNonNull((String) headers.get(SQS_SENT_TIMESTAMP))) : null;
+		return headers.containsKey(SQS_SENT_TIMESTAMP)
+				? Long.parseLong(
+						Objects.requireNonNull((String) headers.get(SQS_SENT_TIMESTAMP)))
+				: null;
 	}
 
 	private static UUID getId(Map<String, Object> headers) {
-		return headers.containsKey(ID) ?  (UUID)headers.get(ID) : null;
+		return headers.containsKey(ID) ? (UUID) headers.get(ID) : null;
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/SqsMessageHeaders.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.aws.messaging.core;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 import org.springframework.messaging.MessageHeaders;
 
@@ -26,6 +28,7 @@ import org.springframework.messaging.MessageHeaders;
  * consumer side for traceability.
  *
  * @author Alain Sahli
+ * @author Wojciech Mąka
  * @since 1.0
  */
 public class SqsMessageHeaders extends MessageHeaders {
@@ -45,12 +48,54 @@ public class SqsMessageHeaders extends MessageHeaders {
 	 */
 	public static final String SQS_DEDUPLICATION_ID_HEADER = "message-deduplication-id";
 
-	public SqsMessageHeaders(Map<String, Object> headers) {
-		super(headers);
+	/**
+	 * ApproximateFirstReceiveTimestamp header in a SQS message.
+	 */
+	public static final String SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP = "ApproximateFirstReceiveTimestamp";
 
-		if (headers.containsKey(ID)) {
-			this.getRawHeaders().put(ID, headers.get(ID));
+	/**
+	 * ApproximateReceiveCount header in a SQS message.
+	 */
+	public static final String SQS_APPROXIMATE_RECEIVE_COUNT = "ApproximateReceiveCount";
+
+	/**
+	 * SentTimestamp header in a SQS message.
+	 */
+	public static final String SQS_SENT_TIMESTAMP = "SentTimestamp";
+
+
+	public SqsMessageHeaders(Map<String, Object> headers) {
+		super(headers, getId(headers), getTimestamp(headers));
+	}
+
+	public static SqsMessageHeaders createFrom(SqsMessageHeaders other, Map<String,Object> newHeaders) {
+		for (String key : newHeaders.keySet())  {
+			other.getRawHeaders().put(key, newHeaders.get(key));
 		}
+		return other;
+	}
+
+	public Long getApproximateFirstReceiveTimestamp() {
+		return containsKey(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP) ? Long.parseLong(Objects
+			.requireNonNull(get(SQS_APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, String.class))) : null;
+	}
+
+	public Long getSentTimestamp() {
+		return getTimestamp(getRawHeaders());
+	}
+
+	public Long getApproximateReceiveCount() {
+		return containsKey(SQS_APPROXIMATE_RECEIVE_COUNT) ? Long.parseLong(Objects
+			.requireNonNull(get(SQS_APPROXIMATE_RECEIVE_COUNT, String.class))) : null;
+	}
+
+	private static Long getTimestamp(Map<String, Object> headers) {
+		return headers.containsKey(SQS_SENT_TIMESTAMP) ? Long.parseLong(Objects
+			.requireNonNull((String) headers.get(SQS_SENT_TIMESTAMP))) : null;
+	}
+
+	private static UUID getId(Map<String, Object> headers) {
+		return headers.containsKey(ID) ?  (UUID)headers.get(ID) : null;
 	}
 
 }

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -21,17 +21,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.cloud.aws.messaging.core.SqsMessageHeaders;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
 import org.springframework.cloud.aws.messaging.listener.support.AcknowledgmentHandlerMethodArgumentResolver;
 import org.springframework.cloud.aws.messaging.listener.support.VisibilityHandlerMethodArgumentResolver;
@@ -56,7 +53,6 @@ import org.springframework.messaging.handler.invocation.AbstractMethodMessageHan
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.HandlerMethodReturnValueHandler;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.comparator.ComparableComparator;
 import org.springframework.validation.Errors;
@@ -108,19 +104,6 @@ public class QueueMessageHandler
 				new NoOpValidator()));
 
 		return resolvers;
-	}
-
-	public void handleSqsMessage(Message<?> message) throws MessagingException {
-		String destination = getDestination(message);
-		if (destination != null) {
-			String lookupDestination = getLookupDestination(destination);
-			if (lookupDestination != null) {
-				final Map<String, Object> newHeaders = new HashMap<>();
-				newHeaders.put("lookupDestination", lookupDestination);
-				message = MessageBuilder.createMessage(message.getPayload(), SqsMessageHeaders.createFrom((SqsMessageHeaders) message.getHeaders(), newHeaders));
-				handleMessageInternal(message, lookupDestination);
-			}
-		}
 	}
 
 	@Override

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/SqsHeadersMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/SqsHeadersMethodArgumentResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.aws.messaging.core.SqsMessageHeaders;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.support.HeadersMethodArgumentResolver;
+
+/**
+ * @author Wojciech Mąka
+ * @since 2.2.3
+ */
+public class SqsHeadersMethodArgumentResolver extends HeadersMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return super.supportsParameter(parameter) || SqsMessageHeaders.class == parameter.getParameterType();
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		final Class<? extends MessageHeaders> messageHeadersClass = message.getHeaders().getClass();
+		if (messageHeadersClass.getName().equals("org.springframework.messaging.support.MessageHeaderAccessor$MutableMessageHeaders")) {
+			final Map<String, Object> headers = new HashMap<>();
+			for (String key : message.getHeaders().keySet()) {
+				headers.put(key, message.getHeaders().get(key));
+			}
+			return new SqsMessageHeaders(headers);
+		}
+		else {
+			return super.resolveArgument(parameter, message);
+		}
+	}
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/SqsHeadersMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/support/SqsHeadersMethodArgumentResolver.java
@@ -33,13 +33,17 @@ public class SqsHeadersMethodArgumentResolver extends HeadersMethodArgumentResol
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return super.supportsParameter(parameter) || SqsMessageHeaders.class == parameter.getParameterType();
+		return super.supportsParameter(parameter)
+				|| SqsMessageHeaders.class == parameter.getParameterType();
 	}
 
 	@Override
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
-		final Class<? extends MessageHeaders> messageHeadersClass = message.getHeaders().getClass();
-		if (messageHeadersClass.getName().equals("org.springframework.messaging.support.MessageHeaderAccessor$MutableMessageHeaders")) {
+	public Object resolveArgument(MethodParameter parameter, Message<?> message)
+			throws Exception {
+		final Class<? extends MessageHeaders> messageHeadersClass = message.getHeaders()
+				.getClass();
+		if (messageHeadersClass.getName().equals(
+				"org.springframework.messaging.support.MessageHeaderAccessor$MutableMessageHeaders")) {
 			final Map<String, Object> headers = new HashMap<>();
 			for (String key : message.getHeaders().keySet()) {
 				headers.put(key, message.getHeaders().get(key));
@@ -50,4 +54,5 @@ public class SqsHeadersMethodArgumentResolver extends HeadersMethodArgumentResol
 			return super.resolveArgument(parameter, message);
 		}
 	}
+
 }

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.messaging.listener;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -46,6 +47,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 import org.springframework.cloud.aws.messaging.config.annotation.NotificationMessage;
 import org.springframework.cloud.aws.messaging.config.annotation.NotificationSubject;
+import org.springframework.cloud.aws.messaging.core.SqsMessageHeaders;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -85,6 +87,7 @@ import static org.mockito.Mockito.when;
  * @author Agim Emruli
  * @author Alain Sahli
  * @author Maciej Walkowiak
+ * @author Wojciech Mąka
  * @since 1.0
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -367,7 +370,9 @@ public class QueueMessageHandlerTest {
 		queueMessageHandler
 				.handleMessage(MessageBuilder.withPayload("Hello from a sender")
 						.setHeader(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue")
-						.setHeader("SenderId", "ID").build());
+						.setHeader("SenderId", "ID")
+						.setHeader("SentTimestamp","1000")
+						.setHeader("ApproximateFirstReceiveTimestamp","2000").build());
 
 		// Assert
 		assertThat(messageReceiver.getHeaders()).isNotNull();
@@ -375,6 +380,75 @@ public class QueueMessageHandlerTest {
 		assertThat(
 				messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
 						.isEqualTo("testQueue");
+	}
+
+	@Test
+	public void receiveMessage_withSqsMessageHeadersObject_shouldReceiveAllHeaders()  {
+		// Arrange
+		StaticApplicationContext applicationContext = new StaticApplicationContext();
+		applicationContext.registerSingleton("messageHandlerWithMessageHeaderObject",
+			MessageReceiverWithSqsMessageHeadersObject.class);
+		applicationContext.registerSingleton("queueMessageHandler",
+			QueueMessageHandler.class);
+		applicationContext.refresh();
+
+		QueueMessageHandler queueMessageHandler = applicationContext
+			.getBean(QueueMessageHandler.class);
+		MessageReceiverWithSqsMessageHeadersObject messageReceiver = applicationContext
+			.getBean(MessageReceiverWithSqsMessageHeadersObject.class);
+
+		// Act
+		queueMessageHandler
+			.handleMessage(MessageBuilder.createMessage("Hello from a sender",new SqsMessageHeaders(new HashMap<String,Object>(){{
+				put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
+				put("SenderId", "ID");
+				put("SentTimestamp", "1000");
+				put("ApproximateFirstReceiveTimestamp","2000");
+			}})));
+
+		// Assert
+		assertThat(messageReceiver.getHeaders()).isNotNull();
+		assertThat(messageReceiver.getHeaders().getTimestamp()).isEqualTo(1000);
+		assertThat(messageReceiver.getHeaders().getSentTimestamp()).isEqualTo(1000);
+		assertThat(messageReceiver.getHeaders().getApproximateReceiveCount()).isNull();
+		assertThat(messageReceiver.getHeaders().getApproximateFirstReceiveTimestamp()).isEqualTo(2000);
+		assertThat(
+			messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
+			.isEqualTo("testQueue");
+	}
+
+	@Test
+	public void receiveMessage_withMessageHeadersObject_shouldReceiveAllHeaders()  {
+		// Arrange
+		StaticApplicationContext applicationContext = new StaticApplicationContext();
+		applicationContext.registerSingleton("messageHandlerWithMessageHeaderObject",
+			MessageReceiverWithMessageHeadersObject.class);
+		applicationContext.registerSingleton("queueMessageHandler",
+			QueueMessageHandler.class);
+		applicationContext.refresh();
+
+		QueueMessageHandler queueMessageHandler = applicationContext
+			.getBean(QueueMessageHandler.class);
+		MessageReceiverWithMessageHeadersObject messageReceiver = applicationContext
+			.getBean(MessageReceiverWithMessageHeadersObject.class);
+
+		// Act
+		queueMessageHandler
+			.handleMessage(MessageBuilder.createMessage("Hello from a sender",new SqsMessageHeaders(new HashMap<String,Object>(){{
+				put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
+				put("SenderId", "ID");
+				put("SentTimestamp", "1000");
+				put("ApproximateFirstReceiveTimestamp","2000");
+			}})));
+
+		// Assert
+		assertThat(messageReceiver.getHeaders()).isNotNull();
+		assertThat(messageReceiver.getHeaders().getTimestamp()).isEqualTo(1000);
+		assertThat(messageReceiver.getHeaders().get("SentTimestamp")).isEqualTo("1000");
+		assertThat(messageReceiver.getHeaders().get("ApproximateFirstReceiveTimestamp")).isEqualTo("2000");
+		assertThat(
+			messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
+			.isEqualTo("testQueue");
 	}
 
 	@Test
@@ -781,6 +855,50 @@ public class QueueMessageHandlerTest {
 			this.headers = headers;
 		}
 
+	}
+
+	private static class MessageReceiverWithSqsMessageHeadersObject {
+		private String payload;
+
+		private SqsMessageHeaders headers;
+
+		@RuntimeUse
+		public String getPayload() {
+			return this.payload;
+		}
+
+		public SqsMessageHeaders getHeaders() {
+			return this.headers;
+		}
+
+		@RuntimeUse
+		@SqsListener("testQueue")
+		public void receive(@Payload String payload, SqsMessageHeaders headers) {
+			this.payload = payload;
+			this.headers = headers;
+		}
+	}
+
+	private static class MessageReceiverWithMessageHeadersObject {
+		private String payload;
+
+		private MessageHeaders headers;
+
+		@RuntimeUse
+		public String getPayload() {
+			return this.payload;
+		}
+
+		public MessageHeaders getHeaders() {
+			return this.headers;
+		}
+
+		@RuntimeUse
+		@SqsListener("testQueue")
+		public void receive(@Payload String payload, MessageHeaders headers) {
+			this.payload = payload;
+			this.headers = headers;
+		}
 	}
 
 	private static class NotificationMessageReceiver {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -16,18 +16,6 @@
 
 package org.springframework.cloud.aws.messaging.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +23,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,15 +71,17 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
 import org.springframework.messaging.handler.invocation.HandlerMethodReturnValueHandler;
 import org.springframework.messaging.support.MessageBuilder;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Agim Emruli

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandlerTest.java
@@ -370,9 +370,8 @@ public class QueueMessageHandlerTest {
 		queueMessageHandler
 				.handleMessage(MessageBuilder.withPayload("Hello from a sender")
 						.setHeader(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue")
-						.setHeader("SenderId", "ID")
-						.setHeader("SentTimestamp","1000")
-						.setHeader("ApproximateFirstReceiveTimestamp","2000").build());
+						.setHeader("SenderId", "ID").setHeader("SentTimestamp", "1000")
+						.setHeader("ApproximateFirstReceiveTimestamp", "2000").build());
 
 		// Assert
 		assertThat(messageReceiver.getHeaders()).isNotNull();
@@ -383,72 +382,80 @@ public class QueueMessageHandlerTest {
 	}
 
 	@Test
-	public void receiveMessage_withSqsMessageHeadersObject_shouldReceiveAllHeaders()  {
+	public void receiveMessage_withSqsMessageHeadersObject_shouldReceiveAllHeaders() {
 		// Arrange
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("messageHandlerWithMessageHeaderObject",
-			MessageReceiverWithSqsMessageHeadersObject.class);
+				MessageReceiverWithSqsMessageHeadersObject.class);
 		applicationContext.registerSingleton("queueMessageHandler",
-			QueueMessageHandler.class);
+				QueueMessageHandler.class);
 		applicationContext.refresh();
 
 		QueueMessageHandler queueMessageHandler = applicationContext
-			.getBean(QueueMessageHandler.class);
+				.getBean(QueueMessageHandler.class);
 		MessageReceiverWithSqsMessageHeadersObject messageReceiver = applicationContext
-			.getBean(MessageReceiverWithSqsMessageHeadersObject.class);
+				.getBean(MessageReceiverWithSqsMessageHeadersObject.class);
 
 		// Act
 		queueMessageHandler
-			.handleMessage(MessageBuilder.createMessage("Hello from a sender",new SqsMessageHeaders(new HashMap<String,Object>(){{
-				put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
-				put("SenderId", "ID");
-				put("SentTimestamp", "1000");
-				put("ApproximateFirstReceiveTimestamp","2000");
-			}})));
+				.handleMessage(MessageBuilder.createMessage("Hello from a sender",
+						new SqsMessageHeaders(new HashMap<String, Object>() {
+							{
+								put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
+								put("SenderId", "ID");
+								put("SentTimestamp", "1000");
+								put("ApproximateFirstReceiveTimestamp", "2000");
+							}
+						})));
 
 		// Assert
 		assertThat(messageReceiver.getHeaders()).isNotNull();
 		assertThat(messageReceiver.getHeaders().getTimestamp()).isEqualTo(1000);
 		assertThat(messageReceiver.getHeaders().getSentTimestamp()).isEqualTo(1000);
 		assertThat(messageReceiver.getHeaders().getApproximateReceiveCount()).isNull();
-		assertThat(messageReceiver.getHeaders().getApproximateFirstReceiveTimestamp()).isEqualTo(2000);
+		assertThat(messageReceiver.getHeaders().getApproximateFirstReceiveTimestamp())
+				.isEqualTo(2000);
 		assertThat(
-			messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
-			.isEqualTo("testQueue");
+				messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
+						.isEqualTo("testQueue");
 	}
 
 	@Test
-	public void receiveMessage_withMessageHeadersObject_shouldReceiveAllHeaders()  {
+	public void receiveMessage_withMessageHeadersObject_shouldReceiveAllHeaders() {
 		// Arrange
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("messageHandlerWithMessageHeaderObject",
-			MessageReceiverWithMessageHeadersObject.class);
+				MessageReceiverWithMessageHeadersObject.class);
 		applicationContext.registerSingleton("queueMessageHandler",
-			QueueMessageHandler.class);
+				QueueMessageHandler.class);
 		applicationContext.refresh();
 
 		QueueMessageHandler queueMessageHandler = applicationContext
-			.getBean(QueueMessageHandler.class);
+				.getBean(QueueMessageHandler.class);
 		MessageReceiverWithMessageHeadersObject messageReceiver = applicationContext
-			.getBean(MessageReceiverWithMessageHeadersObject.class);
+				.getBean(MessageReceiverWithMessageHeadersObject.class);
 
 		// Act
 		queueMessageHandler
-			.handleMessage(MessageBuilder.createMessage("Hello from a sender",new SqsMessageHeaders(new HashMap<String,Object>(){{
-				put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
-				put("SenderId", "ID");
-				put("SentTimestamp", "1000");
-				put("ApproximateFirstReceiveTimestamp","2000");
-			}})));
+				.handleMessage(MessageBuilder.createMessage("Hello from a sender",
+						new SqsMessageHeaders(new HashMap<String, Object>() {
+							{
+								put(QueueMessageHandler.LOGICAL_RESOURCE_ID, "testQueue");
+								put("SenderId", "ID");
+								put("SentTimestamp", "1000");
+								put("ApproximateFirstReceiveTimestamp", "2000");
+							}
+						})));
 
 		// Assert
 		assertThat(messageReceiver.getHeaders()).isNotNull();
 		assertThat(messageReceiver.getHeaders().getTimestamp()).isEqualTo(1000);
 		assertThat(messageReceiver.getHeaders().get("SentTimestamp")).isEqualTo("1000");
-		assertThat(messageReceiver.getHeaders().get("ApproximateFirstReceiveTimestamp")).isEqualTo("2000");
+		assertThat(messageReceiver.getHeaders().get("ApproximateFirstReceiveTimestamp"))
+				.isEqualTo("2000");
 		assertThat(
-			messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
-			.isEqualTo("testQueue");
+				messageReceiver.getHeaders().get(QueueMessageHandler.LOGICAL_RESOURCE_ID))
+						.isEqualTo("testQueue");
 	}
 
 	@Test
@@ -858,6 +865,7 @@ public class QueueMessageHandlerTest {
 	}
 
 	private static class MessageReceiverWithSqsMessageHeadersObject {
+
 		private String payload;
 
 		private SqsMessageHeaders headers;
@@ -877,9 +885,11 @@ public class QueueMessageHandlerTest {
 			this.payload = payload;
 			this.headers = headers;
 		}
+
 	}
 
 	private static class MessageReceiverWithMessageHeadersObject {
+
 		private String payload;
 
 		private MessageHeaders headers;
@@ -899,6 +909,7 @@ public class QueueMessageHandlerTest {
 			this.payload = payload;
 			this.headers = headers;
 		}
+
 	}
 
 	private static class NotificationMessageReceiver {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -412,14 +412,17 @@ public class SimpleMessageListenerContainerTest {
 		when(sqs.receiveMessage(new ReceiveMessageRequest(
 				"https://messageExecutor_withMessageWithAttributes_shouldPassThemAsHeaders.amazonaws.com")
 						.withAttributeNames("All").withMessageAttributeNames("All")
-						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20)))
-								.thenReturn(new ReceiveMessageResult().withMessages(
-										new Message().withBody("messageContent")
-												.withAttributes(new HashMap<String,String>() {{
-													put("SenderId","ID");
-													put("SentTimestamp","1000");
-													put("ApproximateFirstReceiveTimestamp","2000");
-												}})))
+						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20))).thenReturn(
+								new ReceiveMessageResult().withMessages(new Message()
+										.withBody("messageContent")
+										.withAttributes(new HashMap<String, String>() {
+											{
+												put("SenderId", "ID");
+												put("SentTimestamp", "1000");
+												put("ApproximateFirstReceiveTimestamp",
+														"2000");
+											}
+										})))
 								.thenReturn(new ReceiveMessageResult());
 		when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 				.thenReturn(new GetQueueAttributesResult());
@@ -435,10 +438,9 @@ public class SimpleMessageListenerContainerTest {
 		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SenderId"))
 				.isEqualTo("ID");
 		assertThat(this.stringMessageCaptor.getValue().getHeaders().getTimestamp())
-			.isEqualTo(1000L);
-		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("ApproximateFirstReceiveTimestamp"))
-			.isEqualTo("2000");
-
+				.isEqualTo(1000L);
+		assertThat(this.stringMessageCaptor.getValue().getHeaders()
+				.get("ApproximateFirstReceiveTimestamp")).isEqualTo("2000");
 
 	}
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.messaging.listener;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -414,8 +415,11 @@ public class SimpleMessageListenerContainerTest {
 						.withMaxNumberOfMessages(10).withWaitTimeSeconds(20)))
 								.thenReturn(new ReceiveMessageResult().withMessages(
 										new Message().withBody("messageContent")
-												.withAttributes(Collections
-														.singletonMap("SenderId", "ID"))))
+												.withAttributes(new HashMap<String,String>() {{
+													put("SenderId","ID");
+													put("SentTimestamp","1000");
+													put("ApproximateFirstReceiveTimestamp","2000");
+												}})))
 								.thenReturn(new ReceiveMessageResult());
 		when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
 				.thenReturn(new GetQueueAttributesResult());
@@ -430,6 +434,11 @@ public class SimpleMessageListenerContainerTest {
 		verify(messageHandler).handleMessage(this.stringMessageCaptor.capture());
 		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("SenderId"))
 				.isEqualTo("ID");
+		assertThat(this.stringMessageCaptor.getValue().getHeaders().getTimestamp())
+			.isEqualTo(1000L);
+		assertThat(this.stringMessageCaptor.getValue().getHeaders().get("ApproximateFirstReceiveTimestamp"))
+			.isEqualTo("2000");
+
 
 	}
 


### PR DESCRIPTION
code changes: 
- `SqsMessageHeaders` extended by convenient getters for sqs specific headers.
- `SqsHeadersMethodArgumentResolver` added to resolve `MesageHeaderAccessor.MessageHeaders` instance into `SqsMessageHeaders` with timestamp resolved from sqs SentTimestamp
- Unit tests added in `QueueMessageHandlerTest` testing `SqsHeadersMethodArgumentResolver` and `SqsMessageHeaders`
- `QueueListenerTest` (integration tests) - additional assertions to test providing SqsMessageHeaders argument on `SqsListener` handler method. 

Let me know Your thoughts.