### PR TITLE
Deprecate @EnableElastiCache annotation.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -16,25 +16,106 @@
 
 package org.springframework.cloud.aws.autoconfigure.cache;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.elasticache.AmazonElastiCache;
+import com.amazonaws.services.elasticache.AmazonElastiCacheClient;
+import net.spy.memcached.MemcachedClient;
+
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.aws.autoconfigure.condition.ConditionalOnAwsCloudEnvironment;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
-import org.springframework.cloud.aws.cache.config.annotation.EnableElastiCache;
+import org.springframework.cloud.aws.cache.CacheFactory;
+import org.springframework.cloud.aws.cache.config.annotation.ElastiCacheCacheConfigurer;
+import org.springframework.cloud.aws.cache.memcached.MemcachedCacheFactory;
+import org.springframework.cloud.aws.cache.redis.RedisCacheFactory;
+import org.springframework.cloud.aws.context.config.annotation.ContextDefaultConfigurationRegistrar;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientFactoryBean;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.cloud.aws.core.env.stack.ListableStackResourceFactory;
+import org.springframework.cloud.aws.core.env.stack.StackResource;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 /**
  * @author Agim Emruli
  * @author Eddú Meléndez
+ * @author Maciej Walkowiak
  */
 @Configuration(proxyBeanMethods = false)
-@Import(ContextCredentialsAutoConfiguration.class)
-@EnableElastiCache
-@ConditionalOnClass(name = "com.amazonaws.services.elasticache.AmazonElastiCache")
-@ConditionalOnAwsCloudEnvironment
+@Import({ ContextCredentialsAutoConfiguration.class,
+		ContextDefaultConfigurationRegistrar.class })
+@ConditionalOnClass(com.amazonaws.services.elasticache.AmazonElastiCache.class)
 @ConditionalOnProperty(name = "cloud.aws.elasticache.enabled", havingValue = "true",
 		matchIfMissing = true)
+@EnableConfigurationProperties(ElastiCacheProperties.class)
 public class ElastiCacheAutoConfiguration {
+
+	private final ElastiCacheProperties properties;
+
+	private final ListableStackResourceFactory stackResourceFactory;
+
+	public ElastiCacheAutoConfiguration(ElastiCacheProperties properties,
+			ObjectProvider<ListableStackResourceFactory> stackResourceFactory) {
+		this.properties = properties;
+		this.stackResourceFactory = stackResourceFactory.getIfAvailable();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(AmazonElastiCache.class)
+	public AmazonWebserviceClientFactoryBean<AmazonElastiCacheClient> amazonElastiCache(
+			ObjectProvider<RegionProvider> regionProvider,
+			ObjectProvider<AWSCredentialsProvider> credentialsProvider) {
+		return new AmazonWebserviceClientFactoryBean<>(AmazonElastiCacheClient.class,
+				credentialsProvider.getIfAvailable(), regionProvider.getIfAvailable());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(CachingConfigurer.class)
+	public CachingConfigurer cachingConfigurer(AmazonElastiCache amazonElastiCache,
+			ResourceIdResolver resourceIdResolver, List<CacheFactory> cacheFactories) {
+		if (!this.properties.getClusters().isEmpty()) {
+			return new ElastiCacheCacheConfigurer(amazonElastiCache, resourceIdResolver,
+					this.properties.getCacheNames(), cacheFactories);
+		}
+		else {
+			return new ElastiCacheCacheConfigurer(amazonElastiCache, resourceIdResolver,
+					getConfiguredCachesInStack(), cacheFactories);
+		}
+	}
+
+	@Bean
+	@ConditionalOnClass(RedisConnectionFactory.class)
+	public RedisCacheFactory redisCacheFactory() {
+		return new RedisCacheFactory(this.properties.getExpiryTimePerCache(),
+				this.properties.getDefaultExpiration());
+	}
+
+	@Bean
+	@ConditionalOnClass(MemcachedClient.class)
+	public MemcachedCacheFactory memcachedCacheFactory() {
+		return new MemcachedCacheFactory(this.properties.getExpiryTimePerCache(),
+				this.properties.getDefaultExpiration());
+	}
+
+	private List<String> getConfiguredCachesInStack() {
+		List<String> cacheNames = new ArrayList<>();
+		if (this.stackResourceFactory != null) {
+			for (StackResource stackResource : this.stackResourceFactory
+					.resourcesByType("AWS::ElastiCache::CacheCluster")) {
+				cacheNames.add(stackResource.getLogicalId());
+			}
+		}
+		return cacheNames;
+	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheProperties.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.cache;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties related to ElastiCache configuration.
+ *
+ * @author Maciej Walkowiak
+ */
+@ConfigurationProperties(prefix = "cloud.aws.elasticache")
+public class ElastiCacheProperties {
+
+	/**
+	 * Configures the cache clusters for the caching configuration. Support one or
+	 * multiple caches {@link Cluster} configurations with their physical cache name (as
+	 * configured in the ElastiCache service) or their logical cache name if the caches
+	 * are configured inside a stack and
+	 * {@link org.springframework.cloud.aws.context.config.annotation.EnableStackConfiguration}
+	 * annotation is used inside the application.
+	 */
+	private List<Cluster> clusters = Collections.emptyList();
+
+	/**
+	 * Configures the default expiration time in seconds if there is no custom expiration
+	 * time configuration with a {@link Cluster} configuration for the cache. The
+	 * expiration time is implementation specific (e.g. Redis or Memcached) and could
+	 * therefore differ in the behaviour based on the cache implementation.
+	 */
+	private int defaultExpiration;
+
+	public List<Cluster> getClusters() {
+		return clusters;
+	}
+
+	public void setClusters(List<Cluster> clusters) {
+		this.clusters = clusters;
+	}
+
+	public int getDefaultExpiration() {
+		return defaultExpiration;
+	}
+
+	public void setDefaultExpiration(int defaultExpiration) {
+		this.defaultExpiration = defaultExpiration;
+	}
+
+	public List<String> getCacheNames() {
+		return this.getClusters().stream().map(Cluster::getName)
+				.collect(Collectors.toList());
+	}
+
+	public Map<String, Integer> getExpiryTimePerCache() {
+		Map<String, Integer> expiryTimePerCache = new HashMap<>(clusters.size());
+		for (Cluster cluster : clusters) {
+			expiryTimePerCache.put(cluster.getName(), cluster.getExpiration());
+		}
+		return expiryTimePerCache;
+	}
+
+	public static class Cluster {
+
+		/**
+		 * Defines the name for the cache cluster. The name might be the physical name of
+		 * the cache cluster itself or a logical name of a cache cluster inside a stack.
+		 * The caching infrastructure will automatically retrieve the cache engine (redis
+		 * or memcached) and configured the appropriate cache driver with the cache
+		 * implementation. Caches can be used inside the application code with the
+		 * {@link org.springframework.cache.annotation.Cacheable} annotation or others
+		 * referring to this name attribute inside the
+		 * {@link org.springframework.cache.annotation.Cacheable#value()} attribute.
+		 */
+		private String name;
+
+		/**
+		 * Configures the expiration time of the particular cache cluster in seconds. The
+		 * expiration time is based on the cache level and is implementation specific.
+		 * Typically this expiration time will configure the expiration of one item at the
+		 * time the item is inserted into the cache regardless of the last access. If this
+		 * value is not explicitly configured then the value of
+		 * {@link ElastiCacheProperties#getDefaultExpiration()} will be used.
+		 */
+		private int expiration;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getExpiration() {
+			return expiration;
+		}
+
+		public void setExpiration(int expiration) {
+			this.expiration = expiration;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/AbstractCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/AbstractCacheFactory.java
@@ -38,6 +38,12 @@ public abstract class AbstractCacheFactory<T> implements CacheFactory, Disposabl
 	protected AbstractCacheFactory() {
 	}
 
+	protected AbstractCacheFactory(Map<String, Integer> expiryTimePerCache,
+			int expiryTime) {
+		this.setExpiryTimePerCache(expiryTimePerCache);
+		this.setExpiryTime(expiryTime);
+	}
+
 	@Override
 	public void destroy() throws Exception {
 		synchronized (this.nativeConnectionClients) {

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/CacheClusterConfig.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/CacheClusterConfig.java
@@ -24,7 +24,9 @@ package org.springframework.cloud.aws.cache.config.annotation;
  * the expiration.
  *
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
+@Deprecated
 public @interface CacheClusterConfig {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfiguration.java
@@ -50,9 +50,11 @@ import org.springframework.util.Assert;
 /**
  * @author Agim Emruli
  * @author Eddú Meléndez
+ * @deprecated use auto-configuration
  */
 @Configuration(proxyBeanMethods = false)
 @Import(ContextDefaultConfigurationRegistrar.class)
+@Deprecated
 public class ElastiCacheCachingConfiguration implements ImportAware {
 
 	private static final String CACHE_CLUSTER_CONFIG_ATTRIBUTE_NAME = AnnotationUtils.VALUE;

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/EnableElastiCache.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/annotation/EnableElastiCache.java
@@ -42,11 +42,13 @@ import org.springframework.context.annotation.Import;
  * in one stack) will be used.
  *
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @EnableCaching
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Import(ElastiCacheCachingConfiguration.class)
+@Deprecated
 public @interface EnableElastiCache {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/memcached/MemcachedCacheFactory.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.cache.memcached;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.MemcachedClient;
@@ -28,6 +29,14 @@ import org.springframework.cloud.aws.cache.AbstractCacheFactory;
  * @author Agim Emruli
  */
 public class MemcachedCacheFactory extends AbstractCacheFactory<MemcachedClient> {
+
+	public MemcachedCacheFactory() {
+	}
+
+	public MemcachedCacheFactory(Map<String, Integer> expiryTimePerCache,
+			int expiryTime) {
+		super(expiryTimePerCache, expiryTime);
+	}
 
 	@Override
 	public boolean isSupportingCacheArchitecture(String architecture) {

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactory.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/redis/RedisCacheFactory.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.aws.cache.redis;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.cache.Cache;
 import org.springframework.cloud.aws.cache.AbstractCacheFactory;
@@ -36,6 +38,13 @@ public class RedisCacheFactory extends AbstractCacheFactory<RedisConnectionFacto
 
 	private static final boolean LETTUCE_AVAILABLE = ClassUtils
 			.isPresent("io.lettuce.core.RedisClient", ClassUtils.getDefaultClassLoader());
+
+	public RedisCacheFactory() {
+	}
+
+	public RedisCacheFactory(Map<String, Integer> expiryTimePerCache, int expiryTime) {
+		super(expiryTimePerCache, expiryTime);
+	}
 
 	@Override
 	public boolean isSupportingCacheArchitecture(String architecture) {

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/annotation/ElastiCacheCachingConfigurationTest.java
@@ -41,6 +41,7 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Deprecated
 class ElastiCacheCachingConfigurationTest {
 
 	private AnnotationConfigApplicationContext context;


### PR DESCRIPTION
This change includes moving all configuration to auto-configuration completely decoupling auto-configuration from legacy Java configuration.
Additionally enables users to configure cache names through environment properties and enables custom `CachingConfigurer` registration.

Fixes gh-159
Fixes gh-248