### PR TITLE
Add new parameter-store module and starter

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -29,5 +29,12 @@
 |cloud.aws.sqs.region || The specific region for SQS integration.
 |cloud.aws.stack.auto | true | Enables the automatic stack name detection for the application.
 |cloud.aws.stack.name |  | The name of the manually configured stack name that will be used to retrieve the resources.
+|spring.cloud.aws.parameterstore.default-context | application |
+|spring.cloud.aws.parameterstore.enabled | true | Is AWS Parameter Store support enabled.
+|spring.cloud.aws.parameterstore.fail-fast | true | Throw exceptions during config lookup if true, otherwise, log warnings.
+|spring.cloud.aws.parameterstore.name |  | Alternative to spring.application.name to use in looking up values in AWS Parameter Store.
+|spring.cloud.aws.parameterstore.prefix | /config | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
+|spring.cloud.aws.parameterstore.profile-separator | _ |
+|spring.cloud.aws.parameterstore.region |  | The specific region for Parameter Store integration.
 
 |===

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -707,6 +707,49 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 |`aws.paramstore.enabled`
 |`true`
 |Can be used to disable the Parameter Store Configuration support even though the auto-configuration is on the classpath.
+
+|`aws.paramstore.region`
+|`_`
+|The specific region for Parameter Store integration.
+|===
+
+There is a new starter `spring-cloud-starter-aws-parameter-store` and it offers new configuration properties.
+
+[cols="3*", options="header"]
+|===
+|property
+|default
+|explanation
+
+|`spring.cloud.aws.parameterstore.prefix`
+|`/config`
+|Prefix indicating first level for every property loaded from the Parameter Store.
+Value must start with a forward slash followed by one or more valid path segments or be empty.
+
+|`spring.cloud.aws.parameterstore.defaultContext`
+|`application`
+|Name of the context that defines properties shared across all services
+
+|`spring.cloud.aws.parameterstore.profileSeparator`
+|`_`
+|String that separates an appended profile from the context name. Can only contain
+dots, dashes, forward slashes, backward slashes and underscores next to alphanumeric characters.
+
+|`spring.cloud.aws.parameterstore.failFast`
+|`true`
+|Indicates if an error while retrieving the parameters should fail starting the application.
+
+|`spring.cloud.aws.parameterstore.name`
+|the configured value for `spring.application.name`
+|Name to use when constructing the path for the properties to look up for this specific service.
+
+|`spring.cloud.aws.parameterstore.enabled`
+|`true`
+|Can be used to disable the Parameter Store Configuration support even though the auto-configuration is on the classpath.
+
+|`spring.cloud.aws.parameterstore.region`
+|`_`
+|The specific region for Parameter Store integration.
 |===
 
 [TIP]

--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,13 @@
 		<module>spring-cloud-aws-jdbc</module>
 		<module>spring-cloud-aws-messaging</module>
 		<module>spring-cloud-aws-autoconfigure</module>
+		<module>spring-cloud-aws-parameter-store</module>
 		<module>spring-cloud-aws-parameter-store-config</module>
 		<module>spring-cloud-aws-secrets-manager-config</module>
 		<module>spring-cloud-starter-aws</module>
 		<module>spring-cloud-starter-aws-jdbc</module>
 		<module>spring-cloud-starter-aws-messaging</module>
+		<module>spring-cloud-starter-aws-parameter-store</module>
 		<module>spring-cloud-starter-aws-parameter-store-config</module>
 		<module>spring-cloud-starter-aws-secrets-manager-config</module>
 		<module>spring-cloud-aws-integration-test</module>

--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -45,7 +45,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
+			<artifactId>spring-cloud-aws-parameter-store</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfiguration.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.config;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientFactoryBean;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
+import org.springframework.cloud.aws.parameterstore.AwsParamStorePropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Cloud Bootstrap Configuration for setting up an
+ * {@link AwsParamStorePropertySourceLocator} and its dependencies.
+ *
+ * @author Joris Kuipers
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(ParameterStoreProperties.class)
+@ConditionalOnMissingClass("org.springframework.cloud.aws.autoconfigure.paramstore.AwsParamStoreBootstrapConfiguration")
+@ConditionalOnClass({ AWSSimpleSystemsManagement.class,
+		AwsParamStorePropertySourceLocator.class })
+@ConditionalOnProperty(prefix = "spring.cloud.aws.parameterstore", name = "enabled",
+		matchIfMissing = true)
+public class AwsParameterStoreBootstrapConfiguration {
+
+	private final RegionProvider regionProvider;
+
+	private final ParameterStoreProperties properties;
+
+	public AwsParameterStoreBootstrapConfiguration(ParameterStoreProperties properties,
+			ObjectProvider<RegionProvider> regionProvider) {
+		this.regionProvider = properties.getRegion() == null
+				? regionProvider.getIfAvailable()
+				: new StaticRegionProvider(properties.getRegion());
+		this.properties = properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AmazonWebserviceClientFactoryBean<AWSSimpleSystemsManagementClient> ssmClient() {
+		return new AmazonWebserviceClientFactoryBean<>(
+				AWSSimpleSystemsManagementClient.class, null, this.regionProvider);
+	}
+
+	@Bean
+	public AwsParamStorePropertySourceLocator awsParamStorePropertySourceLocator(
+			AWSSimpleSystemsManagement ssmClient) {
+		AwsParamStorePropertySourceLocator propertySourceLocator = new AwsParamStorePropertySourceLocator(
+				ssmClient);
+		propertySourceLocator.setName(this.properties.getName());
+		propertySourceLocator.setPrefix(this.properties.getPrefix());
+		propertySourceLocator.setDefaultContext(this.properties.getDefaultContext());
+		propertySourceLocator.setFailFast(this.properties.isFailFast());
+		propertySourceLocator.setProfileSeparator(this.properties.getProfileSeparator());
+
+		return propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfiguration.java
@@ -44,10 +44,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(ParameterStoreProperties.class)
 @ConditionalOnMissingClass("org.springframework.cloud.aws.autoconfigure.paramstore.AwsParamStoreBootstrapConfiguration")
-@ConditionalOnClass({ AWSSimpleSystemsManagement.class,
-		AwsParamStorePropertySourceLocator.class })
-@ConditionalOnProperty(prefix = "spring.cloud.aws.parameterstore", name = "enabled",
-		matchIfMissing = true)
+@ConditionalOnClass({ AWSSimpleSystemsManagement.class, AwsParamStorePropertySourceLocator.class })
+@ConditionalOnProperty(prefix = "spring.cloud.aws.parameterstore", name = "enabled", matchIfMissing = true)
 public class AwsParameterStoreBootstrapConfiguration {
 
 	private final RegionProvider regionProvider;
@@ -56,8 +54,7 @@ public class AwsParameterStoreBootstrapConfiguration {
 
 	public AwsParameterStoreBootstrapConfiguration(ParameterStoreProperties properties,
 			ObjectProvider<RegionProvider> regionProvider) {
-		this.regionProvider = properties.getRegion() == null
-				? regionProvider.getIfAvailable()
+		this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()
 				: new StaticRegionProvider(properties.getRegion());
 		this.properties = properties;
 	}
@@ -65,15 +62,13 @@ public class AwsParameterStoreBootstrapConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AmazonWebserviceClientFactoryBean<AWSSimpleSystemsManagementClient> ssmClient() {
-		return new AmazonWebserviceClientFactoryBean<>(
-				AWSSimpleSystemsManagementClient.class, null, this.regionProvider);
+		return new AmazonWebserviceClientFactoryBean<>(AWSSimpleSystemsManagementClient.class, null,
+				this.regionProvider);
 	}
 
 	@Bean
-	public AwsParamStorePropertySourceLocator awsParamStorePropertySourceLocator(
-			AWSSimpleSystemsManagement ssmClient) {
-		AwsParamStorePropertySourceLocator propertySourceLocator = new AwsParamStorePropertySourceLocator(
-				ssmClient);
+	public AwsParamStorePropertySourceLocator awsParamStorePropertySourceLocator(AWSSimpleSystemsManagement ssmClient) {
+		AwsParamStorePropertySourceLocator propertySourceLocator = new AwsParamStorePropertySourceLocator(ssmClient);
 		propertySourceLocator.setName(this.properties.getName());
 		propertySourceLocator.setPrefix(this.properties.getPrefix());
 		propertySourceLocator.setDefaultContext(this.properties.getDefaultContext());

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/ParameterStoreProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/ParameterStoreProperties.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.config;
+
+import java.util.regex.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * Configuration properties for the AWS Parameter Store integration.
+ *
+ * @author Joris Kuipers
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+@ConfigurationProperties(prefix = "spring.cloud.aws.parameterstore")
+public class ParameterStoreProperties implements Validator {
+
+	/**
+	 * Pattern used for prefix validation.
+	 */
+	private static final Pattern PREFIX_PATTERN = Pattern
+			.compile("(/[a-zA-Z0-9.\\-_]+)*");
+
+	/**
+	 * Pattern used for profileSeparator validation.
+	 */
+	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern
+			.compile("[a-zA-Z0-9.\\-_/\\\\]+");
+
+	/**
+	 * Prefix indicating first level for every property. Value must start with a forward
+	 * slash followed by a valid path segment or be empty. Defaults to "/config".
+	 */
+	private String prefix = "/config";
+
+	private String defaultContext = "application";
+
+	private String profileSeparator = "_";
+
+	/**
+	 * If region value is not null or empty it will be used in creation of
+	 * AWSSimpleSystemsManagement.
+	 */
+	private String region;
+
+	/** Throw exceptions during config lookup if true, otherwise, log warnings. */
+	private boolean failFast = true;
+
+	/**
+	 * Alternative to spring.application.name to use in looking up values in AWS Parameter
+	 * Store.
+	 */
+	private String name;
+
+	/** Is AWS Parameter Store support enabled. */
+	private boolean enabled = true;
+
+	@Override
+	public boolean supports(Class clazz) {
+		return ParameterStoreProperties.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	public void validate(Object target, Errors errors) {
+		ParameterStoreProperties properties = (ParameterStoreProperties) target;
+
+		if (StringUtils.isEmpty(properties.getPrefix())) {
+			errors.rejectValue("prefix", "NotEmpty",
+					"prefix should not be empty or null.");
+		}
+
+		if (StringUtils.isEmpty(properties.getDefaultContext())) {
+			errors.rejectValue("defaultContext", "NotEmpty",
+					"defaultContext should not be empty or null.");
+		}
+
+		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
+			errors.rejectValue("profileSeparator", "NotEmpty",
+					"profileSeparator should not be empty or null.");
+		}
+
+		if (!PREFIX_PATTERN.matcher(properties.getPrefix()).matches()) {
+			errors.rejectValue("prefix", "Pattern",
+					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+		}
+		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator())
+				.matches()) {
+			errors.rejectValue("profileSeparator", "Pattern",
+					"The profileSeparator must have pattern of:  "
+							+ PROFILE_SEPARATOR_PATTERN.toString());
+		}
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getDefaultContext() {
+		return defaultContext;
+	}
+
+	public void setDefaultContext(String defaultContext) {
+		this.defaultContext = defaultContext;
+	}
+
+	public String getProfileSeparator() {
+		return profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getRegion() {
+		return region;
+	}
+
+	public void setRegion(final String region) {
+		this.region = region;
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/ParameterStoreProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/config/ParameterStoreProperties.java
@@ -37,14 +37,12 @@ public class ParameterStoreProperties implements Validator {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern
-			.compile("(/[a-zA-Z0-9.\\-_]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/[a-zA-Z0-9.\\-_]+)*");
 
 	/**
 	 * Pattern used for profileSeparator validation.
 	 */
-	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern
-			.compile("[a-zA-Z0-9.\\-_/\\\\]+");
+	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-_/\\\\]+");
 
 	/**
 	 * Prefix indicating first level for every property. Value must start with a forward
@@ -84,29 +82,23 @@ public class ParameterStoreProperties implements Validator {
 		ParameterStoreProperties properties = (ParameterStoreProperties) target;
 
 		if (StringUtils.isEmpty(properties.getPrefix())) {
-			errors.rejectValue("prefix", "NotEmpty",
-					"prefix should not be empty or null.");
+			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getDefaultContext())) {
-			errors.rejectValue("defaultContext", "NotEmpty",
-					"defaultContext should not be empty or null.");
+			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
-			errors.rejectValue("profileSeparator", "NotEmpty",
-					"profileSeparator should not be empty or null.");
+			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
 		}
 
 		if (!PREFIX_PATTERN.matcher(properties.getPrefix()).matches()) {
-			errors.rejectValue("prefix", "Pattern",
-					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+			errors.rejectValue("prefix", "Pattern", "The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
 		}
-		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator())
-				.matches()) {
+		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator()).matches()) {
 			errors.rejectValue("profileSeparator", "Pattern",
-					"The profileSeparator must have pattern of:  "
-							+ PROFILE_SEPARATOR_PATTERN.toString());
+					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "defaultValue": true,
-      "name": "spring.cloud.aws.parameterstore,.enabled",
+      "name": "spring.cloud.aws.parameterstore.enabled",
       "description": "Enables ParameterStore integration.",
       "type": "java.lang.Boolean"
     }

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -47,6 +47,12 @@
       "name": "cloud.aws.stack.enabled",
       "description": "Enables Stack integration.",
       "type": "java.lang.Boolean"
+    },
+    {
+      "defaultValue": true,
+      "name": "spring.cloud.aws.parameterstore,.enabled",
+      "description": "Enables ParameterStore integration.",
+      "type": "java.lang.Boolean"
     }
   ]
 }

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,6 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+org.springframework.cloud.aws.autoconfigure.config.AwsParameterStoreBootstrapConfiguration
+
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration,\

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfigurationTest.java
@@ -35,14 +35,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AwsParameterStoreBootstrapConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(
-					AutoConfigurations.of(AwsParameterStoreBootstrapConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(AwsParameterStoreBootstrapConfiguration.class));
 
 	@Test
 	void testWithDefaultRegion() {
 		this.contextRunner.run(context -> {
-			AWSSimpleSystemsManagementClient client = context
-					.getBean(AWSSimpleSystemsManagementClient.class);
+			AWSSimpleSystemsManagementClient client = context.getBean(AWSSimpleSystemsManagementClient.class);
 			Object region = ReflectionTestUtils.getField(client, "signingRegion");
 			assertThat(region).isEqualTo(Regions.DEFAULT_REGION.getName());
 		});
@@ -50,23 +48,18 @@ class AwsParameterStoreBootstrapConfigurationTest {
 
 	@Test
 	void testWithStaticRegion() {
-		this.contextRunner
-				.withPropertyValues("spring.cloud.aws.parameterstore.region:us-east-1")
-				.run(context -> {
-					AWSSimpleSystemsManagementClient client = context
-							.getBean(AWSSimpleSystemsManagementClient.class);
-					Object region = ReflectionTestUtils.getField(client, "signingRegion");
-					assertThat(region).isEqualTo("us-east-1");
-				});
+		this.contextRunner.withPropertyValues("spring.cloud.aws.parameterstore.region:us-east-1").run(context -> {
+			AWSSimpleSystemsManagementClient client = context.getBean(AWSSimpleSystemsManagementClient.class);
+			Object region = ReflectionTestUtils.getField(client, "signingRegion");
+			assertThat(region).isEqualTo("us-east-1");
+		});
 	}
 
 	@Test
 	void testUserAgent() {
 		this.contextRunner.run(context -> {
-			AWSSimpleSystemsManagementClient client = context
-					.getBean(AWSSimpleSystemsManagementClient.class);
-			assertThat(client.getClientConfiguration().getUserAgentSuffix())
-					.startsWith("spring-cloud-aws/");
+			AWSSimpleSystemsManagementClient client = context.getBean(AWSSimpleSystemsManagementClient.class);
+			assertThat(client.getClientConfiguration().getUserAgentSuffix()).startsWith("spring-cloud-aws/");
 		});
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/config/AwsParameterStoreBootstrapConfigurationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.config;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link AwsParameterStoreBootstrapConfiguration}.
+ *
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ */
+class AwsParameterStoreBootstrapConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(AwsParameterStoreBootstrapConfiguration.class));
+
+	@Test
+	void testWithDefaultRegion() {
+		this.contextRunner.run(context -> {
+			AWSSimpleSystemsManagementClient client = context
+					.getBean(AWSSimpleSystemsManagementClient.class);
+			Object region = ReflectionTestUtils.getField(client, "signingRegion");
+			assertThat(region).isEqualTo(Regions.DEFAULT_REGION.getName());
+		});
+	}
+
+	@Test
+	void testWithStaticRegion() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.aws.parameterstore.region:us-east-1")
+				.run(context -> {
+					AWSSimpleSystemsManagementClient client = context
+							.getBean(AWSSimpleSystemsManagementClient.class);
+					Object region = ReflectionTestUtils.getField(client, "signingRegion");
+					assertThat(region).isEqualTo("us-east-1");
+				});
+	}
+
+	@Test
+	void testUserAgent() {
+		this.contextRunner.run(context -> {
+			AWSSimpleSystemsManagementClient client = context
+					.getBean(AWSSimpleSystemsManagementClient.class);
+			assertThat(client.getClientConfiguration().getUserAgentSuffix())
+					.startsWith("spring-cloud-aws/");
+		});
+	}
+
+}

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -96,6 +96,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-aws-parameter-store</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-aws-parameter-store-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -127,6 +132,11 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-aws-autoconfigure</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-aws-parameter-store</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.paramstore;
 import java.util.regex.Pattern;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -29,6 +30,7 @@ import org.springframework.validation.Validator;
  *
  * @author Joris Kuipers
  * @author Matej Nedic
+ * @author Eddú Meléndez
  * @since 2.0.0
  */
 @ConfigurationProperties(AwsParamStoreProperties.CONFIG_PREFIX)
@@ -107,6 +109,7 @@ public class AwsParamStoreProperties implements Validator {
 		}
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.prefix")
 	public String getPrefix() {
 		return prefix;
 	}
@@ -115,6 +118,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.prefix = prefix;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.default-context")
 	public String getDefaultContext() {
 		return defaultContext;
 	}
@@ -123,6 +127,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.defaultContext = defaultContext;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.profile-separator")
 	public String getProfileSeparator() {
 		return profileSeparator;
 	}
@@ -131,6 +136,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.profileSeparator = profileSeparator;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.fail-fast")
 	public boolean isFailFast() {
 		return failFast;
 	}
@@ -139,6 +145,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.failFast = failFast;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.name")
 	public String getName() {
 		return name;
 	}
@@ -147,6 +154,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.name = name;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.enabled")
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -155,6 +163,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.enabled = enabled;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.region")
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -109,8 +109,7 @@ public class AwsParamStoreProperties implements Validator {
 		}
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.prefix")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.prefix")
 	public String getPrefix() {
 		return prefix;
 	}
@@ -119,8 +118,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.prefix = prefix;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.default-context")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.default-context")
 	public String getDefaultContext() {
 		return defaultContext;
 	}
@@ -129,8 +127,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.defaultContext = defaultContext;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.profile-separator")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.profile-separator")
 	public String getProfileSeparator() {
 		return profileSeparator;
 	}
@@ -139,8 +136,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.profileSeparator = profileSeparator;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.fail-fast")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.fail-fast")
 	public boolean isFailFast() {
 		return failFast;
 	}
@@ -158,8 +154,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.name = name;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.enabled")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.enabled")
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -168,8 +163,7 @@ public class AwsParamStoreProperties implements Validator {
 		this.enabled = enabled;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.parameterstore.region")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.region")
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -109,7 +109,8 @@ public class AwsParamStoreProperties implements Validator {
 		}
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.prefix")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.prefix")
 	public String getPrefix() {
 		return prefix;
 	}
@@ -118,7 +119,8 @@ public class AwsParamStoreProperties implements Validator {
 		this.prefix = prefix;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.default-context")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.default-context")
 	public String getDefaultContext() {
 		return defaultContext;
 	}
@@ -127,7 +129,8 @@ public class AwsParamStoreProperties implements Validator {
 		this.defaultContext = defaultContext;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.profile-separator")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.profile-separator")
 	public String getProfileSeparator() {
 		return profileSeparator;
 	}
@@ -136,7 +139,8 @@ public class AwsParamStoreProperties implements Validator {
 		this.profileSeparator = profileSeparator;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.fail-fast")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.fail-fast")
 	public boolean isFailFast() {
 		return failFast;
 	}
@@ -154,7 +158,8 @@ public class AwsParamStoreProperties implements Validator {
 		this.name = name;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.enabled")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.enabled")
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -163,7 +168,8 @@ public class AwsParamStoreProperties implements Validator {
 		this.enabled = enabled;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.parameterstore.region")
+	@DeprecatedConfigurationProperty(
+			replacement = "spring.cloud.aws.parameterstore.region")
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-parameter-store/pom.xml
+++ b/spring-cloud-aws-parameter-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2013-2019 the original author or authors.
+  ~ Copyright 2013-2020 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -24,20 +25,14 @@
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
-	<name>Spring Cloud AWS Parameter Store Configuration (deprecated)</name>
-	<description>Spring Cloud AWS Parameter Store Configuration</description>
+	<artifactId>spring-cloud-aws-parameter-store</artifactId>
+	<name>Spring Cloud AWS Parameter Store</name>
+	<description>Spring Cloud AWS Parameter Store</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 
 		<dependency>
@@ -48,12 +43,6 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-ssm</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
 		</dependency>
 
 	</dependencies>

--- a/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySource.java
@@ -36,25 +36,22 @@ import org.springframework.core.env.EnumerablePropertySource;
  * @author Joris Kuipers
  * @since 2.3
  */
-public class AwsParamStorePropertySource
-		extends EnumerablePropertySource<AWSSimpleSystemsManagement> {
+public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSimpleSystemsManagement> {
 
-	private static final Logger LOGGER = LoggerFactory
-			.getLogger(AwsParamStorePropertySource.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(AwsParamStorePropertySource.class);
 
 	private String context;
 
 	private Map<String, Object> properties = new LinkedHashMap<>();
 
-	public AwsParamStorePropertySource(String context,
-			AWSSimpleSystemsManagement ssmClient) {
+	public AwsParamStorePropertySource(String context, AWSSimpleSystemsManagement ssmClient) {
 		super(context, ssmClient);
 		this.context = context;
 	}
 
 	public void init() {
-		GetParametersByPathRequest paramsRequest = new GetParametersByPathRequest()
-				.withPath(context).withRecursive(true).withWithDecryption(true);
+		GetParametersByPathRequest paramsRequest = new GetParametersByPathRequest().withPath(context)
+				.withRecursive(true).withWithDecryption(true);
 		getParameters(paramsRequest);
 	}
 
@@ -70,12 +67,10 @@ public class AwsParamStorePropertySource
 	}
 
 	private void getParameters(GetParametersByPathRequest paramsRequest) {
-		GetParametersByPathResult paramsResult = source
-				.getParametersByPath(paramsRequest);
+		GetParametersByPathResult paramsResult = source.getParametersByPath(paramsRequest);
 		for (Parameter parameter : paramsResult.getParameters()) {
 			String key = parameter.getName().replace(context, "").replace('/', '.');
-			LOGGER.debug("Populating property retrieved from AWS Parameter Store: {}",
-					key);
+			LOGGER.debug("Populating property retrieved from AWS Parameter Store: {}", key);
 			properties.put(key, parameter.getValue());
 		}
 		if (paramsResult.getNextToken() != null) {

--- a/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.parameterstore;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.core.env.EnumerablePropertySource;
+
+/**
+ * Recursively retrieves all parameters under the given context / path with decryption
+ * from the AWS Parameter Store using the provided SSM client.
+ *
+ * @author Joris Kuipers
+ * @since 2.3
+ */
+public class AwsParamStorePropertySource
+		extends EnumerablePropertySource<AWSSimpleSystemsManagement> {
+
+	private static final Logger LOGGER = LoggerFactory
+			.getLogger(AwsParamStorePropertySource.class);
+
+	private String context;
+
+	private Map<String, Object> properties = new LinkedHashMap<>();
+
+	public AwsParamStorePropertySource(String context,
+			AWSSimpleSystemsManagement ssmClient) {
+		super(context, ssmClient);
+		this.context = context;
+	}
+
+	public void init() {
+		GetParametersByPathRequest paramsRequest = new GetParametersByPathRequest()
+				.withPath(context).withRecursive(true).withWithDecryption(true);
+		getParameters(paramsRequest);
+	}
+
+	@Override
+	public String[] getPropertyNames() {
+		Set<String> strings = properties.keySet();
+		return strings.toArray(new String[strings.size()]);
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		return properties.get(name);
+	}
+
+	private void getParameters(GetParametersByPathRequest paramsRequest) {
+		GetParametersByPathResult paramsResult = source
+				.getParametersByPath(paramsRequest);
+		for (Parameter parameter : paramsResult.getParameters()) {
+			String key = parameter.getName().replace(context, "").replace('/', '.');
+			LOGGER.debug("Populating property retrieved from AWS Parameter Store: {}",
+					key);
+			properties.put(key, parameter.getValue());
+		}
+		if (paramsResult.getNextToken() != null) {
+			getParameters(paramsRequest.withNextToken(paramsResult.getNextToken()));
+		}
+	}
+
+}

--- a/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.parameterstore;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Builds a {@link CompositePropertySource} with various
+ * {@link AwsParamStorePropertySource} instances based on active profiles, application
+ * name and default context permutations. Mostly copied from Spring Cloud Consul's config
+ * support, but without the option to have full config files in a param value: with the
+ * AWS Parameter Store that wouldn't make sense, given the maximum size limit of 4096
+ * characters for a parameter value.
+ *
+ * @author Joris Kuipers
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class AwsParamStorePropertySourceLocator implements PropertySourceLocator {
+
+	private Log logger = LogFactory.getLog(getClass());
+
+	private final AWSSimpleSystemsManagement ssmClient;
+
+	private String name;
+
+	private String prefix = "/config";
+
+	private String defaultContext = "application";
+
+	private boolean failFast = false;
+
+	private String profileSeparator = "_";
+
+	private final Set<String> contexts = new LinkedHashSet<>();
+
+	public AwsParamStorePropertySourceLocator(AWSSimpleSystemsManagement ssmClient) {
+		this.ssmClient = ssmClient;
+	}
+
+	public List<String> getContexts() {
+		return new ArrayList<>(this.contexts);
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		if (!(environment instanceof ConfigurableEnvironment)) {
+			return null;
+		}
+
+		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
+
+		String appName = getName();
+
+		if (appName == null) {
+			appName = env.getProperty("spring.application.name");
+		}
+
+		List<String> profiles = Arrays.asList(env.getActiveProfiles());
+
+		String prefix = getPrefix();
+
+		String appContext = prefix + "/" + appName;
+		addProfiles(this.contexts, appContext, profiles);
+		this.contexts.add(appContext + "/");
+
+		String defaultContext = prefix + "/" + getDefaultContext();
+		addProfiles(this.contexts, defaultContext, profiles);
+		this.contexts.add(defaultContext + "/");
+
+		CompositePropertySource composite = new CompositePropertySource(
+				"aws-parameter-store");
+
+		for (String propertySourceContext : this.contexts) {
+			try {
+				composite.addPropertySource(create(propertySourceContext));
+			}
+			catch (Exception e) {
+				if (isFailFast()) {
+					logger.error(
+							"Fail fast is set and there was an error reading configuration from AWS Parameter Store:\n"
+									+ e.getMessage());
+					ReflectionUtils.rethrowRuntimeException(e);
+				}
+				else {
+					logger.warn("Unable to load AWS config from " + propertySourceContext,
+							e);
+				}
+			}
+		}
+
+		return composite;
+	}
+
+	private AwsParamStorePropertySource create(String context) {
+		AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(
+				context, this.ssmClient);
+		propertySource.init();
+		return propertySource;
+	}
+
+	private void addProfiles(Set<String> contexts, String baseContext,
+			List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + getProfileSeparator() + profile + "/");
+		}
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getDefaultContext() {
+		return defaultContext;
+	}
+
+	public void setDefaultContext(String defaultContext) {
+		this.defaultContext = defaultContext;
+	}
+
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
+	public String getProfileSeparator() {
+		return profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+}

--- a/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
@@ -137,7 +137,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	public String getName() {
-		return name;
+		return this.name;
 	}
 
 	public void setName(String name) {
@@ -145,7 +145,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	public String getPrefix() {
-		return prefix;
+		return this.prefix;
 	}
 
 	public void setPrefix(String prefix) {
@@ -153,7 +153,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	public String getDefaultContext() {
-		return defaultContext;
+		return this.defaultContext;
 	}
 
 	public void setDefaultContext(String defaultContext) {
@@ -161,7 +161,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	public boolean isFailFast() {
-		return failFast;
+		return this.failFast;
 	}
 
 	public void setFailFast(boolean failFast) {
@@ -169,7 +169,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	public String getProfileSeparator() {
-		return profileSeparator;
+		return this.profileSeparator;
 	}
 
 	public void setProfileSeparator(String profileSeparator) {

--- a/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store/src/main/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocator.java
@@ -98,8 +98,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 		addProfiles(this.contexts, defaultContext, profiles);
 		this.contexts.add(defaultContext + "/");
 
-		CompositePropertySource composite = new CompositePropertySource(
-				"aws-parameter-store");
+		CompositePropertySource composite = new CompositePropertySource("aws-parameter-store");
 
 		for (String propertySourceContext : this.contexts) {
 			try {
@@ -113,8 +112,7 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 					ReflectionUtils.rethrowRuntimeException(e);
 				}
 				else {
-					logger.warn("Unable to load AWS config from " + propertySourceContext,
-							e);
+					logger.warn("Unable to load AWS config from " + propertySourceContext, e);
 				}
 			}
 		}
@@ -123,14 +121,12 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 	}
 
 	private AwsParamStorePropertySource create(String context) {
-		AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(
-				context, this.ssmClient);
+		AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(context, this.ssmClient);
 		propertySource.init();
 		return propertySource;
 	}
 
-	private void addProfiles(Set<String> contexts, String baseContext,
-			List<String> profiles) {
+	private void addProfiles(Set<String> contexts, String baseContext, List<String> profiles) {
 		for (String profile : profiles) {
 			contexts.add(baseContext + getProfileSeparator() + profile + "/");
 		}

--- a/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocatorTest.java
+++ b/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocatorTest.java
@@ -48,11 +48,9 @@ public class AwsParamStorePropertySourceLocatorTest {
 	void contextExpectedToHave2Elements() {
 		GetParametersByPathResult firstResult = getFirstResult();
 		GetParametersByPathResult nextResult = getNextResult();
-		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
-				.thenReturn(firstResult, nextResult);
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class))).thenReturn(firstResult, nextResult);
 
-		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
-				ssmClient);
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(ssmClient);
 		locator.setPrefix("application");
 		locator.setName("application");
 		env.setActiveProfiles("test");
@@ -65,11 +63,9 @@ public class AwsParamStorePropertySourceLocatorTest {
 	void contextExpectedToHave4Elements() {
 		GetParametersByPathResult firstResult = getFirstResult();
 		GetParametersByPathResult nextResult = getNextResult();
-		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
-				.thenReturn(firstResult, nextResult);
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class))).thenReturn(firstResult, nextResult);
 
-		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
-				ssmClient);
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(ssmClient);
 		locator.setPrefix("application");
 		locator.setName("messaging-service");
 		env.setActiveProfiles("test");
@@ -82,11 +78,9 @@ public class AwsParamStorePropertySourceLocatorTest {
 	void contextSpecificOrderExpected() {
 		GetParametersByPathResult firstResult = getFirstResult();
 		GetParametersByPathResult nextResult = getNextResult();
-		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
-				.thenReturn(firstResult, nextResult);
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class))).thenReturn(firstResult, nextResult);
 
-		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
-				ssmClient);
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(ssmClient);
 		locator.setPrefix("application");
 		locator.setName("messaging-service");
 		env.setActiveProfiles("test");
@@ -94,8 +88,7 @@ public class AwsParamStorePropertySourceLocatorTest {
 
 		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
 
-		assertThat(contextToBeTested.get(0))
-				.isEqualTo("application/messaging-service_test/");
+		assertThat(contextToBeTested.get(0)).isEqualTo("application/messaging-service_test/");
 		assertThat(contextToBeTested.get(1)).isEqualTo("application/messaging-service/");
 		assertThat(contextToBeTested.get(2)).isEqualTo("application/application_test/");
 		assertThat(contextToBeTested.get(3)).isEqualTo("application/application/");

--- a/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocatorTest.java
+++ b/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceLocatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.parameterstore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link AwsParamStorePropertySourceLocator}.
+ *
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ */
+public class AwsParamStorePropertySourceLocatorTest {
+
+	private AWSSimpleSystemsManagement ssmClient = mock(AWSSimpleSystemsManagement.class);
+
+	private MockEnvironment env = new MockEnvironment();
+
+	@Test
+	void contextExpectedToHave2Elements() {
+		GetParametersByPathResult firstResult = getFirstResult();
+		GetParametersByPathResult nextResult = getNextResult();
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
+				.thenReturn(firstResult, nextResult);
+
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
+				ssmClient);
+		locator.setPrefix("application");
+		locator.setName("application");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(2);
+	}
+
+	@Test
+	void contextExpectedToHave4Elements() {
+		GetParametersByPathResult firstResult = getFirstResult();
+		GetParametersByPathResult nextResult = getNextResult();
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
+				.thenReturn(firstResult, nextResult);
+
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
+				ssmClient);
+		locator.setPrefix("application");
+		locator.setName("messaging-service");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(4);
+	}
+
+	@Test
+	void contextSpecificOrderExpected() {
+		GetParametersByPathResult firstResult = getFirstResult();
+		GetParametersByPathResult nextResult = getNextResult();
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
+				.thenReturn(firstResult, nextResult);
+
+		AwsParamStorePropertySourceLocator locator = new AwsParamStorePropertySourceLocator(
+				ssmClient);
+		locator.setPrefix("application");
+		locator.setName("messaging-service");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
+
+		assertThat(contextToBeTested.get(0))
+				.isEqualTo("application/messaging-service_test/");
+		assertThat(contextToBeTested.get(1)).isEqualTo("application/messaging-service/");
+		assertThat(contextToBeTested.get(2)).isEqualTo("application/application_test/");
+		assertThat(contextToBeTested.get(3)).isEqualTo("application/application/");
+	}
+
+	private static GetParametersByPathResult getNextResult() {
+		return new GetParametersByPathResult().withParameters(
+				new Parameter().withName("/config/myservice/key3").withValue("value3"),
+				new Parameter().withName("/config/myservice/key4").withValue("value4"));
+	}
+
+	private static GetParametersByPathResult getFirstResult() {
+		return new GetParametersByPathResult().withParameters(
+				new Parameter().withName("/config/myservice/key3").withValue("value3"),
+				new Parameter().withName("/config/myservice/key4").withValue("value4"));
+	}
+
+}

--- a/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceTest.java
+++ b/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceTest.java
@@ -31,32 +31,24 @@ class AwsParamStorePropertySourceTest {
 
 	private AWSSimpleSystemsManagement ssmClient = mock(AWSSimpleSystemsManagement.class);
 
-	private AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(
-			"/config/myservice/", ssmClient);
+	private AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource("/config/myservice/",
+			ssmClient);
 
 	@Test
 	void followsNextToken() {
-		GetParametersByPathResult firstResult = new GetParametersByPathResult()
-				.withNextToken("next").withParameters(
-						new Parameter().withName("/config/myservice/key1")
-								.withValue("value1"),
-						new Parameter().withName("/config/myservice/key2")
-								.withValue("value2"));
+		GetParametersByPathResult firstResult = new GetParametersByPathResult().withNextToken("next").withParameters(
+				new Parameter().withName("/config/myservice/key1").withValue("value1"),
+				new Parameter().withName("/config/myservice/key2").withValue("value2"));
 
-		GetParametersByPathResult nextResult = new GetParametersByPathResult()
-				.withParameters(
-						new Parameter().withName("/config/myservice/key3")
-								.withValue("value3"),
-						new Parameter().withName("/config/myservice/key4")
-								.withValue("value4"));
+		GetParametersByPathResult nextResult = new GetParametersByPathResult().withParameters(
+				new Parameter().withName("/config/myservice/key3").withValue("value3"),
+				new Parameter().withName("/config/myservice/key4").withValue("value4"));
 
-		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
-				.thenReturn(firstResult, nextResult);
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class))).thenReturn(firstResult, nextResult);
 
 		propertySource.init();
 
-		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2",
-				"key3", "key4");
+		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2", "key3", "key4");
 		assertThat(propertySource.getProperty("key3")).isEqualTo("value3");
 	}
 

--- a/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceTest.java
+++ b/spring-cloud-aws-parameter-store/src/test/java/org/springframework/cloud/aws/parameterstore/AwsParamStorePropertySourceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.parameterstore;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AwsParamStorePropertySourceTest {
+
+	private AWSSimpleSystemsManagement ssmClient = mock(AWSSimpleSystemsManagement.class);
+
+	private AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(
+			"/config/myservice/", ssmClient);
+
+	@Test
+	void followsNextToken() {
+		GetParametersByPathResult firstResult = new GetParametersByPathResult()
+				.withNextToken("next").withParameters(
+						new Parameter().withName("/config/myservice/key1")
+								.withValue("value1"),
+						new Parameter().withName("/config/myservice/key2")
+								.withValue("value2"));
+
+		GetParametersByPathResult nextResult = new GetParametersByPathResult()
+				.withParameters(
+						new Parameter().withName("/config/myservice/key3")
+								.withValue("value3"),
+						new Parameter().withName("/config/myservice/key4")
+								.withValue("value4"));
+
+		when(ssmClient.getParametersByPath(any(GetParametersByPathRequest.class)))
+				.thenReturn(firstResult, nextResult);
+
+		propertySource.init();
+
+		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2",
+				"key3", "key4");
+		assertThat(propertySource.getProperty("key3")).isEqualTo("value3");
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/pom.xml
+++ b/spring-cloud-starter-aws-parameter-store-config/pom.xml
@@ -25,7 +25,7 @@
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-aws-parameter-store-config</artifactId>
-	<name>Spring Cloud AWS Parameter Store Configuration Starter</name>
+	<name>Spring Cloud AWS Parameter Store Configuration Starter (deprecated)</name>
 	<description>Spring Cloud AWS Parameter Store Configuration Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>

--- a/spring-cloud-starter-aws-parameter-store/pom.xml
+++ b/spring-cloud-starter-aws-parameter-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2013-2019 the original author or authors.
+  ~ Copyright 2013-2020 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,38 +24,25 @@
 		<artifactId>spring-cloud-aws</artifactId>
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
-
-	<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
-	<name>Spring Cloud AWS Parameter Store Configuration (deprecated)</name>
-	<description>Spring Cloud AWS Parameter Store Configuration</description>
-
+	<artifactId>spring-cloud-starter-aws-parameter-store</artifactId>
+	<name>Spring Cloud AWS Parameter Store Starter</name>
+	<description>Spring Cloud AWS Parameter Store Starter</description>
+	<url>https://projects.spring.io/spring-cloud</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>https://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
 	<dependencies>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-context</artifactId>
+			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ssm</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-
 	</dependencies>
 </project>


### PR DESCRIPTION
This commit introduces the following changes:

* Deprecate `spring-cloud-aws-parameter-store-config` module
* Deperecate `spring-cloud-starter-aws-parameter-store-config` module
* Create `spring-cloud-aws-parameter-store`
* Create `spring-cloud-starter-aws-parameter-store`

New module is not aware of spring boot and the starter has not classes.
