### PR TITLE
Deprecate Context EnableX annotations

### DIFF
--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextCredentialsConfigurationRegistrar.java
@@ -27,8 +27,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @Configuration(proxyBeanMethods = false)
+@Deprecated
 public class ContextCredentialsConfigurationRegistrar
 		implements ImportBeanDefinitionRegistrar {
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextInstanceDataConfiguration.java
@@ -27,9 +27,11 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @SuppressWarnings("NonFinalUtilityClass")
 @Configuration(proxyBeanMethods = false)
+@Deprecated
 public class ContextInstanceDataConfiguration implements ImportBeanDefinitionRegistrar {
 
 	@Override

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextRegionConfigurationRegistrar.java
@@ -27,8 +27,10 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
 
 /**
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @Configuration(proxyBeanMethods = false)
+@Deprecated
 public class ContextRegionConfigurationRegistrar
 		implements ImportBeanDefinitionRegistrar {
 

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextStackConfiguration.java
@@ -40,9 +40,11 @@ import org.springframework.util.StringUtils;
 /**
  * @author Agim Emruli
  * @author Eddú Meléndez
+ * @deprecated use auto-configuration
  */
 @Configuration(proxyBeanMethods = false)
 @Import(ContextDefaultConfigurationRegistrar.class)
+@Deprecated
 public class ContextStackConfiguration implements ImportAware {
 
 	private AnnotationAttributes annotationAttributes;

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextCredentials.java
@@ -29,10 +29,12 @@ import org.springframework.context.annotation.Import;
  * (either through annotations or xml).
  *
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Import(ContextCredentialsConfigurationRegistrar.class)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface EnableContextCredentials {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextInstanceData.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextInstanceData.java
@@ -31,10 +31,12 @@ import org.springframework.context.annotation.Import;
  * <b>Note:</b>This annotation does not have any effect outside the EC2 environment.
  *
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import(ContextInstanceDataConfiguration.class)
+@Deprecated
 public @interface EnableContextInstanceData {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableContextRegion.java
@@ -40,10 +40,12 @@ import org.springframework.context.annotation.Import;
  *
  * @author Agim Emruli
  * @author Maciej Walkowiak
+ * @deprecated use auto-configuration
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Import(ContextRegionConfigurationRegistrar.class)
+@Deprecated
 public @interface EnableContextRegion {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableStackConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/EnableStackConfiguration.java
@@ -27,10 +27,12 @@ import org.springframework.context.annotation.Import;
  * Enables Cloudformation support for the application context configuration.
  *
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Import(ContextStackConfiguration.class)
+@Deprecated
 public @interface EnableStackConfiguration {
 
 	/**

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/support/ContextConfigurationUtils.java
@@ -37,7 +37,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Agim Emruli
+ * @deprecated use auto-configuration
  */
+@Deprecated
 public final class ContextConfigurationUtils {
 
 	/**


### PR DESCRIPTION
Deprecate Context module EnableX annotations and related classes. I have left `EnableContextResourceLoader` for now as I am not sure if this part is used at all in auto-configuration. SQS, SNS and RDS are still left to be deprecated and separated from auto-configuration - they will come in separate pull request.