### PR TITLE
Make it possible to disable the _profile-name suffix in AWS SSM

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/pom.xml
+++ b/pom.xml
@@ -156,19 +156,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>io.spring.javaformat</groupId>
-				<artifactId>spring-javaformat-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<inherited>true</inherited>
-						<goals>
-							<goal>validate</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+
 		</plugins>
 	</build>
 

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -61,6 +61,8 @@ public class AwsParamStoreProperties implements Validator {
 
 	private String profileSeparator = "_";
 
+	private boolean profileSuffixEnabled = true;
+
 	/**
 	 * If region value is not null or empty it will be used in creation of
 	 * AWSSimpleSystemsManagement.
@@ -171,4 +173,11 @@ public class AwsParamStoreProperties implements Validator {
 		this.region = region;
 	}
 
+	public boolean isProfileSuffixEnabled() {
+		return profileSuffixEnabled;
+	}
+
+	public void setProfileSuffixEnabled(boolean profileSuffixEnabled) {
+		this.profileSuffixEnabled = enabled;
+	}
 }

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -180,4 +180,5 @@ public class AwsParamStoreProperties implements Validator {
 	public void setProfileSuffixEnabled(boolean profileSuffixEnabled) {
 		this.profileSuffixEnabled = enabled;
 	}
+
 }

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -124,9 +124,11 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 	private void addProfiles(Set<String> contexts, String baseContext,
 			List<String> profiles) {
-		for (String profile : profiles) {
-			contexts.add(
+		if (this.properties.isProfileSuffixEnabled()) {
+			for (String profile : profiles) {
+				contexts.add(
 					baseContext + this.properties.getProfileSeparator() + profile + "/");
+			}
 		}
 	}
 

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -126,8 +126,8 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 			List<String> profiles) {
 		if (this.properties.isProfileSuffixEnabled()) {
 			for (String profile : profiles) {
-				contexts.add(
-					baseContext + this.properties.getProfileSeparator() + profile + "/");
+				contexts.add(baseContext + this.properties.getProfileSeparator() + profile
+						+ "/");
 			}
 		}
 	}


### PR DESCRIPTION
This is a suggestion to make it possible to disable the _profile-name suffix expected in the SSM parameter store path.
My team is using a strategy where we have one AWS account per environment so having the profile as part of the name conflicts with the naming standard we already have and makes the couldformation templates more complex. We still use the profile to configure some things we want different in test, stage and prod so it would be nice to be able to turn this off.

If you think this is a good idea I will clean up the PR, add tests and make sure everything is spiffy