### PR TITLE
Fixes SQS Queues shutting down gracefully

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/SimpleMessageListenerContainerFactory.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Alain Sahli
+ * @author Mete Alpaslan Katırcıoğlu
  * @since 1.0
  */
 public class SimpleMessageListenerContainerFactory {
@@ -40,6 +41,8 @@ public class SimpleMessageListenerContainerFactory {
 	private Integer visibilityTimeout;
 
 	private Integer waitTimeOut;
+
+	private Long queueStopTimeout;
 
 	private boolean autoStartup = true;
 
@@ -94,6 +97,15 @@ public class SimpleMessageListenerContainerFactory {
 	 */
 	public void setWaitTimeOut(Integer waitTimeOut) {
 		this.waitTimeOut = waitTimeOut;
+	}
+
+	/**
+	 * Configures the queue stop timeout that waits for a queue to stop before
+	 * interrupting the running thread.
+	 * @param queueStopTimeout in milliseconds
+	 */
+	public void setQueueStopTimeout(Long queueStopTimeout) {
+		this.queueStopTimeout = queueStopTimeout;
 	}
 
 	/**
@@ -203,6 +215,9 @@ public class SimpleMessageListenerContainerFactory {
 		}
 		if (this.waitTimeOut != null) {
 			simpleMessageListenerContainer.setWaitTimeOut(this.waitTimeOut);
+		}
+		if (this.queueStopTimeout != null) {
+			simpleMessageListenerContainer.setQueueStopTimeout(this.queueStopTimeout);
 		}
 		if (this.resourceIdResolver != null) {
 			simpleMessageListenerContainer.setResourceIdResolver(this.resourceIdResolver);

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/DeleteMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/DeleteMessageHandler.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Callback executed on SQS message deletion.
  *
- * @author Mete Alpaslan Katircioglu
+ * @author Mete Alpaslan Katırcıoğlu
  */
 class DeleteMessageHandler
 		implements AsyncHandler<DeleteMessageRequest, DeleteMessageResult> {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageAcknowledgment.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageAcknowledgment.java
@@ -23,7 +23,7 @@ import com.amazonaws.services.sqs.model.DeleteMessageRequest;
 
 /**
  * @author Alain Sahli
- * @author Mete Alpaslan Katircioglu
+ * @author Mete Alpaslan Katırcıoğlu
  * @since 1.1
  */
 public class QueueMessageAcknowledgment implements Acknowledgment {

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainer.java
@@ -40,7 +40,7 @@ import static org.springframework.cloud.aws.messaging.core.QueueMessageUtils.cre
 /**
  * @author Agim Emruli
  * @author Alain Sahli
- * @author Mete Alpaslan Katircioglu
+ * @author Mete Alpaslan Katırcıoğlu
  * @since 1.0
  */
 public class SimpleMessageListenerContainer extends AbstractMessageListenerContainer {
@@ -54,7 +54,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private long backOffTime = 10000;
 
-	private long queueStopTimeout = 10000;
+	private long queueStopTimeout = 20000;
 
 	private AsyncTaskExecutor taskExecutor;
 
@@ -100,7 +100,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	/**
 	 * The number of milliseconds the {@link SimpleMessageListenerContainer#stop(String)}
 	 * method waits for a queue to stop before interrupting the current thread. Default
-	 * value is 10000 milliseconds (10 seconds).
+	 * value is 20000 milliseconds (20 seconds).
 	 * @param queueStopTimeout in milliseconds
 	 */
 	public void setQueueStopTimeout(long queueStopTimeout) {

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/annotation/SqsConfigurationTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.withSettings;
 /**
  * @author Alain Sahli
  * @author Maciej Walkowiak
+ * @author Mete Alpaslan Katırcıoğlu
  */
 class SqsConfigurationTest {
 
@@ -160,6 +161,8 @@ class SqsConfigurationTest {
 				.isEqualTo(ConfigurationWithCustomContainerFactory.VISIBILITY_TIMEOUT);
 		assertThat(ReflectionTestUtils.getField(container, "waitTimeOut"))
 				.isEqualTo(ConfigurationWithCustomContainerFactory.WAIT_TIME_OUT);
+		assertThat(ReflectionTestUtils.getField(container, "queueStopTimeout"))
+				.isEqualTo(ConfigurationWithCustomContainerFactory.QUEUE_STOP_TIME_OUT);
 		assertThat(
 				ConfigurationWithCustomContainerFactory.DESTINATION_RESOLVER == ReflectionTestUtils
 						.getField(container, "destinationResolver")).isTrue();
@@ -334,6 +337,8 @@ class SqsConfigurationTest {
 
 		static final int WAIT_TIME_OUT = 12;
 
+		static final long QUEUE_STOP_TIME_OUT = 12;
+
 		static final DestinationResolver<String> DESTINATION_RESOLVER = new DynamicQueueUrlDestinationResolver(
 				mock(AmazonSQSAsync.class, withSettings().stubOnly()));
 
@@ -356,6 +361,7 @@ class SqsConfigurationTest {
 			factory.setTaskExecutor(TASK_EXECUTOR);
 			factory.setVisibilityTimeout(VISIBILITY_TIMEOUT);
 			factory.setWaitTimeOut(WAIT_TIME_OUT);
+			factory.setQueueStopTimeout(QUEUE_STOP_TIME_OUT);
 			factory.setDestinationResolver(DESTINATION_RESOLVER);
 			factory.setBackOffTime(BACK_OFF_TIME);
 

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/listener/SimpleMessageListenerContainerTest.java
@@ -83,6 +83,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 /**
  * @author Agim Emruli
  * @author Alain Sahli
+ * @author Mete Alpaslan Katırcıoğlu
  * @since 1.0
  */
 class SimpleMessageListenerContainerTest {
@@ -1270,7 +1271,7 @@ class SimpleMessageListenerContainerTest {
 				.isTrue();
 		assertThat(stopWatch
 				.getTotalTimeMillis() < LongRunningListenerMethod.LISTENER_METHOD_WAIT_TIME)
-						.as("stop must last less than the listener method (< 10000ms)")
+						.as("stop must last less than the listener method (< 20000ms)")
 						.isTrue();
 		container.stop();
 	}
@@ -1621,7 +1622,7 @@ class SimpleMessageListenerContainerTest {
 
 	private static class LongRunningListenerMethod {
 
-		private static final int LISTENER_METHOD_WAIT_TIME = 10000;
+		private static final int LISTENER_METHOD_WAIT_TIME = 20000;
 
 		private final CountDownLatch countDownLatch = new CountDownLatch(1);
 


### PR DESCRIPTION
* Allow queueStopTimeout can be configurable via SimpleMessageListenerContainerFactory #gh-504
* Increase queueStopTimeout default value in milliseconds to be equal to waitTimeOut #gh-507