### PR TITLE
Missing enabled tests

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
@@ -95,10 +95,11 @@ class SnsAutoConfigurationTest {
 
 	@Test
 	void disableSns() {
-		this.contextRunner.withPropertyValues("cloud.aws.sns.enabled:false").run(context -> {
-			assertThat(context).doesNotHaveBean(AmazonSNS.class);
-			assertThat(context).doesNotHaveBean(AmazonSNSClient.class);
-		});
+		this.contextRunner.withPropertyValues("cloud.aws.sns.enabled:false")
+				.run(context -> {
+					assertThat(context).doesNotHaveBean(AmazonSNS.class);
+					assertThat(context).doesNotHaveBean(AmazonSNSClient.class);
+				});
 	}
 
 	@Test

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
@@ -94,6 +94,14 @@ class SnsAutoConfigurationTest {
 	}
 
 	@Test
+	void disableSns() {
+		this.contextRunner.withPropertyValues("cloud.aws.sns.enabled:false").run(context -> {
+			assertThat(context).doesNotHaveBean(AmazonSNS.class);
+			assertThat(context).doesNotHaveBean(AmazonSNSClient.class);
+		});
+	}
+
+	@Test
 	void enableSns_withCustomAmazonSnsClient_shouldBeUsedByTheArgumentResolver()
 			throws Exception {
 		// Arrange & Act

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
@@ -343,6 +343,14 @@ class SqsAutoConfigurationTest {
 	}
 
 	@Test
+	void disableSqs() {
+		this.contextRunner.withPropertyValues("cloud.aws.sqs.enabled:false").run(context -> {
+			assertThat(context).doesNotHaveBean(AmazonSQSAsync.class);
+			assertThat(context).doesNotHaveBean(AmazonSQSBufferedAsyncClient.class);
+		});
+	}
+
+	@Test
 	void enableSqsWithSpecificRegion() {
 		this.contextRunner.withPropertyValues("cloud.aws.sqs.region:us-east-1")
 				.run(context -> {

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
@@ -344,10 +344,12 @@ class SqsAutoConfigurationTest {
 
 	@Test
 	void disableSqs() {
-		this.contextRunner.withPropertyValues("cloud.aws.sqs.enabled:false").run(context -> {
-			assertThat(context).doesNotHaveBean(AmazonSQSAsync.class);
-			assertThat(context).doesNotHaveBean(AmazonSQSBufferedAsyncClient.class);
-		});
+		this.contextRunner.withPropertyValues("cloud.aws.sqs.enabled:false")
+				.run(context -> {
+					assertThat(context).doesNotHaveBean(AmazonSQSAsync.class);
+					assertThat(context)
+							.doesNotHaveBean(AmazonSQSBufferedAsyncClient.class);
+				});
 	}
 
 	@Test


### PR DESCRIPTION
Param store and Secret store autoconfiguration have missing enabled tests but since migrating to contextRunner is in another ticket and currently in 2.3.x it wasn't included.