### PR TITLE
Allow `/` and `\` as profile separator in Secrets Manager and Parameter Store integrations

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -695,8 +695,8 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 
 |`aws.paramstore.profileSeparator`
 |`_`
-|String that separates an appended profile from the context name. Note that an AWS parameter key can only contain
- dots, dashes and underscores next to alphanumeric characters.
+|String that separates an appended profile from the context name. Can only contain
+ dots, dashes, forward slashes, backward slashes and underscores next to alphanumeric characters.
 
 |`aws.paramstore.failFast`
 |`true`
@@ -778,7 +778,8 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 
 |`aws.secretsmanager.profileSeparator`
 |`_`
-|String that separates an appended profile from the context name.
+|String that separates an appended profile from the context name. Can only contain
+ dots, dashes, forward slashes, backward slashes and underscores next to alphanumeric characters.
 
 |`aws.secretsmanager.failFast`
 |`true`

--- a/spring-cloud-aws-parameter-store-config/pom.xml
+++ b/spring-cloud-aws-parameter-store-config/pom.xml
@@ -62,5 +62,17 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>jakarta.el</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -51,7 +51,7 @@ public class AwsParamStoreProperties {
 	private String defaultContext = "application";
 
 	@NotNull
-	@Pattern(regexp = "[a-zA-Z0-9.\\-_/]+")
+	@Pattern(regexp = "[a-zA-Z0-9.\\-_/\\\\]+")
 	private String profileSeparator = "_";
 
 	/** Throw exceptions during config lookup if true, otherwise, log warnings. */

--- a/spring-cloud-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertiesTest.java
+++ b/spring-cloud-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertiesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.paramstore;
+
+import javax.validation.Validation;
+
+import org.junit.Test;
+
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.SmartValidator;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AwsParamStorePropertiesTest {
+
+	private SmartValidator validator = new SpringValidatorAdapter(
+			Validation.buildDefaultValidatorFactory().getValidator());
+
+	@Test
+	public void acceptsForwardSlashAsProfileSeparator() {
+		AwsParamStoreProperties properties = new AwsParamStoreProperties();
+		properties.setProfileSeparator("/");
+
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+
+		validator.validate(properties, errors);
+
+		assertThat(errors.getFieldError("profileSeparator")).isNull();
+	}
+
+	@Test
+	public void acceptsBackslashAsProfileSeparator() {
+		AwsParamStoreProperties properties = new AwsParamStoreProperties();
+		properties.setProfileSeparator("\\");
+
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+
+		validator.validate(properties, errors);
+
+		assertThat(errors.getFieldError("profileSeparator")).isNull();
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-aws-secrets-manager-config/pom.xml
@@ -62,5 +62,17 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>jakarta.el</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -51,7 +51,7 @@ public class AwsSecretsManagerProperties {
 	private String defaultContext = "application";
 
 	@NotNull
-	@Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
+	@Pattern(regexp = "[a-zA-Z0-9.\\-_/\\\\]+")
 	private String profileSeparator = "_";
 
 	/** Throw exceptions during config lookup if true, otherwise, log warnings. */

--- a/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertiesTest.java
+++ b/spring-cloud-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertiesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import javax.validation.Validation;
+
+import org.junit.Test;
+
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.SmartValidator;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AwsSecretsManagerPropertiesTest {
+
+	private SmartValidator validator = new SpringValidatorAdapter(
+			Validation.buildDefaultValidatorFactory().getValidator());
+
+	@Test
+	public void acceptsForwardSlashAsProfileSeparator() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setProfileSeparator("/");
+
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+
+		validator.validate(properties, errors);
+
+		assertThat(errors.getFieldError("profileSeparator")).isNull();
+	}
+
+	@Test
+	public void acceptsBackslashAsProfileSeparator() {
+		AwsSecretsManagerProperties properties = new AwsSecretsManagerProperties();
+		properties.setProfileSeparator("\\");
+
+		Errors errors = new BeanPropertyBindingResult(properties, "properties");
+
+		validator.validate(properties, errors);
+
+		assertThat(errors.getFieldError("profileSeparator")).isNull();
+	}
+
+}


### PR DESCRIPTION
Fixes gh-554
Fixes gh-512