### PR TITLE
Add new secrets-manager module and starter

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -29,5 +29,12 @@
 |cloud.aws.sqs.region || The specific region for SQS integration.
 |cloud.aws.stack.auto | true | Enables the automatic stack name detection for the application.
 |cloud.aws.stack.name |  | The name of the manually configured stack name that will be used to retrieve the resources.
+|spring.cloud.aws.secretsmanager.default-context | application |
+|spring.cloud.aws.secretsmanager.enabled | true | Is AWS Secrets Manager support enabled.
+|spring.cloud.aws.secretsmanager.fail-fast | true | Throw exceptions during config lookup if true, otherwise, log warnings.
+|spring.cloud.aws.secretsmanager.name |  | Alternative to spring.application.name to use in looking up values in AWS Secrets Manager.
+|spring.cloud.aws.secretsmanager.prefix | /secret | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
+|spring.cloud.aws.secretsmanager.profile-separator | _ |
+|spring.cloud.aws.secretsmanager.region |  | The specific region for Secrets Manager integration.
 
 |===

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -790,6 +790,52 @@ You can configure the following settings in a Spring Cloud `bootstrap.properties
 |`aws.secretsmanager.enabled`
 |`true`
 |Can be used to disable the Secrets Manager Configuration support even though the auto-configuration is on the classpath.
+
+|`aws.secretsmanager.region`
+|`_`
+|The specific region for Secrets Manager integration.
+
+|===
+
+There is a new starter `spring-cloud-starter-aws-secrets-manager` and it offers the same configuration properties with
+prefix `spring.cloud`.
+
+[cols="3*", options="header"]
+|===
+|property
+|default
+|explanation
+
+|`spring.cloud.aws.secretsmanager.prefix`
+|`/secret`
+|Prefix indicating first level for every property loaded from the Secrets Manager.
+Value must start with a forward slash followed by one or more valid path segments or be empty.
+
+|`spring.cloud.aws.secretsmanager.defaultContext`
+|`application`
+|Name of the context that defines properties shared across all services
+
+|`spring.cloud.aws.secretsmanager.profileSeparator`
+|`_`
+|String that separates an appended profile from the context name. Can only contain
+dots, dashes, forward slashes, backward slashes and underscores next to alphanumeric characters.
+
+|`spring.cloud.aws.secretsmanager.failFast`
+|`true`
+|Indicates if an error while retrieving the secrets should fail starting the application.
+
+|`spring.cloud.aws.secretsmanager.name`
+|the configured value for `spring.application.name`
+|Name to use when constructing the path for the properties to look up for this specific service.
+
+|`spring.cloud.aws.secretsmanager.enabled`
+|`true`
+|Can be used to disable the Secrets Manager Configuration support even though the auto-configuration is on the classpath.
+
+|`spring.cloud.aws.secretsmanager.region`
+|`_`
+|The specific region for Secrets Manager integration.
+
 |===
 
 == Managing cloud environments

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,13 @@
 		<module>spring-cloud-aws-messaging</module>
 		<module>spring-cloud-aws-autoconfigure</module>
 		<module>spring-cloud-aws-parameter-store-config</module>
+		<module>spring-cloud-aws-secrets-manager</module>
 		<module>spring-cloud-aws-secrets-manager-config</module>
 		<module>spring-cloud-starter-aws</module>
 		<module>spring-cloud-starter-aws-jdbc</module>
 		<module>spring-cloud-starter-aws-messaging</module>
 		<module>spring-cloud-starter-aws-parameter-store-config</module>
+		<module>spring-cloud-starter-aws-secrets-manager</module>
 		<module>spring-cloud-starter-aws-secrets-manager-config</module>
 		<module>spring-cloud-aws-integration-test</module>
 		<module>docs</module>

--- a/spring-cloud-aws-autoconfigure/pom.xml
+++ b/spring-cloud-aws-autoconfigure/pom.xml
@@ -49,6 +49,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-aws-secrets-manager</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -44,10 +44,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(SecretsManagerProperties.class)
 @ConditionalOnMissingClass("org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerProperties")
-@ConditionalOnClass({ AWSSecretsManager.class,
-		AwsSecretsManagerPropertySourceLocator.class })
-@ConditionalOnProperty(prefix = "spring.cloud.aws.secretsmanager", name = "enabled",
-		matchIfMissing = true)
+@ConditionalOnClass({ AWSSecretsManager.class, AwsSecretsManagerPropertySourceLocator.class })
+@ConditionalOnProperty(prefix = "spring.cloud.aws.secretsmanager", name = "enabled", matchIfMissing = true)
 public class AwsSecretsManagerBootstrapConfiguration {
 
 	private final RegionProvider regionProvider;
@@ -56,8 +54,7 @@ public class AwsSecretsManagerBootstrapConfiguration {
 
 	public AwsSecretsManagerBootstrapConfiguration(SecretsManagerProperties properties,
 			ObjectProvider<RegionProvider> regionProvider) {
-		this.regionProvider = properties.getRegion() == null
-				? regionProvider.getIfAvailable()
+		this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()
 				: new StaticRegionProvider(properties.getRegion());
 		this.properties = properties;
 	}
@@ -65,13 +62,11 @@ public class AwsSecretsManagerBootstrapConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AmazonWebserviceClientFactoryBean<AWSSecretsManagerClient> ssmClient() {
-		return new AmazonWebserviceClientFactoryBean<>(AWSSecretsManagerClient.class,
-				null, this.regionProvider);
+		return new AmazonWebserviceClientFactoryBean<>(AWSSecretsManagerClient.class, null, this.regionProvider);
 	}
 
 	@Bean
-	public AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(
-			AWSSecretsManager smClient) {
+	public AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(AWSSecretsManager smClient) {
 		AwsSecretsManagerPropertySourceLocator propertySourceLocator = new AwsSecretsManagerPropertySourceLocator(
 				smClient);
 		propertySourceLocator.setName(this.properties.getName());

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClient;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientFactoryBean;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Cloud Bootstrap Configuration for setting up an
+ * {@link AwsSecretsManagerPropertySourceLocator} and its dependencies.
+ *
+ * @author Fabio Maia
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(SecretsManagerProperties.class)
+@ConditionalOnMissingClass("org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerProperties")
+@ConditionalOnClass({ AWSSecretsManager.class,
+		AwsSecretsManagerPropertySourceLocator.class })
+@ConditionalOnProperty(prefix = "spring.cloud.aws.secretsmanager", name = "enabled",
+		matchIfMissing = true)
+public class AwsSecretsManagerBootstrapConfiguration {
+
+	private final RegionProvider regionProvider;
+
+	private final SecretsManagerProperties properties;
+
+	public AwsSecretsManagerBootstrapConfiguration(SecretsManagerProperties properties,
+			ObjectProvider<RegionProvider> regionProvider) {
+		this.regionProvider = properties.getRegion() == null
+				? regionProvider.getIfAvailable()
+				: new StaticRegionProvider(properties.getRegion());
+		this.properties = properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AmazonWebserviceClientFactoryBean<AWSSecretsManagerClient> ssmClient() {
+		return new AmazonWebserviceClientFactoryBean<>(AWSSecretsManagerClient.class,
+				null, this.regionProvider);
+	}
+
+	@Bean
+	public AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(
+			AWSSecretsManager smClient) {
+		AwsSecretsManagerPropertySourceLocator propertySourceLocator = new AwsSecretsManagerPropertySourceLocator(
+				smClient);
+		propertySourceLocator.setName(this.properties.getName());
+		propertySourceLocator.setPrefix(this.properties.getPrefix());
+		propertySourceLocator.setDefaultContext(this.properties.getDefaultContext());
+		propertySourceLocator.setFailFast(this.properties.isFailFast());
+		propertySourceLocator.setProfileSeparator(this.properties.getProfileSeparator());
+
+		return propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/SecretsManagerProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/SecretsManagerProperties.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.aws.secretsmanager;
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
 
 import java.util.regex.Pattern;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -31,25 +30,22 @@ import org.springframework.validation.Validator;
  * @author Fabio Maia
  * @author Matej Nedic
  * @author Eddú Meléndez
- * @since 2.0.0
+ * @since 2.3
  */
-@ConfigurationProperties(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX)
-public class AwsSecretsManagerProperties implements Validator {
-
-	/**
-	 * Configuration prefix.
-	 */
-	public static final String CONFIG_PREFIX = "aws.secretsmanager";
+@ConfigurationProperties(prefix = "spring.cloud.aws.secretsmanager")
+public class SecretsManagerProperties implements Validator {
 
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/[a-zA-Z0-9.\\-_]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern
+			.compile("(/[a-zA-Z0-9.\\-_]+)*");
 
 	/**
 	 * Pattern used for profileSeparator validation.
 	 */
-	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-_/\\\\]+");
+	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern
+			.compile("[a-zA-Z0-9.\\-_/\\\\]+");
 
 	/**
 	 * Prefix indicating first level for every property. Value must start with a forward
@@ -81,36 +77,40 @@ public class AwsSecretsManagerProperties implements Validator {
 
 	@Override
 	public boolean supports(Class<?> clazz) {
-		return AwsSecretsManagerProperties.class.isAssignableFrom(clazz);
+		return SecretsManagerProperties.class.isAssignableFrom(clazz);
 	}
 
 	@Override
 	public void validate(Object target, Errors errors) {
-		AwsSecretsManagerProperties properties = (AwsSecretsManagerProperties) target;
+		SecretsManagerProperties properties = (SecretsManagerProperties) target;
 
 		if (StringUtils.isEmpty(properties.getPrefix())) {
-			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
+			errors.rejectValue("prefix", "NotEmpty",
+					"prefix should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getDefaultContext())) {
-			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
+			errors.rejectValue("defaultContext", "NotEmpty",
+					"defaultContext should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
-			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
+			errors.rejectValue("profileSeparator", "NotEmpty",
+					"profileSeparator should not be empty or null.");
 		}
 
 		if (!PREFIX_PATTERN.matcher(properties.getPrefix()).matches()) {
-			errors.rejectValue("prefix", "Pattern", "The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+			errors.rejectValue("prefix", "Pattern",
+					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
 		}
-		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator()).matches()) {
+		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator())
+				.matches()) {
 			errors.rejectValue("profileSeparator", "Pattern",
-					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
+					"The profileSeparator must have pattern of:  "
+							+ PROFILE_SEPARATOR_PATTERN.toString());
 		}
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.prefix")
 	public String getPrefix() {
 		return prefix;
 	}
@@ -119,8 +119,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.prefix = prefix;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.defaultContext")
 	public String getDefaultContext() {
 		return defaultContext;
 	}
@@ -129,8 +127,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.defaultContext = defaultContext;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.profile-separator")
 	public String getProfileSeparator() {
 		return profileSeparator;
 	}
@@ -139,8 +135,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.profileSeparator = profileSeparator;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.fail-fast")
 	public boolean isFailFast() {
 		return failFast;
 	}
@@ -149,7 +143,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.failFast = failFast;
 	}
 
-	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.name")
 	public String getName() {
 		return name;
 	}
@@ -158,8 +151,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.name = name;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.enabled")
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -168,8 +159,6 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.enabled = enabled;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.region")
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/SecretsManagerProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/SecretsManagerProperties.java
@@ -38,14 +38,12 @@ public class SecretsManagerProperties implements Validator {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern
-			.compile("(/[a-zA-Z0-9.\\-_]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/[a-zA-Z0-9.\\-_]+)*");
 
 	/**
 	 * Pattern used for profileSeparator validation.
 	 */
-	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern
-			.compile("[a-zA-Z0-9.\\-_/\\\\]+");
+	private static final Pattern PROFILE_SEPARATOR_PATTERN = Pattern.compile("[a-zA-Z0-9.\\-_/\\\\]+");
 
 	/**
 	 * Prefix indicating first level for every property. Value must start with a forward
@@ -85,29 +83,23 @@ public class SecretsManagerProperties implements Validator {
 		SecretsManagerProperties properties = (SecretsManagerProperties) target;
 
 		if (StringUtils.isEmpty(properties.getPrefix())) {
-			errors.rejectValue("prefix", "NotEmpty",
-					"prefix should not be empty or null.");
+			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getDefaultContext())) {
-			errors.rejectValue("defaultContext", "NotEmpty",
-					"defaultContext should not be empty or null.");
+			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
 		}
 
 		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
-			errors.rejectValue("profileSeparator", "NotEmpty",
-					"profileSeparator should not be empty or null.");
+			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
 		}
 
 		if (!PREFIX_PATTERN.matcher(properties.getPrefix()).matches()) {
-			errors.rejectValue("prefix", "Pattern",
-					"The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
+			errors.rejectValue("prefix", "Pattern", "The prefix must have pattern of:  " + PREFIX_PATTERN.toString());
 		}
-		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator())
-				.matches()) {
+		if (!PROFILE_SEPARATOR_PATTERN.matcher(properties.getProfileSeparator()).matches()) {
 			errors.rejectValue("profileSeparator", "Pattern",
-					"The profileSeparator must have pattern of:  "
-							+ PROFILE_SEPARATOR_PATTERN.toString());
+					"The profileSeparator must have pattern of:  " + PROFILE_SEPARATOR_PATTERN.toString());
 		}
 	}
 

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -47,6 +47,12 @@
       "name": "cloud.aws.stack.enabled",
       "description": "Enables Stack integration.",
       "type": "java.lang.Boolean"
+    },
+    {
+      "defaultValue": true,
+      "name": "spring.cloud.aws.secretsmanager.enabled",
+      "description": "Enables Secrets Manager integration.",
+      "type": "java.lang.Boolean"
     }
   ]
 }

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,6 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+org.springframework.cloud.aws.autoconfigure.secretsmanager.AwsSecretsManagerBootstrapConfiguration
+
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration,\

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfigurationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import java.lang.reflect.Method;
+
+import com.amazonaws.AmazonWebServiceClient;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AwsSecretsManagerBootstrapConfigurationTest {
+
+	AwsSecretsManagerBootstrapConfiguration bootstrapConfig = new AwsSecretsManagerBootstrapConfiguration();
+
+	@Test
+	void testWithStaticRegion() {
+		String region = "us-east-2";
+		AWSSecretsManagerClient awsSimpleClient = createSecretsManagerClient(region);
+
+		Method signingRegionMethod = ReflectionUtils
+				.findMethod(AmazonWebServiceClient.class, "getSigningRegion");
+		signingRegionMethod.setAccessible(true);
+		String signedRegion = (String) ReflectionUtils.invokeMethod(signingRegionMethod,
+				awsSimpleClient);
+
+		assertThat(signedRegion).isEqualTo(region);
+	}
+
+	@Test
+	void testUserAgent() {
+		String region = "us-east-2";
+		AWSSecretsManagerClient awsSimpleClient = createSecretsManagerClient(region);
+
+		assertThat(awsSimpleClient.getClientConfiguration().getUserAgentSuffix())
+				.startsWith("spring-cloud-aws/");
+	}
+
+	private AWSSecretsManagerClient createSecretsManagerClient(String region) {
+		SecretsManagerProperties awsParamStoreProperties = new SecretsManagerProperties();
+		awsParamStoreProperties.setRegion(region);
+
+		Method SMClientMethod = ReflectionUtils.findMethod(
+				AwsSecretsManagerBootstrapConfiguration.class, "smClient",
+				SecretsManagerProperties.class);
+		SMClientMethod.setAccessible(true);
+		AWSSecretsManagerClient awsSimpleClient = (AWSSecretsManagerClient) ReflectionUtils
+				.invokeMethod(SMClientMethod, bootstrapConfig, awsParamStoreProperties);
+		return awsSimpleClient;
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfigurationTest.java
@@ -29,14 +29,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AwsSecretsManagerBootstrapConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(
-					AutoConfigurations.of(AwsSecretsManagerBootstrapConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(AwsSecretsManagerBootstrapConfiguration.class));
 
 	@Test
 	void testWithDefaultRegion() {
 		this.contextRunner.run(context -> {
-			AWSSecretsManagerClient client = context
-					.getBean(AWSSecretsManagerClient.class);
+			AWSSecretsManagerClient client = context.getBean(AWSSecretsManagerClient.class);
 			Object region = ReflectionTestUtils.getField(client, "signingRegion");
 			assertThat(region).isEqualTo(Regions.DEFAULT_REGION.getName());
 		});
@@ -44,23 +42,18 @@ class AwsSecretsManagerBootstrapConfigurationTest {
 
 	@Test
 	void testWithStaticRegion() {
-		this.contextRunner
-				.withPropertyValues("spring.cloud.aws.secretsmanager.region:us-east-1")
-				.run(context -> {
-					AWSSecretsManagerClient client = context
-							.getBean(AWSSecretsManagerClient.class);
-					Object region = ReflectionTestUtils.getField(client, "signingRegion");
-					assertThat(region).isEqualTo("us-east-1");
-				});
+		this.contextRunner.withPropertyValues("spring.cloud.aws.secretsmanager.region:us-east-1").run(context -> {
+			AWSSecretsManagerClient client = context.getBean(AWSSecretsManagerClient.class);
+			Object region = ReflectionTestUtils.getField(client, "signingRegion");
+			assertThat(region).isEqualTo("us-east-1");
+		});
 	}
 
 	@Test
 	void testUserAgent() {
 		this.contextRunner.run(context -> {
-			AWSSecretsManagerClient client = context
-					.getBean(AWSSecretsManagerClient.class);
-			assertThat(client.getClientConfiguration().getUserAgentSuffix())
-					.startsWith("spring-cloud-aws/");
+			AWSSecretsManagerClient client = context.getBean(AWSSecretsManagerClient.class);
+			assertThat(client.getClientConfiguration().getUserAgentSuffix()).startsWith("spring-cloud-aws/");
 		});
 	}
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -101,6 +101,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-aws-secrets-manager</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-aws-secrets-manager-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -132,6 +137,11 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-aws-parameter-store-config</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-aws-secrets-manager</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -109,8 +109,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		}
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.prefix")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.prefix")
 	public String getPrefix() {
 		return prefix;
 	}
@@ -119,8 +118,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.prefix = prefix;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.defaultContext")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.defaultContext")
 	public String getDefaultContext() {
 		return defaultContext;
 	}
@@ -129,8 +127,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.defaultContext = defaultContext;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.profile-separator")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.profile-separator")
 	public String getProfileSeparator() {
 		return profileSeparator;
 	}
@@ -139,8 +136,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.profileSeparator = profileSeparator;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.fail-fast")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.fail-fast")
 	public boolean isFailFast() {
 		return failFast;
 	}
@@ -158,8 +154,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.name = name;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.enabled")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.enabled")
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -168,8 +163,7 @@ public class AwsSecretsManagerProperties implements Validator {
 		this.enabled = enabled;
 	}
 
-	@DeprecatedConfigurationProperty(
-			replacement = "spring.cloud.aws.secretsmanager.region")
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.secretsmanager.region")
 	public String getRegion() {
 		return region;
 	}

--- a/spring-cloud-aws-secrets-manager/pom.xml
+++ b/spring-cloud-aws-secrets-manager/pom.xml
@@ -24,20 +24,14 @@
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
-	<name>Spring Cloud AWS Secrets Manager Configuration (deprecated)</name>
-	<description>Spring Cloud AWS Secrets Manager Configuration</description>
+	<artifactId>spring-cloud-aws-secrets-manager</artifactId>
+	<name>Spring Cloud AWS Secrets Manager</name>
+	<description>Spring Cloud AWS Secrets Manager</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 
 		<dependency>
@@ -49,12 +43,5 @@
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-secretsmanager</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.core.env.EnumerablePropertySource;
+
+/**
+ * Retrieves secret value under the given context / path from the AWS Secrets Manager
+ * using the provided SM client.
+ *
+ * @author Fabio Maia
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class AwsSecretsManagerPropertySource
+		extends EnumerablePropertySource<AWSSecretsManager> {
+
+	private final ObjectMapper jsonMapper = new ObjectMapper();
+
+	private String context;
+
+	private Map<String, Object> properties = new LinkedHashMap<>();
+
+	public AwsSecretsManagerPropertySource(String context, AWSSecretsManager smClient) {
+		super(context, smClient);
+		this.context = context;
+	}
+
+	public void init() {
+		GetSecretValueRequest secretValueRequest = new GetSecretValueRequest();
+		secretValueRequest.setSecretId(context);
+		readSecretValue(secretValueRequest);
+	}
+
+	@Override
+	public String[] getPropertyNames() {
+		Set<String> strings = properties.keySet();
+		return strings.toArray(new String[strings.size()]);
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		return properties.get(name);
+	}
+
+	private void readSecretValue(GetSecretValueRequest secretValueRequest) {
+		try {
+			GetSecretValueResult secretValueResult = source
+					.getSecretValue(secretValueRequest);
+			Map<String, Object> secretMap = jsonMapper.readValue(
+					secretValueResult.getSecretString(),
+					new TypeReference<Map<String, Object>>() {
+					});
+
+			for (Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
+				properties.put(secretEntry.getKey(), secretEntry.getValue());
+			}
+		}
+		catch (ResourceNotFoundException e) {
+			logger.debug("AWS secret not found from " + secretValueRequest.getSecretId());
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySource.java
@@ -38,8 +38,7 @@ import org.springframework.core.env.EnumerablePropertySource;
  * @author Eddú Meléndez
  * @since 2.3
  */
-public class AwsSecretsManagerPropertySource
-		extends EnumerablePropertySource<AWSSecretsManager> {
+public class AwsSecretsManagerPropertySource extends EnumerablePropertySource<AWSSecretsManager> {
 
 	private final ObjectMapper jsonMapper = new ObjectMapper();
 
@@ -71,10 +70,8 @@ public class AwsSecretsManagerPropertySource
 
 	private void readSecretValue(GetSecretValueRequest secretValueRequest) {
 		try {
-			GetSecretValueResult secretValueResult = source
-					.getSecretValue(secretValueRequest);
-			Map<String, Object> secretMap = jsonMapper.readValue(
-					secretValueResult.getSecretString(),
+			GetSecretValueResult secretValueResult = source.getSecretValue(secretValueRequest);
+			Map<String, Object> secretMap = jsonMapper.readValue(secretValueResult.getSecretString(),
 					new TypeReference<Map<String, Object>>() {
 					});
 

--- a/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Builds a {@link CompositePropertySource} with various
+ * {@link AwsSecretsManagerPropertySource} instances based on active profiles, application
+ * name and default context permutations. Mostly copied from Spring Cloud Consul's config
+ * support.
+ *
+ * @author Fabio Maia
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
+public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLocator {
+
+	private Log logger = LogFactory.getLog(getClass());
+
+	private final AWSSecretsManager smClient;
+
+	private String name;
+
+	private String prefix = "/secret";
+
+	private String defaultContext = "application";
+
+	private boolean failFast = false;
+
+	private String profileSeparator = "_";
+
+	private final Set<String> contexts = new LinkedHashSet();
+
+	public AwsSecretsManagerPropertySourceLocator(AWSSecretsManager smClient) {
+		this.smClient = smClient;
+	}
+
+	public List<String> getContexts() {
+		return new ArrayList<>(contexts);
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		if (!(environment instanceof ConfigurableEnvironment)) {
+			return null;
+		}
+
+		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
+
+		String appName = getName();
+
+		if (appName == null) {
+			appName = env.getProperty("spring.application.name");
+		}
+
+		List<String> profiles = Arrays.asList(env.getActiveProfiles());
+
+		String prefix = getPrefix();
+
+		String appContext = prefix + "/" + appName;
+		addProfiles(this.contexts, appContext, profiles);
+		this.contexts.add(appContext);
+
+		String defaultContext = prefix + "/" + getDefaultContext();
+		addProfiles(this.contexts, defaultContext, profiles);
+		this.contexts.add(defaultContext);
+
+		CompositePropertySource composite = new CompositePropertySource(
+				"aws-secrets-manager");
+
+		for (String propertySourceContext : this.contexts) {
+			try {
+				composite.addPropertySource(create(propertySourceContext));
+			}
+			catch (Exception e) {
+				if (isFailFast()) {
+					logger.error(
+							"Fail fast is set and there was an error reading configuration from AWS Secrets Manager:\n"
+									+ e.getMessage());
+					ReflectionUtils.rethrowRuntimeException(e);
+				}
+				else {
+					logger.warn("Unable to load AWS secret from " + propertySourceContext,
+							e);
+				}
+			}
+		}
+
+		return composite;
+	}
+
+	private AwsSecretsManagerPropertySource create(String context) {
+		AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(
+				context, this.smClient);
+		propertySource.init();
+		return propertySource;
+	}
+
+	private void addProfiles(Set<String> contexts, String baseContext,
+			List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + getProfileSeparator() + profile);
+		}
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPrefix() {
+		return this.prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getDefaultContext() {
+		return this.defaultContext;
+	}
+
+	public void setDefaultContext(String defaultContext) {
+		this.defaultContext = defaultContext;
+	}
+
+	public boolean isFailFast() {
+		return this.failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
+	public String getProfileSeparator() {
+		return this.profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
+++ b/spring-cloud-aws-secrets-manager/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocator.java
@@ -96,8 +96,7 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 		addProfiles(this.contexts, defaultContext, profiles);
 		this.contexts.add(defaultContext);
 
-		CompositePropertySource composite = new CompositePropertySource(
-				"aws-secrets-manager");
+		CompositePropertySource composite = new CompositePropertySource("aws-secrets-manager");
 
 		for (String propertySourceContext : this.contexts) {
 			try {
@@ -111,8 +110,7 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 					ReflectionUtils.rethrowRuntimeException(e);
 				}
 				else {
-					logger.warn("Unable to load AWS secret from " + propertySourceContext,
-							e);
+					logger.warn("Unable to load AWS secret from " + propertySourceContext, e);
 				}
 			}
 		}
@@ -121,14 +119,12 @@ public class AwsSecretsManagerPropertySourceLocator implements PropertySourceLoc
 	}
 
 	private AwsSecretsManagerPropertySource create(String context) {
-		AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(
-				context, this.smClient);
+		AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(context, this.smClient);
 		propertySource.init();
 		return propertySource;
 	}
 
-	private void addProfiles(Set<String> contexts, String baseContext,
-			List<String> profiles) {
+	private void addProfiles(Set<String> contexts, String baseContext, List<String> profiles) {
 		for (String profile : profiles) {
 			contexts.add(baseContext + getProfileSeparator() + profile);
 		}

--- a/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link AwsSecretsManagerPropertySourceLocator}.
+ *
+ * @author Anthony Foulfoin
+ * @author Matej Nedic
+ * @author Eddú Meléndez
+ */
+class AwsSecretsManagerPropertySourceLocatorTest {
+
+	private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
+
+	private MockEnvironment env = new MockEnvironment();
+
+	@Test
+	void locate_nameNotSpecifiedInConstructor_returnsPropertySourceWithDefaultName() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
+				smClient);
+		PropertySource propertySource = locator.locate(env);
+
+		assertThat(propertySource.getName()).isEqualTo("aws-secrets-manager");
+	}
+
+	@Test
+	public void contextExpectedToHave2Elements() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
+				smClient);
+		locator.setDefaultContext("application");
+		locator.setName("application");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(2);
+	}
+
+	@Test
+	public void contextExpectedToHave4Elements() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
+				smClient);
+		locator.setDefaultContext("application");
+		locator.setName("messaging-service");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		assertThat(locator.getContexts()).hasSize(4);
+	}
+
+	@Test
+	public void contextSpecificOrderExpected() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenReturn(secretValueResult);
+
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
+				smClient);
+		locator.setDefaultContext("application");
+		locator.setName("messaging-service");
+		env.setActiveProfiles("test");
+		locator.locate(env);
+
+		List<String> contextToBeTested = new ArrayList<>(locator.getContexts());
+
+		assertThat(contextToBeTested.get(0)).isEqualTo("/secret/messaging-service_test");
+		assertThat(contextToBeTested.get(1)).isEqualTo("/secret/messaging-service");
+		assertThat(contextToBeTested.get(2)).isEqualTo("/secret/application_test");
+		assertThat(contextToBeTested.get(3)).isEqualTo("/secret/application");
+
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceLocatorTest.java
@@ -49,11 +49,9 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 	void locate_nameNotSpecifiedInConstructor_returnsPropertySourceWithDefaultName() {
 		GetSecretValueResult secretValueResult = new GetSecretValueResult();
 		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
-		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
-				.thenReturn(secretValueResult);
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 
-		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
-				smClient);
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient);
 		PropertySource propertySource = locator.locate(env);
 
 		assertThat(propertySource.getName()).isEqualTo("aws-secrets-manager");
@@ -63,11 +61,9 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 	public void contextExpectedToHave2Elements() {
 		GetSecretValueResult secretValueResult = new GetSecretValueResult();
 		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
-		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
-				.thenReturn(secretValueResult);
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 
-		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
-				smClient);
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient);
 		locator.setDefaultContext("application");
 		locator.setName("application");
 		env.setActiveProfiles("test");
@@ -80,11 +76,9 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 	public void contextExpectedToHave4Elements() {
 		GetSecretValueResult secretValueResult = new GetSecretValueResult();
 		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
-		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
-				.thenReturn(secretValueResult);
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 
-		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
-				smClient);
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient);
 		locator.setDefaultContext("application");
 		locator.setName("messaging-service");
 		env.setActiveProfiles("test");
@@ -97,11 +91,9 @@ class AwsSecretsManagerPropertySourceLocatorTest {
 	public void contextSpecificOrderExpected() {
 		GetSecretValueResult secretValueResult = new GetSecretValueResult();
 		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
-		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
-				.thenReturn(secretValueResult);
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 
-		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(
-				smClient);
+		AwsSecretsManagerPropertySourceLocator locator = new AwsSecretsManagerPropertySourceLocator(smClient);
 		locator.setDefaultContext("application");
 		locator.setName("messaging-service");
 		env.setActiveProfiles("test");

--- a/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -30,16 +30,15 @@ class AwsSecretsManagerPropertySourceTest {
 
 	private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
 
-	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(
-			"/config/myservice", smClient);
+	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource("/config/myservice",
+			smClient);
 
 	@Test
 	void shouldParseSecretValue() {
 		GetSecretValueResult secretValueResult = new GetSecretValueResult();
 		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
 
-		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
-				.thenReturn(secretValueResult);
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class))).thenReturn(secretValueResult);
 
 		propertySource.init();
 

--- a/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
+++ b/spring-cloud-aws-secrets-manager/src/test/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySourceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AwsSecretsManagerPropertySourceTest {
+
+	private AWSSecretsManager smClient = mock(AWSSecretsManager.class);
+
+	private AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(
+			"/config/myservice", smClient);
+
+	@Test
+	void shouldParseSecretValue() {
+		GetSecretValueResult secretValueResult = new GetSecretValueResult();
+		secretValueResult.setSecretString("{\"key1\": \"value1\", \"key2\": \"value2\"}");
+
+		when(smClient.getSecretValue(any(GetSecretValueRequest.class)))
+				.thenReturn(secretValueResult);
+
+		propertySource.init();
+
+		assertThat(propertySource.getPropertyNames()).containsExactly("key1", "key2");
+		assertThat(propertySource.getProperty("key1")).isEqualTo("value1");
+		assertThat(propertySource.getProperty("key2")).isEqualTo("value2");
+	}
+
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager-config/pom.xml
@@ -25,7 +25,7 @@
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-aws-secrets-manager-config</artifactId>
-	<name>Spring Cloud AWS Secrets Manager Configuration Starter</name>
+	<name>Spring Cloud AWS Secrets Manager Configuration Starter (deprecated)</name>
 	<description>Spring Cloud AWS Secrets Manager Configuration Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>
 	<organization>

--- a/spring-cloud-starter-aws-secrets-manager/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager/pom.xml
@@ -14,6 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,38 +24,26 @@
 		<artifactId>spring-cloud-aws</artifactId>
 		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
-
-	<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
-	<name>Spring Cloud AWS Secrets Manager Configuration (deprecated)</name>
-	<description>Spring Cloud AWS Secrets Manager Configuration</description>
-
+	<artifactId>spring-cloud-starter-aws-secrets-manager</artifactId>
+	<name>Spring Cloud AWS Secrets Manager Starter</name>
+	<description>Spring Cloud AWS Secrets Manager Starter</description>
+	<url>https://projects.spring.io/spring-cloud</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>https://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
 	<dependencies>
-
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-aws-autoconfigure</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-context</artifactId>
+			<artifactId>spring-cloud-aws-secrets-manager</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-secretsmanager</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-
 	</dependencies>
 </project>


### PR DESCRIPTION
This commit introduces the following changes:

* Deprecate spring-cloud-aws-secrets-manager-config module
* Deperecate spring-cloud-starter-aws-secrets-manager-config module
* Create spring-cloud-aws-secrets-manager
* Create spring-cloud-starter-aws-secrets-manager

New module is not aware of spring boot and the starter has not classes.
