### PR TITLE
Configure SQS to use existing ObjectMapper if present in application context.

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.messaging.config.annotation;
 import java.util.Arrays;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -54,12 +55,15 @@ public class SqsConfiguration {
 
 	private final MappingJackson2MessageConverter mappingJackson2MessageConverter;
 
+	private final ObjectMapper objectMapper;
+
 	public SqsConfiguration(
 			ObjectProvider<SimpleMessageListenerContainerFactory> simpleMessageListenerContainerFactory,
 			ObjectProvider<QueueMessageHandlerFactory> queueMessageHandlerFactory,
 			BeanFactory beanFactory,
 			ObjectProvider<ResourceIdResolver> resourceIdResolver,
-			ObjectProvider<MappingJackson2MessageConverter> mappingJackson2MessageConverter) {
+			ObjectProvider<MappingJackson2MessageConverter> mappingJackson2MessageConverter,
+			ObjectProvider<ObjectMapper> objectMapper) {
 		this.simpleMessageListenerContainerFactory = simpleMessageListenerContainerFactory
 				.getIfAvailable(SimpleMessageListenerContainerFactory::new);
 		this.queueMessageHandlerFactory = queueMessageHandlerFactory
@@ -68,6 +72,7 @@ public class SqsConfiguration {
 		this.resourceIdResolver = resourceIdResolver.getIfAvailable();
 		this.mappingJackson2MessageConverter = mappingJackson2MessageConverter
 				.getIfAvailable();
+		this.objectMapper = objectMapper.getIfAvailable();
 	}
 
 	@Bean
@@ -111,6 +116,7 @@ public class SqsConfiguration {
 		}
 
 		this.queueMessageHandlerFactory.setBeanFactory(this.beanFactory);
+		this.queueMessageHandlerFactory.setObjectMapper(this.objectMapper);
 
 		return this.queueMessageHandlerFactory.createQueueMessageHandler();
 	}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplate.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/support/AbstractMessageChannelMessagingSendingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
@@ -33,7 +32,6 @@ import org.springframework.messaging.core.CachingDestinationResolverProxy;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.core.DestinationResolvingMessageSendingOperations;
 import org.springframework.messaging.core.MessagePostProcessor;
-import org.springframework.util.ClassUtils;
 
 /**
  * @param <D> message channel type
@@ -44,10 +42,6 @@ import org.springframework.util.ClassUtils;
 public abstract class AbstractMessageChannelMessagingSendingTemplate<D extends MessageChannel>
 		extends AbstractMessageSendingTemplate<D>
 		implements DestinationResolvingMessageSendingOperations<D> {
-
-	private static final boolean JACKSON_2_PRESENT = ClassUtils.isPresent(
-			"com.fasterxml.jackson.databind.ObjectMapper",
-			AbstractMessageChannelMessagingSendingTemplate.class.getClassLoader());
 
 	private final DestinationResolver<String> destinationResolver;
 
@@ -120,10 +114,8 @@ public abstract class AbstractMessageChannelMessagingSendingTemplate<D extends M
 		if (messageConverter != null) {
 			messageConverters.add(messageConverter);
 		}
-		else if (JACKSON_2_PRESENT) {
+		else {
 			MappingJackson2MessageConverter mappingJackson2MessageConverter = new MappingJackson2MessageConverter();
-			mappingJackson2MessageConverter
-					.setObjectMapper(Jackson2ObjectMapperBuilder.json().build());
 			mappingJackson2MessageConverter.setSerializedPayloadClass(String.class);
 			messageConverters.add(mappingJackson2MessageConverter);
 		}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -202,7 +202,7 @@ class QueueMessagingTemplateTest {
 		// Assert
 		assertThat(
 				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
-						.getConverters().size()).isEqualTo(2);
+						.getConverters()).hasSize(2);
 		assertThat(
 				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
 						.getConverters().get(1)).isEqualTo(simpleMessageConverter);
@@ -217,7 +217,7 @@ class QueueMessagingTemplateTest {
 		// Assert
 		assertThat(
 				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
-						.getConverters().size()).isEqualTo(2);
+						.getConverters()).hasSize(2);
 		assertThat(
 				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
 						.getConverters().get(1))

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/core/QueueMessagingTemplateTest.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.aws.messaging.core;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Locale;
 
@@ -27,12 +26,10 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.aws.core.env.ResourceIdResolver;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -212,65 +209,19 @@ class QueueMessagingTemplateTest {
 	}
 
 	@Test
-	void instantiation_WithCustomJacksonConverterThatSupportsJava8Types_shouldConvertMessageToString()
-			throws IOException {
-
-		// Arrange
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
-
-		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
-
-		MappingJackson2MessageConverter simpleMessageConverter = new MappingJackson2MessageConverter();
-		simpleMessageConverter.setSerializedPayloadClass(String.class);
-		simpleMessageConverter.setObjectMapper(objectMapper);
-
-		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs, (ResourceIdResolver) null, simpleMessageConverter);
-
+	void instantiation_withoutConverter_shouldAddDefaultJacksonConverterToTheCompositeConverter() {
 		// Act
-		queueMessagingTemplate.convertAndSend("test",
-				new TestPerson("Agim", "Emruli", LocalDate.of(2017, 1, 1)));
+		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
+				createAmazonSqs(), (ResourceIdResolver) null, null);
 
 		// Assert
-		ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
-				.forClass(SendMessageRequest.class);
-		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-		TestPerson testPerson = objectMapper.readValue(
-				sendMessageRequestArgumentCaptor.getValue().getMessageBody(),
-				TestPerson.class);
-
-		assertThat(testPerson.getFirstName()).isEqualTo("Agim");
-		assertThat(testPerson.getLastName()).isEqualTo("Emruli");
-		assertThat(testPerson.getActiveSince()).isEqualTo(LocalDate.of(2017, 1, 1));
-	}
-
-	@Test
-	void instantiation_withDefaultMapping2JacksonConverter_shouldSupportJava8Types()
-			throws IOException {
-
-		// Arrange
-		AmazonSQSAsync amazonSqs = createAmazonSqs();
-
-		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
-
-		QueueMessagingTemplate queueMessagingTemplate = new QueueMessagingTemplate(
-				amazonSqs);
-
-		// Act
-		queueMessagingTemplate.convertAndSend("test",
-				new TestPerson("Agim", "Emruli", LocalDate.of(2017, 1, 1)));
-
-		// Assert
-		ArgumentCaptor<SendMessageRequest> sendMessageRequestArgumentCaptor = ArgumentCaptor
-				.forClass(SendMessageRequest.class);
-		verify(amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
-		TestPerson testPerson = objectMapper.readValue(
-				sendMessageRequestArgumentCaptor.getValue().getMessageBody(),
-				TestPerson.class);
-
-		assertThat(testPerson.getFirstName()).isEqualTo("Agim");
-		assertThat(testPerson.getLastName()).isEqualTo("Emruli");
-		assertThat(testPerson.getActiveSince()).isEqualTo(LocalDate.of(2017, 1, 1));
+		assertThat(
+				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
+						.getConverters().size()).isEqualTo(2);
+		assertThat(
+				((CompositeMessageConverter) queueMessagingTemplate.getMessageConverter())
+						.getConverters().get(1))
+								.isInstanceOf(MappingJackson2MessageConverter.class);
 	}
 
 	private AmazonSQSAsync createAmazonSqs() {


### PR DESCRIPTION
Configure SQS to use existing ObjectMapper if present in application context. If ObjectMapper is not present, creates default Jackson ObjectMapper without the dependency to spring-web module.

Fixes gh-533
Fixes gh-522
Fixes gh-540