### PR TITLE
Change the default charset to  UTF-8 to support Special Characters

### DIFF
--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/endpoint/NotificationMessageHandlerMethodArgumentResolver.java
@@ -127,7 +127,7 @@ public class NotificationMessageHandlerMethodArgumentResolver
 
 		private Charset getCharset() {
 			return this.mediaType.getCharset() != null ? this.mediaType.getCharset()
-					: Charset.forName(WebUtils.DEFAULT_CHARACTER_ENCODING);
+					: Charset.defaultCharset();
 		}
 
 		@Override


### PR DESCRIPTION
Charset.forName(WebUtils.DEFAULT_CHARACTER_ENCODING) to
Charset.defaultCharset() to support special characters using UTF-8