### PR TITLE
Fix conditional on SimpleEmailAutoConfiguration

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfiguration.java
@@ -76,7 +76,7 @@ public class SimpleEmailAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingClass("org.springframework.cloud.aws.mail.simplemail.SimpleEmailServiceJavaMailSender")
+	@ConditionalOnMissingClass("javax.mail.Session")
 	public MailSender simpleMailSender(
 			AmazonSimpleEmailService amazonSimpleEmailService) {
 		return new SimpleEmailServiceMailSender(amazonSimpleEmailService);

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -63,6 +64,17 @@ class SimpleEmailAutoConfigurationTest {
 
 					Object region = ReflectionTestUtils.getField(client, "signingRegion");
 					assertThat(region).isEqualTo(Regions.US_EAST_1.getName());
+				});
+	}
+
+	@Test
+	void mailSenderWithSimpleEmail() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("javax.mail.Session"))
+				.run(context -> {
+					assertThat(context.getBean(MailSender.class)).isNotNull();
+					assertThat(context.getBean("simpleMailSender")).isNotNull();
+					assertThat(context.getBean("simpleMailSender"))
+							.isSameAs(context.getBean(MailSender.class));
 				});
 	}
 


### PR DESCRIPTION
Currently, `simpleMailSender` bean is activated when `SimpleEmailServiceJavaMailSender`
is not in the classpath but the bean itself depends on one class
in the same package that `SimpleEmailServiceJavaMailSender`.
This commit improves the condition by activating when `javax.mailSession`
is not in the classpath.