### PR TITLE
Draft: Move SqsAutoConfigration to spring.cloud.aws prefix 

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfiguration.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.messaging;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.aws.context.annotation.ConditionalOnMissingAmazonClient;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientFactoryBean;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
+import org.springframework.cloud.aws.messaging.config.QueueMessageHandlerFactory;
+import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.util.CollectionUtils;
+
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for SQS integration.
+ *
+ * @author Maciej Walkowiak
+ */
+@AutoConfigureBefore(SqsAutoConfiguration.class)
+@ConditionalOnClass(SimpleMessageListenerContainer.class)
+@ConditionalOnMissingBean(SimpleMessageListenerContainer.class)
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "spring.cloud.aws.sqs.enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(SimpleQueueServiceProperties.class)
+public class SimpleQueueServiceAutoConfiguration {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingAmazonClient(AmazonSQS.class)
+	static class SqsClientConfiguration {
+
+		private final AWSCredentialsProvider awsCredentialsProvider;
+
+		private final RegionProvider regionProvider;
+
+		SqsClientConfiguration(
+			ObjectProvider<AWSCredentialsProvider> awsCredentialsProvider,
+			ObjectProvider<RegionProvider> regionProvider, SimpleQueueServiceProperties properties) {
+			this.awsCredentialsProvider = awsCredentialsProvider.getIfAvailable();
+			this.regionProvider = properties.getRegion() == null
+				? regionProvider.getIfAvailable()
+				: new StaticRegionProvider(properties.getRegion());
+		}
+
+		@Lazy
+		@Bean(destroyMethod = "shutdown")
+		public AmazonSQSBufferedAsyncClient amazonSQS() throws Exception {
+			AmazonWebserviceClientFactoryBean<AmazonSQSAsyncClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
+				AmazonSQSAsyncClient.class, this.awsCredentialsProvider,
+				this.regionProvider);
+			clientFactoryBean.afterPropertiesSet();
+			return new AmazonSQSBufferedAsyncClient(clientFactoryBean.getObject());
+		}
+
+	}
+
+	@Configuration
+	static class SqsConfiguration {
+
+		private final SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory;
+
+		private final QueueMessageHandlerFactory queueMessageHandlerFactory;
+
+		private final BeanFactory beanFactory;
+
+		private final ResourceIdResolver resourceIdResolver;
+
+		private final MappingJackson2MessageConverter mappingJackson2MessageConverter;
+
+		private final ObjectMapper objectMapper;
+
+		SqsConfiguration(
+			ObjectProvider<SimpleMessageListenerContainerFactory> simpleMessageListenerContainerFactory,
+			ObjectProvider<QueueMessageHandlerFactory> queueMessageHandlerFactory,
+			BeanFactory beanFactory,
+			ObjectProvider<ResourceIdResolver> resourceIdResolver,
+			ObjectProvider<MappingJackson2MessageConverter> mappingJackson2MessageConverter,
+			ObjectProvider<ObjectMapper> objectMapper, SimpleQueueServiceProperties SimpleQueueServiceProperties) {
+			this.simpleMessageListenerContainerFactory = simpleMessageListenerContainerFactory
+				.getIfAvailable(() -> createSimpleMessageListenerContainerFactory(
+					SimpleQueueServiceProperties));
+			this.queueMessageHandlerFactory = queueMessageHandlerFactory.getIfAvailable(
+				() -> createQueueMessageHandlerFactory(SimpleQueueServiceProperties));
+			this.beanFactory = beanFactory;
+			this.resourceIdResolver = resourceIdResolver.getIfAvailable();
+			this.mappingJackson2MessageConverter = mappingJackson2MessageConverter
+				.getIfAvailable();
+			this.objectMapper = objectMapper.getIfAvailable();
+		}
+
+		private static QueueMessageHandlerFactory createQueueMessageHandlerFactory(
+			SimpleQueueServiceProperties SimpleQueueServiceProperties) {
+			QueueMessageHandlerFactory factory = new QueueMessageHandlerFactory();
+
+			Optional.ofNullable(SimpleQueueServiceProperties.getHandler().getDefaultDeletionPolicy())
+				.ifPresent(factory::setSqsMessageDeletionPolicy);
+
+			return factory;
+		}
+
+		private static SimpleMessageListenerContainerFactory createSimpleMessageListenerContainerFactory(
+			SimpleQueueServiceProperties SimpleQueueServiceProperties) {
+			SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+
+			Optional.ofNullable(SimpleQueueServiceProperties.getListener().getBackOffTime())
+				.ifPresent(factory::setBackOffTime);
+			Optional.ofNullable(SimpleQueueServiceProperties.getListener().getMaxNumberOfMessages())
+				.ifPresent(factory::setMaxNumberOfMessages);
+			Optional.ofNullable(SimpleQueueServiceProperties.getListener().getQueueStopTimeout())
+				.ifPresent(factory::setQueueStopTimeout);
+			Optional.ofNullable(SimpleQueueServiceProperties.getListener().getVisibilityTimeout())
+				.ifPresent(factory::setVisibilityTimeout);
+			Optional.ofNullable(SimpleQueueServiceProperties.getListener().getWaitTimeout())
+				.ifPresent(factory::setWaitTimeOut);
+			factory.setAutoStartup(SimpleQueueServiceProperties.getListener().isAutoStartup());
+
+			return factory;
+		}
+
+		@Bean
+		public SimpleMessageListenerContainer simpleMessageListenerContainer(
+			AmazonSQSAsync amazonSqs) {
+			if (this.simpleMessageListenerContainerFactory.getAmazonSqs() == null) {
+				this.simpleMessageListenerContainerFactory.setAmazonSqs(amazonSqs);
+			}
+			if (this.simpleMessageListenerContainerFactory.getResourceIdResolver() == null
+				&& this.resourceIdResolver != null) {
+				this.simpleMessageListenerContainerFactory
+					.setResourceIdResolver(this.resourceIdResolver);
+			}
+
+			SimpleMessageListenerContainer simpleMessageListenerContainer = this.simpleMessageListenerContainerFactory
+				.createSimpleMessageListenerContainer();
+
+			simpleMessageListenerContainer
+				.setMessageHandler(queueMessageHandler(amazonSqs));
+			return simpleMessageListenerContainer;
+		}
+
+		@Bean
+		public QueueMessageHandler queueMessageHandler(AmazonSQSAsync amazonSqs) {
+			if (this.simpleMessageListenerContainerFactory
+				.getQueueMessageHandler() != null) {
+				return this.simpleMessageListenerContainerFactory
+					.getQueueMessageHandler();
+			}
+			else {
+				return getMessageHandler(amazonSqs);
+			}
+		}
+
+		private QueueMessageHandler getMessageHandler(AmazonSQSAsync amazonSqs) {
+			if (this.queueMessageHandlerFactory.getAmazonSqs() == null) {
+				this.queueMessageHandlerFactory.setAmazonSqs(amazonSqs);
+			}
+
+			if (CollectionUtils
+				.isEmpty(this.queueMessageHandlerFactory.getMessageConverters())
+				&& this.mappingJackson2MessageConverter != null) {
+				this.queueMessageHandlerFactory.setMessageConverters(
+					Arrays.asList(this.mappingJackson2MessageConverter));
+			}
+
+			this.queueMessageHandlerFactory.setBeanFactory(this.beanFactory);
+			this.queueMessageHandlerFactory.setObjectMapper(this.objectMapper);
+
+			return this.queueMessageHandlerFactory.createQueueMessageHandler();
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceProperties.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.messaging;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
+import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+
+/**
+ * Properties related to SQS integration.
+ *
+ * @author Maciej Walkowiak
+ * @author Eddú Meléndez
+ */
+@ConfigurationProperties("spring.cloud.aws.sqs")
+public class SimpleQueueServiceProperties {
+
+		/**
+		 * Properties related to {@link SimpleMessageListenerContainer}.
+		 */
+		private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties();
+
+		/**
+		 * Properties related to {@link QueueMessageHandler}.
+		 */
+		private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties();
+
+		/**
+		 * Overrides the default region.
+		 */
+		private String region;
+
+		public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties getListener() {
+			return listener;
+		}
+
+		public void setListener(org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener) {
+			this.listener = listener;
+		}
+
+		public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties getHandler() {
+			return handler;
+		}
+
+		public void setHandler(org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler) {
+			this.handler = handler;
+		}
+
+		public String getRegion() {
+			return this.region;
+		}
+
+		public void setRegion(String region) {
+			this.region = region;
+		}
+
+		public static class ListenerProperties {
+
+			/**
+			 * The maximum number of messages that should be retrieved during one poll to the
+			 * Amazon SQS system. This number must be a positive, non-zero number that has a
+			 * maximum number of 10. Values higher then 10 are currently not supported by the
+			 * queueing system.
+			 */
+			private Integer maxNumberOfMessages = 10;
+
+			/**
+			 * The duration (in seconds) that the received messages are hidden from subsequent
+			 * poll requests after being retrieved from the system.
+			 */
+			private Integer visibilityTimeout;
+
+			/**
+			 * The wait timeout that the poll request will wait for new message to arrive if
+			 * the are currently no messages on the queue. Higher values will reduce poll
+			 * request to the system significantly. The value should be between 1 and 20. For
+			 * more information read the <a href=
+			 * "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+			 */
+			private Integer waitTimeout = 20;
+
+			/**
+			 * The queue stop timeout that waits for a queue to stop before interrupting the
+			 * running thread.
+			 */
+			private Long queueStopTimeout;
+
+			/**
+			 * The number of milliseconds the polling thread must wait before trying to
+			 * recover when an error occurs (e.g. connection timeout).
+			 */
+			private Long backOffTime;
+
+			/**
+			 * Configures if this container should be automatically started.
+			 */
+			private boolean autoStartup = true;
+
+			public Integer getMaxNumberOfMessages() {
+				return maxNumberOfMessages;
+			}
+
+			public void setMaxNumberOfMessages(Integer maxNumberOfMessages) {
+				this.maxNumberOfMessages = maxNumberOfMessages;
+			}
+
+			public Integer getVisibilityTimeout() {
+				return visibilityTimeout;
+			}
+
+			public void setVisibilityTimeout(Integer visibilityTimeout) {
+				this.visibilityTimeout = visibilityTimeout;
+			}
+
+			public Integer getWaitTimeout() {
+				return waitTimeout;
+			}
+
+			public void setWaitTimeout(Integer waitTimeout) {
+				this.waitTimeout = waitTimeout;
+			}
+
+			public Long getQueueStopTimeout() {
+				return queueStopTimeout;
+			}
+
+			public void setQueueStopTimeout(Long queueStopTimeout) {
+				this.queueStopTimeout = queueStopTimeout;
+			}
+
+			public Long getBackOffTime() {
+				return backOffTime;
+			}
+
+			public void setBackOffTime(Long backOffTime) {
+				this.backOffTime = backOffTime;
+			}
+
+			public boolean isAutoStartup() {
+				return autoStartup;
+			}
+
+			public void setAutoStartup(boolean autoStartup) {
+				this.autoStartup = autoStartup;
+			}
+
+		}
+
+		public static class HandlerProperties {
+
+			/**
+			 * Configures global deletion policy used if deletion policy is not explicitly set
+			 * on {@link SqsListener}.
+			 */
+			private SqsMessageDeletionPolicy defaultDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;
+
+			public SqsMessageDeletionPolicy getDefaultDeletionPolicy() {
+				return defaultDeletionPolicy;
+			}
+
+			public void setDefaultDeletionPolicy(
+				SqsMessageDeletionPolicy defaultDeletionPolicy) {
+				this.defaultDeletionPolicy = defaultDeletionPolicy;
+			}
+
+		}
+
+	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceProperties.java
@@ -31,154 +31,156 @@ import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
 @ConfigurationProperties("spring.cloud.aws.sqs")
 public class SimpleQueueServiceProperties {
 
-		/**
-		 * Properties related to {@link SimpleMessageListenerContainer}.
-		 */
-		private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties();
+	/**
+	 * Properties related to {@link SimpleMessageListenerContainer}.
+	 */
+	private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties();
+
+	/**
+	 * Properties related to {@link QueueMessageHandler}.
+	 */
+	private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties();
+
+	/**
+	 * Overrides the default region.
+	 */
+	private String region;
+
+	public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties getListener() {
+		return listener;
+	}
+
+	public void setListener(
+			org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener) {
+		this.listener = listener;
+	}
+
+	public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties getHandler() {
+		return handler;
+	}
+
+	public void setHandler(
+			org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler) {
+		this.handler = handler;
+	}
+
+	public String getRegion() {
+		return this.region;
+	}
+
+	public void setRegion(String region) {
+		this.region = region;
+	}
+
+	public static class ListenerProperties {
 
 		/**
-		 * Properties related to {@link QueueMessageHandler}.
+		 * The maximum number of messages that should be retrieved during one poll to the
+		 * Amazon SQS system. This number must be a positive, non-zero number that has a
+		 * maximum number of 10. Values higher then 10 are currently not supported by the
+		 * queueing system.
 		 */
-		private org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler = new org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties();
+		private Integer maxNumberOfMessages = 10;
 
 		/**
-		 * Overrides the default region.
+		 * The duration (in seconds) that the received messages are hidden from subsequent
+		 * poll requests after being retrieved from the system.
 		 */
-		private String region;
+		private Integer visibilityTimeout;
 
-		public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties getListener() {
-			return listener;
+		/**
+		 * The wait timeout that the poll request will wait for new message to arrive if
+		 * the are currently no messages on the queue. Higher values will reduce poll
+		 * request to the system significantly. The value should be between 1 and 20. For
+		 * more information read the <a href=
+		 * "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+		 */
+		private Integer waitTimeout = 20;
+
+		/**
+		 * The queue stop timeout that waits for a queue to stop before interrupting the
+		 * running thread.
+		 */
+		private Long queueStopTimeout;
+
+		/**
+		 * The number of milliseconds the polling thread must wait before trying to
+		 * recover when an error occurs (e.g. connection timeout).
+		 */
+		private Long backOffTime;
+
+		/**
+		 * Configures if this container should be automatically started.
+		 */
+		private boolean autoStartup = true;
+
+		public Integer getMaxNumberOfMessages() {
+			return maxNumberOfMessages;
 		}
 
-		public void setListener(org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.ListenerProperties listener) {
-			this.listener = listener;
+		public void setMaxNumberOfMessages(Integer maxNumberOfMessages) {
+			this.maxNumberOfMessages = maxNumberOfMessages;
 		}
 
-		public org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties getHandler() {
-			return handler;
+		public Integer getVisibilityTimeout() {
+			return visibilityTimeout;
 		}
 
-		public void setHandler(org.springframework.cloud.aws.autoconfigure.messaging.SqsProperties.HandlerProperties handler) {
-			this.handler = handler;
+		public void setVisibilityTimeout(Integer visibilityTimeout) {
+			this.visibilityTimeout = visibilityTimeout;
 		}
 
-		public String getRegion() {
-			return this.region;
+		public Integer getWaitTimeout() {
+			return waitTimeout;
 		}
 
-		public void setRegion(String region) {
-			this.region = region;
+		public void setWaitTimeout(Integer waitTimeout) {
+			this.waitTimeout = waitTimeout;
 		}
 
-		public static class ListenerProperties {
-
-			/**
-			 * The maximum number of messages that should be retrieved during one poll to the
-			 * Amazon SQS system. This number must be a positive, non-zero number that has a
-			 * maximum number of 10. Values higher then 10 are currently not supported by the
-			 * queueing system.
-			 */
-			private Integer maxNumberOfMessages = 10;
-
-			/**
-			 * The duration (in seconds) that the received messages are hidden from subsequent
-			 * poll requests after being retrieved from the system.
-			 */
-			private Integer visibilityTimeout;
-
-			/**
-			 * The wait timeout that the poll request will wait for new message to arrive if
-			 * the are currently no messages on the queue. Higher values will reduce poll
-			 * request to the system significantly. The value should be between 1 and 20. For
-			 * more information read the <a href=
-			 * "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
-			 */
-			private Integer waitTimeout = 20;
-
-			/**
-			 * The queue stop timeout that waits for a queue to stop before interrupting the
-			 * running thread.
-			 */
-			private Long queueStopTimeout;
-
-			/**
-			 * The number of milliseconds the polling thread must wait before trying to
-			 * recover when an error occurs (e.g. connection timeout).
-			 */
-			private Long backOffTime;
-
-			/**
-			 * Configures if this container should be automatically started.
-			 */
-			private boolean autoStartup = true;
-
-			public Integer getMaxNumberOfMessages() {
-				return maxNumberOfMessages;
-			}
-
-			public void setMaxNumberOfMessages(Integer maxNumberOfMessages) {
-				this.maxNumberOfMessages = maxNumberOfMessages;
-			}
-
-			public Integer getVisibilityTimeout() {
-				return visibilityTimeout;
-			}
-
-			public void setVisibilityTimeout(Integer visibilityTimeout) {
-				this.visibilityTimeout = visibilityTimeout;
-			}
-
-			public Integer getWaitTimeout() {
-				return waitTimeout;
-			}
-
-			public void setWaitTimeout(Integer waitTimeout) {
-				this.waitTimeout = waitTimeout;
-			}
-
-			public Long getQueueStopTimeout() {
-				return queueStopTimeout;
-			}
-
-			public void setQueueStopTimeout(Long queueStopTimeout) {
-				this.queueStopTimeout = queueStopTimeout;
-			}
-
-			public Long getBackOffTime() {
-				return backOffTime;
-			}
-
-			public void setBackOffTime(Long backOffTime) {
-				this.backOffTime = backOffTime;
-			}
-
-			public boolean isAutoStartup() {
-				return autoStartup;
-			}
-
-			public void setAutoStartup(boolean autoStartup) {
-				this.autoStartup = autoStartup;
-			}
-
+		public Long getQueueStopTimeout() {
+			return queueStopTimeout;
 		}
 
-		public static class HandlerProperties {
+		public void setQueueStopTimeout(Long queueStopTimeout) {
+			this.queueStopTimeout = queueStopTimeout;
+		}
 
-			/**
-			 * Configures global deletion policy used if deletion policy is not explicitly set
-			 * on {@link SqsListener}.
-			 */
-			private SqsMessageDeletionPolicy defaultDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;
+		public Long getBackOffTime() {
+			return backOffTime;
+		}
 
-			public SqsMessageDeletionPolicy getDefaultDeletionPolicy() {
-				return defaultDeletionPolicy;
-			}
+		public void setBackOffTime(Long backOffTime) {
+			this.backOffTime = backOffTime;
+		}
 
-			public void setDefaultDeletionPolicy(
-				SqsMessageDeletionPolicy defaultDeletionPolicy) {
-				this.defaultDeletionPolicy = defaultDeletionPolicy;
-			}
+		public boolean isAutoStartup() {
+			return autoStartup;
+		}
 
+		public void setAutoStartup(boolean autoStartup) {
+			this.autoStartup = autoStartup;
 		}
 
 	}
+
+	public static class HandlerProperties {
+
+		/**
+		 * Configures global deletion policy used if deletion policy is not explicitly set
+		 * on {@link SqsListener}.
+		 */
+		private SqsMessageDeletionPolicy defaultDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;
+
+		public SqsMessageDeletionPolicy getDefaultDeletionPolicy() {
+			return defaultDeletionPolicy;
+		}
+
+		public void setDefaultDeletionPolicy(
+				SqsMessageDeletionPolicy defaultDeletionPolicy) {
+			this.defaultDeletionPolicy = defaultDeletionPolicy;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.autoconfigure.messaging;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
 import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
 import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
@@ -62,6 +63,7 @@ public class SqsProperties {
 		this.handler = handler;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.region")
 	public String getRegion() {
 		return this.region;
 	}
@@ -112,6 +114,7 @@ public class SqsProperties {
 		 */
 		private boolean autoStartup = true;
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.max-number-of-messages")
 		public Integer getMaxNumberOfMessages() {
 			return maxNumberOfMessages;
 		}
@@ -120,6 +123,7 @@ public class SqsProperties {
 			this.maxNumberOfMessages = maxNumberOfMessages;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.visibility-timeout")
 		public Integer getVisibilityTimeout() {
 			return visibilityTimeout;
 		}
@@ -128,6 +132,7 @@ public class SqsProperties {
 			this.visibilityTimeout = visibilityTimeout;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.wait-timeout")
 		public Integer getWaitTimeout() {
 			return waitTimeout;
 		}
@@ -136,6 +141,7 @@ public class SqsProperties {
 			this.waitTimeout = waitTimeout;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.queue-stop-timeout")
 		public Long getQueueStopTimeout() {
 			return queueStopTimeout;
 		}
@@ -144,6 +150,7 @@ public class SqsProperties {
 			this.queueStopTimeout = queueStopTimeout;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.back-off-timeout")
 		public Long getBackOffTime() {
 			return backOffTime;
 		}
@@ -152,6 +159,7 @@ public class SqsProperties {
 			this.backOffTime = backOffTime;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.auto-startup")
 		public boolean isAutoStartup() {
 			return autoStartup;
 		}
@@ -170,6 +178,7 @@ public class SqsProperties {
 		 */
 		private SqsMessageDeletionPolicy defaultDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;
 
+		@DeprecatedConfigurationProperty(replacement = "spring.cloud.aws.sqs.handler.default-deletion-policy")
 		public SqsMessageDeletionPolicy getDefaultDeletionPolicy() {
 			return defaultDeletionPolicy;
 		}

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -26,6 +26,12 @@
     },
     {
       "defaultValue": true,
+      "name": "spring.cloud.aws.sqs.enabled",
+      "description": "Enables SQS integration.",
+      "type": "java.lang.Boolean"
+    },
+    {
+      "defaultValue": true,
       "name": "cloud.aws.sns.enabled",
       "description": "Enables SNS integration.",
       "type": "java.lang.Boolean"

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -6,6 +6,7 @@ org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoCon
 org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.mail.SimpleEmailAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration,\
+org.springframework.cloud.aws.autoconfigure.messaging.SimpleQueueServiceAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.messaging.SqsAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.messaging.SnsAutoConfiguration,\
 org.springframework.cloud.aws.autoconfigure.jdbc.AmazonRdsDatabaseAutoConfiguration,\

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.messaging;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.cloud.aws.core.region.StaticRegionProvider;
+import org.springframework.cloud.aws.messaging.config.QueueMessageHandlerFactory;
+import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
+import org.springframework.cloud.aws.messaging.support.destination.DynamicQueueUrlDestinationResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.core.DestinationResolvingMessageSendingOperations;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodReturnValueHandler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
+
+/**
+ * Tests for {@link SimpleQueueServiceAutoConfiguration}.
+ *
+ * @author Alain Sahli
+ * @author Maciej Walkowiak
+ * @author Matej Nedic
+ * @author Mete Alpaslan Katırcıoğlu
+ * @author Eddú Meléndez
+ */
+class SimpleQueueServiceAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(SimpleQueueServiceAutoConfiguration.class))
+			.withUserConfiguration(MinimalConfiguration.class);
+
+	@Test
+	void configuration_withCustomClient_shouldBeUsedByContainer() {
+		this.contextRunner
+				.withUserConfiguration(ConfigurationWithCustomAmazonClient.class)
+				.run((context) -> {
+					AmazonSQSAsync amazonSqsClient = context
+							.getBean(AmazonSQSAsync.class);
+					assertThat(amazonSqsClient).isEqualTo(
+							ConfigurationWithCustomAmazonClient.CUSTOM_SQS_CLIENT);
+				});
+	}
+
+	@Test
+	void configuration_withMinimalBeans_shouldStartSqsListenerContainer()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner.run((context) -> {
+			SimpleMessageListenerContainer container = context
+					.getBean(SimpleMessageListenerContainer.class);
+
+			// Assert
+			assertThat(container.isRunning()).isTrue();
+			QueueMessageHandler queueMessageHandler = context
+					.getBean(QueueMessageHandler.class);
+
+			assertThat(queueMessageHandler.getCustomReturnValueHandlers().get(0))
+					.extracting("messageTemplate").extracting("amazonSqs")
+					.extracting("realSQS").extracting("awsCredentialsProvider")
+					.isNotNull();
+		});
+
+	}
+
+	@Test
+	void configuration_withCustomProperties_shouldBeUsedByTheContainer() {
+		this.contextRunner
+				.withPropertyValues(
+						"spring.cloud.aws.sqs.listener.max-number-of-messages=5",
+						"spring.cloud.aws.sqs.listener.visibility-timeout=10",
+						"spring.cloud.aws.sqs.listener.wait-timeout=5",
+						"spring.cloud.aws.sqs.listener.queue-stop-timeout=10",
+						"spring.cloud.aws.sqs.listener.back-off-time=15",
+						"spring.cloud.aws.sqs.listener.auto-startup=false")
+				.run((context) -> {
+					SimpleMessageListenerContainer container = context
+							.getBean(SimpleMessageListenerContainer.class);
+
+					assertThat(container.getBackOffTime()).isEqualTo(15);
+					assertThat(container.getQueueStopTimeout()).isEqualTo(10);
+					assertThat(container)
+							.hasFieldOrPropertyWithValue("maxNumberOfMessages", 5);
+					assertThat(container).hasFieldOrPropertyWithValue("visibilityTimeout",
+							10);
+					assertThat(container).hasFieldOrPropertyWithValue("waitTimeOut", 5);
+					assertThat(container).hasFieldOrPropertyWithValue("autoStartup",
+							false);
+				});
+	}
+
+	@Test
+	void configuration_withCustomProperties_shouldBeUsedByTheQueueMessageHandler() {
+		this.contextRunner
+				.withPropertyValues(
+						"spring.cloud.aws.sqs.handler.default-deletion-policy=ALWAYS")
+				.run((context) -> {
+					QueueMessageHandler handler = context
+							.getBean(QueueMessageHandler.class);
+
+					assertThat(handler).hasFieldOrPropertyWithValue(
+							"sqsMessageDeletionPolicy", SqsMessageDeletionPolicy.ALWAYS);
+				});
+	}
+
+	@Test
+	void configuration_withCustomAmazonClient_shouldBeUsedByTheContainer()
+			throws Exception {
+		this.contextRunner
+				.withUserConfiguration(ConfigurationWithCustomAmazonClient.class)
+				.run((context) -> {
+					// Assert
+					AmazonSQSAsync amazonSqsClient = context
+							.getBean(AmazonSQSAsync.class);
+					assertThat(amazonSqsClient).isEqualTo(
+							ConfigurationWithCustomAmazonClient.CUSTOM_SQS_CLIENT);
+				});
+	}
+
+	@Test
+	void messageHandler_withFactoryConfiguration_shouldUseCustomValues()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner
+				.withUserConfiguration(ConfigurationWithCustomizedMessageHandler.class)
+				.run((context) -> {
+					QueueMessageHandler messageHandler = context
+							.getBean(QueueMessageHandler.class);
+
+					// Assert
+					assertThat(messageHandler.getCustomArgumentResolvers()).hasSize(1);
+					assertThat(messageHandler.getCustomArgumentResolvers())
+							.containsExactly(
+									ConfigurationWithCustomizedMessageHandler.CUSTOM_ARGUMENT_RESOLVER);
+
+					assertThat(messageHandler.getCustomReturnValueHandlers()).hasSize(2);
+					assertThat(messageHandler.getCustomReturnValueHandlers().get(0))
+							.isEqualTo(
+									ConfigurationWithCustomizedMessageHandler.CUSTOM_RETURN_VALUE_HANDLER);
+
+					assertThat(messageHandler).hasFieldOrPropertyWithValue(
+							"sqsMessageDeletionPolicy",
+							SqsMessageDeletionPolicy.NO_REDRIVE);
+
+					Object sendToMessageTemplate = ReflectionTestUtils.getField(
+							messageHandler.getReturnValueHandlers().get(1),
+							"messageTemplate");
+					assertThat(sendToMessageTemplate).hasFieldOrPropertyWithValue(
+							"amazonSqs",
+							ConfigurationWithCustomizedMessageHandler.CUSTOM_AMAZON_SQS);
+
+					assertThat(sendToMessageTemplate).extracting("destinationResolver")
+							.extracting("targetDestinationResolver")
+							.extracting("resourceIdResolver").isEqualTo(
+									ConfigurationWithCustomizedMessageHandler.CUSTOM_RESOURCE_ID_RESOLVER);
+				});
+	}
+
+	@Test
+	void messageHandler_withFactoryConfiguration_shouldUseGlobalDeletionPolicy()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(
+				ConfigurationWithCustomizedMessageHandlerGlobalDeletionPolicy.class)
+				.run((context) -> {
+					QueueMessageHandler messageHandler = context
+							.getBean(QueueMessageHandler.class);
+
+					// Assert
+					assertThat(messageHandler).hasFieldOrPropertyWithValue(
+							"sqsMessageDeletionPolicy",
+							SqsMessageDeletionPolicy.ON_SUCCESS);
+				});
+	}
+
+	@Test
+	void configuration_withCustomConfigurationFactory_shouldBeUsedToCreateTheContainer()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner
+				.withUserConfiguration(ConfigurationWithCustomContainerFactory.class)
+				.run((context) -> {
+					SimpleMessageListenerContainer container = context
+							.getBean(SimpleMessageListenerContainer.class);
+
+					// Assert
+					assertThat(container).hasFieldOrPropertyWithValue("amazonSqs",
+							ConfigurationWithCustomContainerFactory.AMAZON_SQS);
+					assertThat(container.isAutoStartup()).isEqualTo(
+							ConfigurationWithCustomContainerFactory.AUTO_STARTUP);
+					assertThat(container).hasFieldOrPropertyWithValue(
+							"maxNumberOfMessages",
+							ConfigurationWithCustomContainerFactory.MAX_NUMBER_OF_MESSAGES);
+					assertThat(container).hasFieldOrPropertyWithValue("messageHandler",
+							ConfigurationWithCustomContainerFactory.MESSAGE_HANDLER);
+					assertThat(container).hasFieldOrPropertyWithValue(
+							"resourceIdResolver",
+							ConfigurationWithCustomContainerFactory.RESOURCE_ID_RESOLVER);
+					assertThat(container).hasFieldOrPropertyWithValue("taskExecutor",
+							ConfigurationWithCustomContainerFactory.TASK_EXECUTOR);
+					assertThat(container).hasFieldOrPropertyWithValue("visibilityTimeout",
+							ConfigurationWithCustomContainerFactory.VISIBILITY_TIMEOUT);
+					assertThat(container).hasFieldOrPropertyWithValue("waitTimeOut",
+							ConfigurationWithCustomContainerFactory.WAIT_TIME_OUT);
+					assertThat(container).hasFieldOrPropertyWithValue("queueStopTimeout",
+							ConfigurationWithCustomContainerFactory.QUEUE_STOP_TIME_OUT);
+					assertThat(container).hasFieldOrPropertyWithValue(
+							"destinationResolver",
+							ConfigurationWithCustomContainerFactory.DESTINATION_RESOLVER);
+					assertThat(container.getBackOffTime()).isEqualTo(
+							ConfigurationWithCustomContainerFactory.BACK_OFF_TIME);
+				});
+	}
+
+	@Test
+	void configuration_withCustomSendToMessageTemplate_shouldUseTheConfiguredTemplate()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner
+				.withUserConfiguration(ConfigurationWithCustomSendToMessageTemplate.class)
+				.run((context) -> {
+					QueueMessageHandler queueMessageHandler = context
+							.getBean(QueueMessageHandler.class);
+
+					// Assert
+					assertThat(queueMessageHandler.getReturnValueHandlers()).hasSize(1);
+					assertThat(queueMessageHandler.getReturnValueHandlers().get(0))
+							.hasFieldOrPropertyWithValue("messageTemplate",
+									ConfigurationWithCustomSendToMessageTemplate.SEND_TO_MESSAGE_TEMPLATE);
+				});
+	}
+
+	@Test
+	void queueMessageHandlerBeanMustBeSetOnContainer() throws Exception {
+		// Arrange & Act
+		this.contextRunner.run((context) -> {
+			SimpleMessageListenerContainer simpleMessageListenerContainer = context
+					.getBean(SimpleMessageListenerContainer.class);
+			QueueMessageHandler queueMessageHandler = context
+					.getBean(QueueMessageHandler.class);
+
+			// Assert
+			assertThat(simpleMessageListenerContainer)
+					.hasFieldOrPropertyWithValue("messageHandler", queueMessageHandler);
+		});
+	}
+
+	@Test
+	void configuration_withObjectMapper_shouldSetObjectMapperOnQueueMessageHandler()
+			throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithObjectMapper.class)
+				.run((context) -> {
+					QueueMessageHandler queueMessageHandler = context
+							.getBean(QueueMessageHandler.class);
+					ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+					List<MessageConverter> converters = (List<MessageConverter>) ReflectionTestUtils
+							.getField(queueMessageHandler, "messageConverters");
+					MappingJackson2MessageConverter mappingJackson2MessageConverter = (MappingJackson2MessageConverter) converters
+							.get(0);
+
+					// Assert
+					assertThat(mappingJackson2MessageConverter.getObjectMapper())
+							.isEqualTo(objectMapper);
+				});
+	}
+
+	@Test
+	void configuration_withoutAwsCredentials_shouldCreateAClientWithDefaultCredentialsProvider()
+			throws Exception {
+		// Arrange & Act
+		new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(SqsAutoConfiguration.class))
+				.withUserConfiguration(ConfigurationWithMissingAwsCredentials.class)
+				.run((context) -> {
+					// Assert
+					AmazonSQSBufferedAsyncClient bufferedAmazonSqsClient = context
+							.getBean(AmazonSQSBufferedAsyncClient.class);
+
+					assertThat(bufferedAmazonSqsClient).extracting("realSQS")
+							.extracting("awsCredentialsProvider")
+							.isInstanceOf(DefaultAWSCredentialsProviderChain.class);
+				});
+	}
+
+	@Test
+	void configuration_withRegionProvider_shouldUseItForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithRegionProvider.class)
+				.run((context) -> {
+					AmazonSQSAsync bufferedAmazonSqsClient = context
+							.getBean(AmazonSQSAsync.class);
+					AmazonSQSAsyncClient amazonSqs = (AmazonSQSAsyncClient) ReflectionTestUtils
+							.getField(bufferedAmazonSqsClient, "realSQS");
+
+					// Assert
+					assertThat(ReflectionTestUtils.getField(amazonSqs, "endpoint")
+							.toString()).isEqualTo(
+									"https://" + Region.getRegion(Regions.EU_WEST_1)
+											.getServiceEndpoint("sqs"));
+				});
+	}
+
+	@Test
+	void enableSqsWithSpecificRegion() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.region:us-east-1")
+				.run(context -> {
+					AmazonSQSBufferedAsyncClient bufferedAmazonSqsClient = context
+							.getBean(AmazonSQSBufferedAsyncClient.class);
+					AmazonSQSAsyncClient client = (AmazonSQSAsyncClient) ReflectionTestUtils
+							.getField(bufferedAmazonSqsClient, "realSQS");
+
+					Object region = ReflectionTestUtils.getField(client, "signingRegion");
+					assertThat(region).isEqualTo(Regions.US_EAST_1.getName());
+				});
+	}
+
+	@Test
+	void disableSqs() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.enabled:false")
+				.run(context -> {
+					assertThat(context)
+							.doesNotHaveBean(AmazonSQSBufferedAsyncClient.class);
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MinimalConfiguration {
+
+		@Bean
+		AWSCredentialsProvider awsCredentials() {
+			return mock(AWSCredentialsProvider.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCustomizedMessageHandler {
+
+		static final HandlerMethodReturnValueHandler CUSTOM_RETURN_VALUE_HANDLER = mock(
+				HandlerMethodReturnValueHandler.class);
+
+		static final HandlerMethodArgumentResolver CUSTOM_ARGUMENT_RESOLVER = mock(
+				HandlerMethodArgumentResolver.class);
+
+		static final AmazonSQSAsync CUSTOM_AMAZON_SQS = mock(AmazonSQSAsync.class,
+				withSettings().stubOnly());
+
+		static final ResourceIdResolver CUSTOM_RESOURCE_ID_RESOLVER = mock(
+				ResourceIdResolver.class);
+
+		@Bean
+		QueueMessageHandlerFactory queueMessageHandlerFactory() {
+			QueueMessageHandlerFactory factory = new QueueMessageHandlerFactory();
+			factory.setArgumentResolvers(
+					Collections.singletonList(CUSTOM_ARGUMENT_RESOLVER));
+			factory.setReturnValueHandlers(
+					Collections.singletonList(CUSTOM_RETURN_VALUE_HANDLER));
+			factory.setAmazonSqs(CUSTOM_AMAZON_SQS);
+			factory.setResourceIdResolver(CUSTOM_RESOURCE_ID_RESOLVER);
+			factory.setSqsMessageDeletionPolicy(SqsMessageDeletionPolicy.NO_REDRIVE);
+			return factory;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCustomizedMessageHandlerGlobalDeletionPolicy {
+
+		static final HandlerMethodReturnValueHandler CUSTOM_RETURN_VALUE_HANDLER = mock(
+				HandlerMethodReturnValueHandler.class);
+
+		static final HandlerMethodArgumentResolver CUSTOM_ARGUMENT_RESOLVER = mock(
+				HandlerMethodArgumentResolver.class);
+
+		static final AmazonSQSAsync CUSTOM_AMAZON_SQS = mock(AmazonSQSAsync.class,
+				withSettings().stubOnly());
+
+		static final ResourceIdResolver CUSTOM_RESOURCE_ID_RESOLVER = mock(
+				ResourceIdResolver.class);
+
+		@Bean
+		QueueMessageHandlerFactory queueMessageHandlerFactory() {
+			QueueMessageHandlerFactory factory = new QueueMessageHandlerFactory();
+			factory.setArgumentResolvers(
+					Collections.singletonList(CUSTOM_ARGUMENT_RESOLVER));
+			factory.setReturnValueHandlers(
+					Collections.singletonList(CUSTOM_RETURN_VALUE_HANDLER));
+			factory.setSqsMessageDeletionPolicy(SqsMessageDeletionPolicy.ON_SUCCESS);
+			factory.setAmazonSqs(CUSTOM_AMAZON_SQS);
+			factory.setResourceIdResolver(CUSTOM_RESOURCE_ID_RESOLVER);
+			factory.setSqsMessageDeletionPolicy(SqsMessageDeletionPolicy.ON_SUCCESS);
+
+			return factory;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCustomContainerFactory {
+
+		static final AmazonSQSAsync AMAZON_SQS = mock(AmazonSQSAsync.class,
+				withSettings().stubOnly());
+
+		static final boolean AUTO_STARTUP = true;
+
+		static final int MAX_NUMBER_OF_MESSAGES = 1456;
+
+		static final QueueMessageHandler MESSAGE_HANDLER;
+
+		static final ResourceIdResolver RESOURCE_ID_RESOLVER = mock(
+				ResourceIdResolver.class);
+
+		static final SimpleAsyncTaskExecutor TASK_EXECUTOR = new SimpleAsyncTaskExecutor();
+
+		static final int VISIBILITY_TIMEOUT = 1789;
+
+		static final int WAIT_TIME_OUT = 12;
+
+		static final long QUEUE_STOP_TIME_OUT = 12;
+
+		static final DestinationResolver<String> DESTINATION_RESOLVER = new DynamicQueueUrlDestinationResolver(
+				mock(AmazonSQSAsync.class, withSettings().stubOnly()));
+
+		static final long BACK_OFF_TIME = 5000;
+
+		static {
+			QueueMessageHandler queueMessageHandler = new QueueMessageHandler();
+			queueMessageHandler.setApplicationContext(new StaticApplicationContext());
+			MESSAGE_HANDLER = queueMessageHandler;
+		}
+
+		@Bean
+		SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory() {
+			SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+			factory.setAmazonSqs(amazonSQS());
+			factory.setAutoStartup(AUTO_STARTUP);
+			factory.setMaxNumberOfMessages(MAX_NUMBER_OF_MESSAGES);
+			factory.setQueueMessageHandler(MESSAGE_HANDLER);
+			factory.setResourceIdResolver(RESOURCE_ID_RESOLVER);
+			factory.setTaskExecutor(TASK_EXECUTOR);
+			factory.setVisibilityTimeout(VISIBILITY_TIMEOUT);
+			factory.setWaitTimeOut(WAIT_TIME_OUT);
+			factory.setQueueStopTimeout(QUEUE_STOP_TIME_OUT);
+			factory.setDestinationResolver(DESTINATION_RESOLVER);
+			factory.setBackOffTime(BACK_OFF_TIME);
+
+			return factory;
+		}
+
+		@Bean
+		AmazonSQSAsync amazonSQS() {
+			return AMAZON_SQS;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCustomSendToMessageTemplate {
+
+		static final DestinationResolvingMessageSendingOperations<?> SEND_TO_MESSAGE_TEMPLATE = mock(
+				DestinationResolvingMessageSendingOperations.class);
+
+		@Bean
+		QueueMessageHandlerFactory queueMessageHandlerFactory() {
+			QueueMessageHandlerFactory factory = new QueueMessageHandlerFactory();
+			factory.setSendToMessagingTemplate(SEND_TO_MESSAGE_TEMPLATE);
+
+			return factory;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithMissingAwsCredentials {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithRegionProvider {
+
+		@Bean(name = REGION_PROVIDER_BEAN_NAME)
+		RegionProvider regionProvider() {
+			return new StaticRegionProvider("eu-west-1");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithObjectMapper {
+
+		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCustomAmazonClient {
+
+		static final AmazonSQSAsync CUSTOM_SQS_CLIENT = mock(AmazonSQSAsync.class);
+
+		@Bean
+		AmazonSQSAsync amazonSQS() {
+			return CUSTOM_SQS_CLIENT;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
@@ -313,7 +313,7 @@ class SimpleQueueServiceAutoConfigurationTest {
 			throws Exception {
 		// Arrange & Act
 		new ApplicationContextRunner()
-				.withConfiguration(AutoConfigurations.of(SqsAutoConfiguration.class))
+				.withConfiguration(AutoConfigurations.of(SimpleQueueServiceAutoConfiguration.class))
 				.withUserConfiguration(ConfigurationWithMissingAwsCredentials.class)
 				.run((context) -> {
 					// Assert

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SimpleQueueServiceAutoConfigurationTest.java
@@ -313,7 +313,8 @@ class SimpleQueueServiceAutoConfigurationTest {
 			throws Exception {
 		// Arrange & Act
 		new ApplicationContextRunner()
-				.withConfiguration(AutoConfigurations.of(SimpleQueueServiceAutoConfiguration.class))
+				.withConfiguration(
+						AutoConfigurations.of(SimpleQueueServiceAutoConfiguration.class))
 				.withUserConfiguration(ConfigurationWithMissingAwsCredentials.class)
 				.run((context) -> {
 					// Assert


### PR DESCRIPTION
Draft #667 .
Move sqs autoconfiguration to new prefix while supporting old one.