### PR TITLE
Fix the ability to provide custom S3 client for resource resolution.

### DIFF
--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -61,7 +61,6 @@ public class ContextResourceLoaderConfiguration {
 		protected BeanDefinition getProtocolResolver(BeanDefinitionHolder client) {
 			BeanDefinitionBuilder resolver = BeanDefinitionBuilder
 					.rootBeanDefinition(SimpleStorageProtocolResolver.class);
-			resolver.addConstructorArgReference(client.getBeanName());
 
 			BeanDefinition taskExecutor = getTaskExecutorDefinition();
 			if (taskExecutor != null) {

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/SimpleStorageProtocolResolverConfigurerIntegrationTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/support/io/SimpleStorageProtocolResolverConfigurerIntegrationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.support.io;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.aop.framework.Advised;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.aws.context.config.annotation.EnableContextResourceLoader;
+import org.springframework.cloud.aws.core.io.s3.SimpleStorageResource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class SimpleStorageProtocolResolverConfigurerIntegrationTest {
+
+	@Autowired
+	@Qualifier("configurationLoadedResource")
+	private Resource resource;
+
+	@Value("s3://foo/bar.txt")
+	private Resource fieldResource;
+
+	@Autowired
+	private ResourceLoader resourceLoader;
+
+	@Test
+	public void configurationClassAnnotatedResourceResolvesToS3Resource()
+			throws Exception {
+		assertThat(((Advised) resource).getTargetSource().getTarget())
+				.isInstanceOf(SimpleStorageResource.class);
+	}
+
+	@Test
+	public void valueAnnotatedResourceResolvesToS3Resource() {
+		assertThat(fieldResource).isInstanceOf(SimpleStorageResource.class);
+	}
+
+	@Test
+	public void resourceLoadedResourceIsS3Resource() {
+		assertThat(resourceLoader.getResource("s3://foo/bar.txt"))
+				.isInstanceOf(SimpleStorageResource.class);
+	}
+
+	@Configuration
+	@EnableContextResourceLoader
+	static class Config {
+
+		@Value("s3://foo/bar.txt")
+		@Lazy
+		private Resource resource;
+
+		@Bean
+		public Resource configurationLoadedResource() {
+			return resource;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.aws.core.io.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
 import org.springframework.core.io.ProtocolResolver;
@@ -31,9 +34,10 @@ import org.springframework.core.task.TaskExecutor;
  * @author Alain Sahli
  * @since 1.0
  */
-public class SimpleStorageProtocolResolver implements ProtocolResolver, InitializingBean {
+public class SimpleStorageProtocolResolver
+		implements ProtocolResolver, InitializingBean, BeanFactoryAware {
 
-	private final AmazonS3 amazonS3;
+	private AmazonS3 amazonS3;
 
 	/**
 	 * <b>IMPORTANT:</b> If a task executor is set with an unbounded queue there will be a
@@ -42,7 +46,16 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 	 */
 	private TaskExecutor taskExecutor;
 
-	public SimpleStorageProtocolResolver(AmazonS3 amazonS3) {
+	private BeanFactory beanFactory;
+
+	public SimpleStorageProtocolResolver() {
+	}
+
+	/**
+	 * Used only for testing.
+	 * @param amazonS3 - the Amazon S3 client.
+	 */
+	SimpleStorageProtocolResolver(AmazonS3 amazonS3) {
 		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 	}
 
@@ -61,7 +74,7 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 	@Override
 	public Resource resolve(String location, ResourceLoader resourceLoader) {
 		if (SimpleStorageNameUtils.isSimpleStorageResource(location)) {
-			return new SimpleStorageResource(this.amazonS3,
+			return new SimpleStorageResource(this.getAmazonS3(),
 					SimpleStorageNameUtils.getBucketNameFromLocation(location),
 					SimpleStorageNameUtils.getObjectNameFromLocation(location),
 					this.taskExecutor,
@@ -73,7 +86,16 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 	}
 
 	public AmazonS3 getAmazonS3() {
+		if (this.amazonS3 == null) {
+			this.amazonS3 = AmazonS3ProxyFactory
+					.createProxy(this.beanFactory.getBean(AmazonS3.class));
+		}
 		return this.amazonS3;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
 	}
 
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -199,6 +199,10 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 				this.taskExecutor);
 	}
 
+	public AmazonS3 getAmazonS3() {
+		return amazonS3;
+	}
+
 	private ObjectMetadata getObjectMetadata() {
 		if (this.objectMetadata == null) {
 			try {

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/CustomS3ClientTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/context/support/io/CustomS3ClientTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.support.io;
+
+import javax.annotation.PostConstruct;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.aws.context.config.annotation.EnableContextResourceLoader;
+import org.springframework.cloud.aws.core.io.s3.SimpleStorageResource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that it is possible to overwrite {@link AmazonS3} client used by
+ * {@link SimpleStorageResource}. Related issues: -
+ * {@see https://github.com/spring-cloud/spring-cloud-aws/issues/640} -
+ * {@see https://github.com/spring-cloud/spring-cloud-aws/issues/348}
+ */
+@SpringBootTest(classes = CustomS3ClientTest.Config.class,
+		properties = { "s3.access=xxx", "s3.secret=yyy" })
+public class CustomS3ClientTest {
+
+	@Autowired
+	private SomeComponent someComponent;
+
+	@Test
+	public void resolvedResourceUsesCustomConfiguredAmazonS3Bean() {
+		assertThat(someComponent.resource).isInstanceOf(SimpleStorageResource.class);
+
+		// check if configuration properties provided credentials are really passed to
+		// Amazon S3 client used by resource resolver
+		SimpleStorageResource s3Resource = (SimpleStorageResource) someComponent.resource;
+		AWSStaticCredentialsProvider chain = (AWSStaticCredentialsProvider) ReflectionTestUtils
+				.getField(s3Resource.getAmazonS3(), "awsCredentialsProvider");
+		assertThat(chain.getCredentials().getAWSSecretKey()).isEqualTo("yyy");
+		assertThat(chain.getCredentials().getAWSAccessKeyId()).isEqualTo("xxx");
+	}
+
+	@Component
+	static class SomeComponent {
+
+		private final ResourceLoader resourceLoader;
+
+		private Resource resource;
+
+		SomeComponent(ResourceLoader resourceLoader) {
+			this.resourceLoader = resourceLoader;
+		}
+
+		@PostConstruct
+		void init() {
+			this.resource = resourceLoader.getResource("s3://foo/bar.txt");
+		}
+
+	}
+
+	@SpringBootConfiguration
+	@EnableContextResourceLoader
+	@EnableConfigurationProperties(S3Properties.class)
+	@Import(SomeComponent.class)
+	static class Config {
+
+		/**
+		 * Overwrites default S3 client and uses {@link ConfigurationProperties} annotated
+		 * class to build custom client. Makes sure that instance is created after
+		 * configuration properties are bound.
+		 * @param s3Properties - s3 properties
+		 * @return custom Amazon S3 client.
+		 */
+		@Bean
+		@Primary
+		public AmazonS3 customAmazonS3(S3Properties s3Properties) {
+			AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(
+					new BasicAWSCredentials(s3Properties.getAccess(),
+							s3Properties.getSecret()));
+
+			return AmazonS3ClientBuilder.standard().withCredentials(credentialsProvider)
+					.build();
+		}
+
+	}
+
+	@ConfigurationProperties("s3")
+	static class S3Properties {
+
+		private String secret;
+
+		private String access;
+
+		public String getSecret() {
+			return secret;
+		}
+
+		public void setSecret(String secret) {
+			this.secret = secret;
+		}
+
+		public String getAccess() {
+			return access;
+		}
+
+		public void setAccess(String access) {
+			this.access = access;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Resolve AmazonS3 client when the first resource is loaded - leaving time for custom AmazonS3 bean to be created.

Fixes gh-640
Fixes gh-641

Introduced when fixing gh-348.