### PR TITLE
Changed the  Charset from WebUtils.DEFAULT_CHARACTER_ENCODING to Charset.defaultCharset() to support UTF-8

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
@@ -127,7 +127,7 @@ public class NotificationMessageHandlerMethodArgumentResolver
 
 		private Charset getCharset() {
 			return this.mediaType.getCharset() != null ? this.mediaType.getCharset()
-					: Charset.forName(WebUtils.DEFAULT_CHARACTER_ENCODING);
+					: Charset.defaultCharset();
 		}
 
 		@Override


### PR DESCRIPTION
Currently this is not supporting the special characters as the default encoding is ISO-8859-1. 
Changed the default charset from WebUtils.DEFAULT_CHARACTER_ENCODING to Charset.defaultCharset() to include support for UTF-8. 