### PR TITLE
Handling custom type labels in headers from Binary/String message attributes. Fix gh-410 [v2].

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -1130,10 +1130,9 @@ annotations. `@Header` is used to inject a specific header value while `@Headers
 containing all headers.
 
 Only the link:https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
-message attributes] sent with an SQS message are fully supported. Custom attributes are handled only partially.
-Custom message attribute value is resolved only by using mandatory type part without custom label (type name without label after '.')
-Custom type label is skipped during conversion to header value.
-(You can still access original message and custom labels using `sourceData` message header)
+message attributes] sent with an SQS message are fully supported.
+Custom message attributes are handled as if custom type label (everything after '.' in type name) wasn't present in attribute key.
+It is silently omitted during conversion, but still can be accessed as long as original message is present in 'sourceData' header.
 
 In addition to the provided argument resolvers, custom ones can be registered on the
 `aws-messaging:annotation-driven-queue-listener` element using the `aws-messaging:argument-resolvers` attribute (see example below).

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -1130,7 +1130,10 @@ annotations. `@Header` is used to inject a specific header value while `@Headers
 containing all headers.
 
 Only the link:https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html[standard
-message attributes] sent with an SQS message are supported. Custom attributes are currently not supported.
+message attributes] sent with an SQS message are fully supported. Custom attributes are handled only partially.
+Custom message attribute value is resolved only by using mandatory type part without custom label (type name without label after '.')
+Custom type label is skipped during conversion to header value.
+(You can still access original message and custom labels using `sourceData` message header)
 
 In addition to the provided argument resolvers, custom ones can be registered on the
 `aws-messaging:annotation-driven-queue-listener` element using the `aws-messaging:argument-resolvers` attribute (see example below).

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/core/QueueMessageUtils.java
@@ -112,8 +112,8 @@ public final class QueueMessageUtils {
 				messageHeaders.put(MessageHeaders.ID,
 						UUID.fromString(messageAttribute.getValue().getStringValue()));
 			}
-			else if (MessageAttributeDataTypes.STRING
-					.equals(messageAttribute.getValue().getDataType())) {
+			else if (messageAttribute.getValue().getDataType()
+					.startsWith(MessageAttributeDataTypes.STRING)) {
 				messageHeaders.put(messageAttribute.getKey(),
 						messageAttribute.getValue().getStringValue());
 			}
@@ -122,8 +122,8 @@ public final class QueueMessageUtils {
 				messageHeaders.put(messageAttribute.getKey(),
 						getNumberValue(messageAttribute.getValue()));
 			}
-			else if (MessageAttributeDataTypes.BINARY
-					.equals(messageAttribute.getValue().getDataType())) {
+			else if (messageAttribute.getValue().getDataType()
+					.startsWith(MessageAttributeDataTypes.BINARY)) {
 				messageHeaders.put(messageAttribute.getKey(),
 						messageAttribute.getValue().getBinaryValue());
 			}


### PR DESCRIPTION
This is another approach to solve gh-410.
First approach is here: https://github.com/spring-cloud/spring-cloud-aws/pull/633.
Original issue and discussion is here: https://github.com/spring-cloud/spring-cloud-aws/issues/410