### PR TITLE
Depend on `core` module only in Secrets Manager and Parameter Store integrations.

### DIFF
--- a/spring-cloud-starter-aws-parameter-store-config/pom.xml
+++ b/spring-cloud-starter-aws-parameter-store-config/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
+			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-starter-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager-config/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
+			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Both Secrets Manager and Parameter Store modules should not depend on `autoconfigure` as it brings dependency to `context` and triggers other potentially unwanted auto-configurations.

Since Secrets Manager and Parameter Store must have now access to `SpringCloudClientConfiguration` its enough to make both of these modules depend on the `core` module instead of `autoconfigure`.

Fixes gh-650
Closes gh-653