### PR TITLE
Add Github action to build docs and upload them to S3.

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,0 +1,31 @@
+name: Build and upload docs
+
+on:
+  push:
+    branches:
+      - 3.0.x
+      - 2.3.x
+      - 2.2.x
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build docs
+        run: ./mvnw -pl docs clean package -Pdocs
+      - name: Upload to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_KEY }}
+        run: aws s3 sync --delete --acl public-read docs/target/generated-docs/ s3://awspring-docs/spring-cloud-aws/docs/

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -31,4 +31,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_KEY }}
         run: |
           aws s3 sync --delete --acl public-read docs/target/generated-docs/ s3://awspring-docs/spring-cloud-aws/docs/
-          aws cloudfront create-invalidation --distribution-id EA7LER7CI960A --paths /*
+          aws cloudfront create-invalidation --distribution-id EA7LER7CI960A --paths "/*"

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -6,6 +6,7 @@ on:
       - 3.0.x
       - 2.3.x
       - 2.2.x
+      - upload-docs-to-s3
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,4 +29,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_KEY }}
-        run: aws s3 sync --delete --acl public-read docs/target/generated-docs/ s3://awspring-docs/spring-cloud-aws/docs/
+        run: |
+          aws s3 sync --delete --acl public-read docs/target/generated-docs/ s3://awspring-docs/spring-cloud-aws/docs/
+          aws cloudfront create-invalidation --distribution-id EA7LER7CI960A --paths /*

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -6,7 +6,6 @@ on:
       - 3.0.x
       - 2.3.x
       - 2.2.x
-      - upload-docs-to-s3
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -33,6 +33,9 @@
 		<main.basedir>${basedir}/..</main.basedir>
 		<configprops.inclusionPattern>cloud.aws.*|aws.*</configprops.inclusionPattern>
 		<upload-docs-zip.phase>deploy</upload-docs-zip.phase>
+		<generated-docs-multipage-output.dir>${project.build.directory}/generated-docs/${project.version}/reference/html</generated-docs-multipage-output.dir>
+		<generated-docs-singlepage-output.dir>${project.build.directory}/generated-docs/${project.version}/reference/htmlsingle</generated-docs-singlepage-output.dir>
+		<generated-docs-pdf-output.dir>${project.build.directory}/generated-docs/${project.version}/reference/pdf</generated-docs-pdf-output.dir>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Github action that builds & uploads docs for selected branches to S3.

Docs are uploaded to: https://docs.awspring.io/spring-cloud-aws/docs/2.2.5.BUILD-SNAPSHOT/reference/html/index.html


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Once project moves to `awspring` we need to publish docs ourselves.

This PR requires `S3_AWS_SECRET_KEY` and `S3_AWS_ACCESS_KEY` secrets set up in repository settings - that's why it's likely going to be merged only after we move to new organisation.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes
