### PR TITLE
Bring back XML configuration and deprecate all related classes.

### DIFF
--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParser.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.cache.config.xml;
+
+import java.util.List;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * Parser for the {@code <aws-cache:cache-manager />} element.
+ *
+ * @author Alain Sahli
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@Deprecated
+class CacheBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String CACHE_MANAGER = "cacheManager";
+
+	private static final String CACHE_CLUSTER_ELEMENT_NAME = "cache-cluster";
+
+	private static final String CACHE_REF_ELEMENT_NAME = "cache-ref";
+
+	private static final String ELASTICACHE_FACTORY_BEAN = "org.springframework.cloud.aws.cache.ElastiCacheFactoryBean";
+
+	// @checkstyle:off
+	private static final String ELASTI_CACHE_CLIENT_CLASS_NAME = "com.amazonaws.services.elasticache.AmazonElastiCacheClient";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	private static final String MEMCACHED_FACTORY_CLASS_NAME = "org.springframework.cloud.aws.cache.memcached.MemcachedCacheFactory";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	private static final String REDIS_CONNECTION_FACTORY_CLASS_NAME = "org.springframework.cloud.aws.cache.redis.RedisCacheFactory";
+
+	// @checkstyle:on
+
+	private static String getRequiredAttribute(String attributeName, Element source, ParserContext parserContext) {
+		if (StringUtils.hasText(source.getAttribute(attributeName))) {
+			return source.getAttribute(attributeName);
+		}
+		else {
+			parserContext.getReaderContext().error("Attribute '" + attributeName + "' is required", source);
+			return null;
+		}
+	}
+
+	private static ManagedList<BeanDefinition> createDefaultCacheFactories(Element element,
+			ParserContext parserContext) {
+		ManagedList<BeanDefinition> result = new ManagedList<>();
+		result.setSource(parserContext.extractSource(element));
+		if (ClassUtils.isPresent("net.spy.memcached.MemcachedClient",
+				parserContext.getReaderContext().getBeanClassLoader())) {
+			result.add(getCacheFactory(MEMCACHED_FACTORY_CLASS_NAME, element));
+		}
+
+		if (ClassUtils.isPresent("org.springframework.data.redis.connection.RedisConnectionFactory",
+				parserContext.getReaderContext().getBeanClassLoader())) {
+			result.add(getCacheFactory(REDIS_CONNECTION_FACTORY_CLASS_NAME, element));
+		}
+		return result;
+	}
+
+	private static BeanDefinition createElastiCacheFactoryBean(Element source, ParserContext parserContext,
+			String clusterId, ManagedList<BeanDefinition> cacheFactories) {
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(ELASTICACHE_FACTORY_BEAN);
+		beanDefinitionBuilder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(source, parserContext,
+				"amazon-elasti-cache", ELASTI_CACHE_CLIENT_CLASS_NAME));
+		beanDefinitionBuilder.addConstructorArgValue(clusterId);
+		beanDefinitionBuilder.addConstructorArgReference(
+				GlobalBeanDefinitionUtils.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
+		beanDefinitionBuilder.addConstructorArgValue(cacheFactories);
+		return beanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static BeanDefinition getCacheFactory(String className, Element element) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(className);
+		if (StringUtils.hasText(element.getAttribute("expiration"))) {
+			builder.addPropertyValue("expiryTime", element.getAttribute("expiration"));
+		}
+		return builder.getBeanDefinition();
+	}
+
+	@Override
+	protected String getBeanClassName(Element element) {
+		return "org.springframework.cache.support.SimpleCacheManager";
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		if (parserContext.getRegistry().containsBeanDefinition(CACHE_MANAGER)) {
+			parserContext.getReaderContext().error("Only one cache manager can be defined", element);
+		}
+
+		builder.addPropertyValue("caches", createCacheCollection(element, parserContext));
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return CACHE_MANAGER;
+	}
+
+	private ManagedList<Object> createCacheCollection(Element element, ParserContext parserContext) {
+		ManagedList<Object> caches = new ManagedList<>();
+		List<Element> cacheElements = DomUtils.getChildElements(element);
+
+		for (Element cacheElement : cacheElements) {
+			String elementName = cacheElement.getLocalName();
+
+			switch (elementName) {
+			case CACHE_REF_ELEMENT_NAME:
+				caches.add(new RuntimeBeanReference(cacheElement.getAttribute("ref")));
+				break;
+			case CACHE_CLUSTER_ELEMENT_NAME:
+				String cacheClusterId = getRequiredAttribute("name", cacheElement, parserContext);
+				caches.add(createElastiCacheFactoryBean(cacheElement, parserContext, cacheClusterId,
+						createDefaultCacheFactories(cacheElement, parserContext)));
+				break;
+			default:
+				parserContext.getReaderContext().error("Unknown element detected",
+						parserContext.extractSource(cacheElement));
+			}
+		}
+		return caches;
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/cache/config/xml/CacheNamespaceHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.cache.config.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+public class CacheNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		registerBeanDefinitionParser("cache-manager", new CacheBeanDefinitionParser());
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParser.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.core.credentials.CredentialsProviderFactoryBean;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.replaceDefaultCredentialsProvider;
+
+/**
+ * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} implementation which
+ * parses the &lt;context-credentials/&gt; Element.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@Deprecated
+class ContextCredentialsBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	// @checkstyle:off
+	private static final String STATIC_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.AWSStaticCredentialsProvider";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	private static final String INSTANCE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.InstanceProfileCredentialsProvider";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	private static final String PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME = "com.amazonaws.auth.profile.ProfileCredentialsProvider";
+
+	// @checkstyle:on
+
+	private static final String ACCESS_KEY_ATTRIBUTE_NAME = "access-key";
+
+	private static final String SECRET_KEY_ATTRIBUTE_NAME = "secret-key";
+
+	private static BeanDefinition getCredentialsProvider(String credentialsProviderClassName,
+			Object... constructorArg) {
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(credentialsProviderClassName);
+		for (Object o : constructorArg) {
+			beanDefinitionBuilder.addConstructorArgValue(o);
+		}
+
+		return beanDefinitionBuilder.getBeanDefinition();
+	}
+
+	/**
+	 * Creates a bean definition for the credentials object. This methods creates a bean
+	 * definition instead of the direct implementation to allow property place holder to
+	 * change any place holder used for the access or secret key.
+	 * @param credentialsProviderElement - The element that contains the credentials
+	 * attributes ACCESS_KEY_ATTRIBUTE_NAME and SECRET_KEY_ATTRIBUTE_NAME
+	 * @param parserContext - Used to report any errors if there is no
+	 * ACCESS_KEY_ATTRIBUTE_NAME or SECRET_KEY_ATTRIBUTE_NAME available with a valid value
+	 * @return - the bean definition with an
+	 * {@link com.amazonaws.auth.BasicAWSCredentials} class
+	 */
+	private static BeanDefinition getCredentials(Element credentialsProviderElement, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder
+				.rootBeanDefinition("com.amazonaws.auth.BasicAWSCredentials");
+		builder.addConstructorArgValue(
+				getAttributeValue(ACCESS_KEY_ATTRIBUTE_NAME, credentialsProviderElement, parserContext));
+		builder.addConstructorArgValue(
+				getAttributeValue(SECRET_KEY_ATTRIBUTE_NAME, credentialsProviderElement, parserContext));
+		return builder.getBeanDefinition();
+	}
+
+	private static List<String> getProfileConfiguration(Element element) {
+		List<String> constructorArguments = new ArrayList<>(2);
+		if (StringUtils.hasText(element.getAttribute("profilePath"))) {
+			constructorArguments.add(element.getAttribute("profilePath"));
+		}
+
+		if (StringUtils.hasText(element.getAttribute("profileName"))) {
+			constructorArguments.add(element.getAttribute("profileName"));
+		}
+		return constructorArguments;
+	}
+
+	/**
+	 * Returns the attribute value and reports an error if the attribute value is null or
+	 * empty. Normally the reported error leads into an exception which will be thrown
+	 * through the {@link org.springframework.beans.factory.parsing.ProblemReporter}
+	 * implementation.
+	 * @param attribute - The name of the attribute which will be valuated
+	 * @param element - The element that contains the attribute
+	 * @param parserContext - The parser context used to report errors
+	 * @return - The attribute value
+	 */
+	private static String getAttributeValue(String attribute, Element element, ParserContext parserContext) {
+		String attributeValue = element.getAttribute(attribute);
+		if (!StringUtils.hasText(attributeValue)) {
+			parserContext.getReaderContext().error("The '" + attribute + "' attribute must not be empty", element);
+		}
+		return attributeValue;
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME;
+	}
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return CredentialsProviderFactoryBean.class;
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		if (parserContext.getRegistry()
+				.containsBeanDefinition(CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME)) {
+			parserContext.getReaderContext().error("Multiple <context-credentials/> detected. "
+					+ "The <context-credentials/> is only allowed once per application context", element);
+		}
+
+		List<Element> elements = DomUtils.getChildElements(element);
+		ManagedList<BeanDefinition> credentialsProviders = new ManagedList<>(elements.size());
+
+		for (Element credentialsProviderElement : elements) {
+			if ("simple-credentials".equals(credentialsProviderElement.getLocalName())) {
+				credentialsProviders.add(getCredentialsProvider(STATIC_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME,
+						getCredentials(credentialsProviderElement, parserContext)));
+			}
+
+			if ("instance-profile-credentials".equals(credentialsProviderElement.getLocalName())) {
+				credentialsProviders.add(getCredentialsProvider(INSTANCE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME));
+			}
+
+			if ("profile-credentials".equals(credentialsProviderElement.getLocalName())) {
+				credentialsProviders.add(getCredentialsProvider(PROFILE_CREDENTIALS_PROVIDER_BEAN_CLASS_NAME,
+						getProfileConfiguration(credentialsProviderElement).toArray()));
+			}
+		}
+
+		builder.addConstructorArgValue(credentialsProviders);
+
+		replaceDefaultCredentialsProvider(parserContext.getRegistry(),
+				CredentialsProviderFactoryBean.CREDENTIALS_PROVIDER_BEAN_NAME);
+
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParser.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils.isRunningOnCloudEnvironment;
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+class ContextInstanceDataPropertySourceBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	// @checkstyle:off
+	private static final String USER_TAGS_BEAN_CLASS_NAME = "org.springframework.cloud.aws.core.env.ec2.AmazonEc2InstanceUserTagsFactoryBean";
+
+	// @checkstyle:on
+
+	private static final String EC2_CLIENT_CLASS_NAME = "com.amazonaws.services.ec2.AmazonEC2Client";
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+
+		if (StringUtils.hasText(element.getAttribute("user-tags-map"))) {
+			BeanDefinitionBuilder userTagsBuilder = BeanDefinitionBuilder
+					.genericBeanDefinition(USER_TAGS_BEAN_CLASS_NAME);
+
+			userTagsBuilder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(element, parserContext,
+					"amazon-ec2", EC2_CLIENT_CLASS_NAME));
+
+			if (StringUtils.hasText(element.getAttribute("instance-id-provider"))) {
+				userTagsBuilder.addConstructorArgReference(element.getAttribute("instance-id-provider"));
+			}
+			BeanDefinitionReaderUtils
+					.registerBeanDefinition(new BeanDefinitionHolder(userTagsBuilder.getBeanDefinition(),
+							element.getAttribute("user-tags-map")), parserContext.getRegistry());
+		}
+
+		if (isRunningOnCloudEnvironment()) {
+			ContextConfigurationUtils.registerInstanceDataPropertySource(parserContext.getRegistry(),
+					element.getAttribute("value-separator"), element.getAttribute("attribute-separator"));
+		}
+
+		return null;
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextNamespaceHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
+
+/**
+ * {@link org.springframework.beans.factory.xml.NamespaceHandler} implementation for the
+ * Spring Cloud AWS context namespace.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@RuntimeUse
+@Deprecated
+public class ContextNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		registerBeanDefinitionParser("context-credentials", new ContextCredentialsBeanDefinitionParser());
+		registerBeanDefinitionParser("context-resource-loader", new ContextResourceLoaderBeanDefinitionParser());
+		registerBeanDefinitionParser("context-region", new ContextRegionBeanDefinitionParser());
+		registerBeanDefinitionParser("context-instance-data",
+				new ContextInstanceDataPropertySourceBeanDefinitionParser());
+		registerBeanDefinitionParser("stack-configuration", new StackConfigurationBeanDefinitionParser());
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParser.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider;
+
+/**
+ * Context region provider bean definition parser.
+ *
+ * @author Agim Emruli
+ */
+@Deprecated
+public class ContextRegionBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	static final String CONTEXT_REGION_PROVIDER_BEAN_NAME = "regionProvider";
+
+	private static boolean isAutoDetect(Element element) {
+		return StringUtils.hasText(element.getAttribute("auto-detect"))
+				&& Boolean.TRUE.toString().equalsIgnoreCase(element.getAttribute("auto-detect"));
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return CONTEXT_REGION_PROVIDER_BEAN_NAME;
+	}
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		if (parserContext.getRegistry().containsBeanDefinition(CONTEXT_REGION_PROVIDER_BEAN_NAME)) {
+			parserContext.getReaderContext().error("Multiple <context-region/> elements detected. "
+					+ "The <context-region/> element is only allowed once per application context", element);
+		}
+
+		if (isAutoDetect(element) && (StringUtils.hasText(element.getAttribute("region"))
+				|| StringUtils.hasText(element.getAttribute("region-provider")))) {
+			parserContext.getReaderContext().error(
+					"The attribute 'auto-detect' can only be enabled without a region or region-provider specified",
+					element);
+			return null;
+		}
+
+		if (!isAutoDetect(element) && !StringUtils.hasText(element.getAttribute("region"))
+				&& !StringUtils.hasText(element.getAttribute("region-provider"))) {
+			parserContext.getReaderContext().error(
+					"Either auto-detect must be enabled, or a region or region-provider must be specified", element);
+			return null;
+		}
+
+		// Replace the default region provider with this one
+		replaceDefaultRegionProvider(parserContext.getRegistry(), CONTEXT_REGION_PROVIDER_BEAN_NAME);
+
+		if (StringUtils.hasText(element.getAttribute("region-provider"))) {
+			parserContext.getRegistry().registerAlias(element.getAttribute("region-provider"),
+					CONTEXT_REGION_PROVIDER_BEAN_NAME);
+			return null;
+		}
+		else if (StringUtils.hasText(element.getAttribute("region"))) {
+			BeanDefinitionBuilder builder = BeanDefinitionBuilder
+					.genericBeanDefinition("org.springframework.cloud.aws.core.region.StaticRegionProvider");
+			builder.addConstructorArgValue(element.getAttribute("region"));
+			return builder.getBeanDefinition();
+		}
+		else if (isAutoDetect(element)) {
+			BeanDefinitionBuilder builder = BeanDefinitionBuilder
+					.genericBeanDefinition("org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider");
+			return builder.getBeanDefinition();
+		}
+		return null;
+	}
+
+	@Override
+	protected boolean shouldGenerateId() {
+		return false;
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.xml.AbstractSimpleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.core.Conventions;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * Parser for the {@code <aws-context:context-resource-loader />} element.
+ *
+ * @author Agim Emruli
+ * @author Alain Sahli
+ * @since 1.0
+ */
+@SuppressWarnings({ "UnusedDeclaration", "WeakerAccess" })
+@Deprecated
+public class ContextResourceLoaderBeanDefinitionParser extends AbstractSimpleBeanDefinitionParser {
+
+	private static final String AMAZON_S3_CLIENT_CLASS_NAME = "com.amazonaws.services.s3.AmazonS3Client";
+
+	// @checkstyle:off
+	private static final String RESOURCE_LOADER_BEAN_POST_PROCESSOR = "org.springframework.cloud.aws.context.support.io.SimpleStorageProtocolResolverConfigurer";
+
+	// @checkstyle:on
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+
+		BeanDefinitionBuilder resolverBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition("org.springframework.cloud.aws.core.io.s3.SimpleStorageProtocolResolver");
+		resolverBuilder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(element, parserContext,
+				"amazon-s3", AMAZON_S3_CLIENT_CLASS_NAME));
+
+		if (StringUtils.hasText(element.getAttribute("task-executor"))) {
+			resolverBuilder.addPropertyReference(Conventions.attributeNameToPropertyName("task-executor"),
+					element.getAttribute("task-executor"));
+		}
+
+		builder.addConstructorArgValue(resolverBuilder.getBeanDefinition());
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return BeanDefinitionReaderUtils.generateBeanName(definition, parserContext.getRegistry(), false);
+	}
+
+	@Override
+	protected String getBeanClassName(Element element) {
+		return RESOURCE_LOADER_BEAN_POST_PROCESSOR;
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSimpleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.core.env.stack.config.StackResourceUserTagsFactoryBean;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
+import static org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils.registerResourceIdResolverBeanIfNeeded;
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * Parser for the {@code <aws-context:stack-configuration />} element.
+ *
+ * @author Christian Stettler
+ * @author Agim Emruli
+ */
+@Deprecated
+class StackConfigurationBeanDefinitionParser extends AbstractSimpleBeanDefinitionParser {
+
+	// @checkstyle:off
+	private static final String STACK_RESOURCE_REGISTRY_FACTORY_BEAN_CLASS_NAME = "org.springframework.cloud.aws.core.env.stack.config.StackResourceRegistryFactoryBean";
+
+	private static final String STATIC_STACK_NAME_PROVIDER_CLASS_NAME = "org.springframework.cloud.aws.core.env.stack.config.StaticStackNameProvider";
+
+	private static final String AUTO_DETECTING_STACK_NAME_PROVIDER_CLASS_NAME = "org.springframework.cloud.aws.core.env.stack.config.AutoDetectingStackNameProvider";
+
+	private static final String INSTANCE_ID_PROVIDER_CLASS_NAME = "org.springframework.cloud.aws.core.env.ec2.AmazonEc2InstanceIdProvider";
+
+	private static final String CLOUD_FORMATION_CLIENT_CLASS_NAME = "com.amazonaws.services.cloudformation.AmazonCloudFormationClient";
+
+	// @checkstyle:on
+
+	private static final String EC2_CLIENT_CLASS_NAME = "com.amazonaws.services.ec2.AmazonEC2Client";
+
+	private static final String STACK_NAME_ATTRIBUTE_NAME = "stack-name";
+
+	private static AbstractBeanDefinition buildStaticStackNameProviderBeanDefinition(String stackName) {
+		BeanDefinitionBuilder staticStackNameProviderBeanDefinitionBuilder = genericBeanDefinition(
+				STATIC_STACK_NAME_PROVIDER_CLASS_NAME);
+		staticStackNameProviderBeanDefinitionBuilder.addConstructorArgValue(stackName);
+
+		return staticStackNameProviderBeanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static AbstractBeanDefinition buildAutoDetectingStackNameProviderBeanDefinition(
+			String amazonCloudFormationClientBeanName, String amazonEc2ClientBeanName) {
+		BeanDefinitionBuilder autoDetectingStackNameProviderBeanDefinitionBuilder = genericBeanDefinition(
+				AUTO_DETECTING_STACK_NAME_PROVIDER_CLASS_NAME);
+		autoDetectingStackNameProviderBeanDefinitionBuilder
+				.addConstructorArgReference(amazonCloudFormationClientBeanName);
+		autoDetectingStackNameProviderBeanDefinitionBuilder.addConstructorArgReference(amazonEc2ClientBeanName);
+		autoDetectingStackNameProviderBeanDefinitionBuilder
+				.addConstructorArgValue(buildInstanceIdProviderBeanDefinition());
+
+		return autoDetectingStackNameProviderBeanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static AbstractBeanDefinition buildInstanceIdProviderBeanDefinition() {
+		BeanDefinitionBuilder instanceIdProviderBeanDefinitionBuilder = genericBeanDefinition(
+				INSTANCE_ID_PROVIDER_CLASS_NAME);
+
+		return instanceIdProviderBeanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static void buildAndRegisterStackUserTagsIfNeeded(Element element, ParserContext parserContext,
+			String cloudformationBeanName, BeanDefinition stackNameProvider) {
+		if (StringUtils.hasText(element.getAttribute("user-tags-map"))) {
+			BeanDefinitionBuilder builder = genericBeanDefinition(StackResourceUserTagsFactoryBean.class);
+			builder.addConstructorArgReference(cloudformationBeanName);
+			builder.addConstructorArgValue(stackNameProvider);
+			parserContext.getRegistry().registerBeanDefinition(element.getAttribute("user-tags-map"),
+					builder.getBeanDefinition());
+		}
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		registerResourceIdResolverBeanIfNeeded(parserContext.getRegistry());
+
+		String amazonCloudFormationClientBeanName = getCustomClientOrDefaultClientBeanName(element, parserContext,
+				"amazon-cloud-formation", CLOUD_FORMATION_CLIENT_CLASS_NAME);
+		String amazonEc2ClientBeanName = getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-ec2",
+				EC2_CLIENT_CLASS_NAME);
+		String stackName = element.getAttribute(STACK_NAME_ATTRIBUTE_NAME);
+
+		builder.addConstructorArgReference(amazonCloudFormationClientBeanName);
+		AbstractBeanDefinition stackNameProviderBeanDefinition = StringUtils.isEmpty(stackName)
+				? buildAutoDetectingStackNameProviderBeanDefinition(amazonCloudFormationClientBeanName,
+						amazonEc2ClientBeanName)
+				: buildStaticStackNameProviderBeanDefinition(stackName);
+		builder.addConstructorArgValue(stackNameProviderBeanDefinition);
+
+		buildAndRegisterStackUserTagsIfNeeded(element, parserContext, amazonCloudFormationClientBeanName,
+				stackNameProviderBeanDefinition);
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return element.hasAttribute(STACK_NAME_ATTRIBUTE_NAME) ? element.getAttribute(STACK_NAME_ATTRIBUTE_NAME)
+				: parserContext.getReaderContext().generateBeanName(definition);
+	}
+
+	@Override
+	protected String getBeanClassName(Element element) {
+		return STACK_RESOURCE_REGISTRY_FACTORY_BEAN_CLASS_NAME;
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/MailNamespaceHandler.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/MailNamespaceHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.mail.config.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+public class MailNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		registerBeanDefinitionParser("mail-sender", new SimpleEmailServiceBeanDefinitionParser());
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.mail.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.ClassUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+class SimpleEmailServiceBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final boolean JAVA_MAIL_PRESENT = ClassUtils.isPresent("javax.mail.Session",
+			SimpleEmailServiceBeanDefinitionParser.class.getClassLoader());
+
+	// @checkstyle:off
+	private static final String SIMPLE_EMAIL_CLIENT_CLASS_NAME = "com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient";
+
+	// @checkstyle:on
+
+	@Override
+	protected String getBeanClassName(Element element) {
+		if (JAVA_MAIL_PRESENT) {
+			return "org.springframework.cloud.aws.mail.simplemail.SimpleEmailServiceJavaMailSender";
+		}
+
+		return "org.springframework.cloud.aws.mail.simplemail.SimpleEmailServiceMailSender";
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		builder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-ses",
+				SIMPLE_EMAIL_CLIENT_CLASS_NAME));
+	}
+
+}

--- a/spring-cloud-aws-context/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-context/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,18 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/context=org.springframework.cloud.aws.context.config.xml.ContextNamespaceHandler
+http\://www.springframework.org/schema/cloud/aws/cache=org.springframework.cloud.aws.cache.config.xml.CacheNamespaceHandler
+http\://www.springframework.org/schema/cloud/aws/mail=org.springframework.cloud.aws.mail.config.xml.MailNamespaceHandler

--- a/spring-cloud-aws-context/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-context/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,24 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.0.xsd=org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+http\://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context-1.2.xsd=org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd=org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.0.xsd=org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
+http\://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache-1.2.xsd=org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd=org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.0.xsd=org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
+http\://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail-1.2.xsd=org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd=org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.0.xsd
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/cache"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/cache"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="cache-manager">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a cache manager based on SpyMemcached that uses the AWS
+				ElastiCache service.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="1" maxOccurs="unbounded">
+				<xsd:element name="cache-ref" type="cacheRefType" minOccurs="0"/>
+				<xsd:element name="cache-cluster" type="cacheClusterType" minOccurs="0"/>
+			</xsd:choice>
+			<xsd:attribute name="id" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The id of the cache manager
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="abstractCacheConfiguration" abstract="true">
+		<xsd:attribute name="expiration" type="xsd:int" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines optionally the expiration time in seconds of a cache entry.
+					Otherwise an expiration of '0'
+					is assumed
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="cacheClusterType">
+		<xsd:complexContent>
+			<xsd:extension base="abstractCacheConfiguration">
+				<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				<xsd:attribute name="name" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>
+							Defines the cache cluster name
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="amazon-elasti-cache" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to an externally configured
+							com.amazonaws.services.elasticache.AmazonElastiCache
+							instance
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type
+									type="com.amazonaws.services.elasticache.AmazonElastiCache"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="cacheRefType">
+		<xsd:attribute name="ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					A reference to a bean that implements the
+					org.springframework.cache.Cache interface.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.cache.Cache"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/cache/config/xml/spring-cloud-aws-cache-1.2.xsd
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/cache"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/cache"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="cache-manager">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a cache manager based on SpyMemcached that uses the AWS
+				ElastiCache service.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="1" maxOccurs="unbounded">
+				<xsd:element name="cache-ref" type="cacheRefType" minOccurs="0"/>
+				<xsd:element name="cache-cluster" type="cacheClusterType" minOccurs="0"/>
+			</xsd:choice>
+			<xsd:attribute name="id" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The id of the cache manager
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="abstractCacheConfiguration" abstract="true">
+		<xsd:attribute name="expiration" type="xsd:int" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines optionally the expiration time in seconds of a cache entry.
+					Otherwise an expiration of '0'
+					is assumed
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="cacheClusterType">
+		<xsd:complexContent>
+			<xsd:extension base="abstractCacheConfiguration">
+				<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				<xsd:attribute name="name" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>
+							Defines the cache cluster name
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="amazon-elasti-cache" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to an externally configured
+							com.amazonaws.services.elasticache.AmazonElastiCache
+							instance
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type
+									type="com.amazonaws.services.elasticache.AmazonElastiCache"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="cacheRefType">
+		<xsd:attribute name="ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					A reference to a bean that implements the
+					org.springframework.cache.Cache interface.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.cache.Cache"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.0.xsd
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns="http://www.springframework.org/schema/cloud/aws/context"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/context"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+
+	<xsd:element name="context-credentials">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.core.credentials.credentials.CredentialsProviderFactoryBean">
+				<![CDATA[
+	Creates the authentication configuration which will be used to authenticate the request made from this application context to the particular service.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.amazonaws.auth.AWSCredentialsProvider"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all>
+				<xsd:element name="simple-credentials" type="simpleCredentialsType"
+							 minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							Simple credentials which can be used to configure the static
+							credentials. This credentials
+							can be either hard-coded in the XML (not recommended),
+							evaluated through an EL expression or
+							replaced by a property place holder variable.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="instance-profile-credentials" minOccurs="0"
+							 maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							This credentials will be fetched through the particular
+							instance profile. So there is no
+							need to define any additional information. NOTE: In order to
+							use the instance profile
+							credentials, the application context must run inside an EC2
+							instance.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="profile-credentials" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							Profile based credentials provider that allows to configure
+							the profiles inside an
+							AWS SDK specific configuration file using different profile
+							names.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:attribute name="profileName" use="required">
+							<xsd:annotation>
+								<xsd:documentation>
+									Configures the profile name used by the profile
+									credentials provider. The profile
+									name is specified according to the profile file
+									format.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="profilePath" use="optional">
+							<xsd:annotation>
+								<xsd:documentation>
+									Allows to configure the profile path. By default the
+									profile file will be read
+									inside
+									the users directory in the folder .aws/credentials .
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:all>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-resource-loader">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParser">
+				Configures a resource loader that supports amazon S3 resources to be
+				loaded by the application context
+				resource loader.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.core.io.ResourceLoader"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an external task-executor bean used to upload file with the WritableResource interface.
+									]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.core.task.TaskExecutor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-s3" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured com.amazonaws.services.s3.AmazonS3 instance used to call the
+					Amazon S3 service
+									]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.s3.AmazonS3"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-region">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextRegionBeanDefinitionParser">
+				<![CDATA[
+				Configures the application context wide region provider used for all webservice access to the amazon webservices
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.core.region.RegionProvider"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attribute name="auto-detect" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Defines that the region should be auto detected
+						through the EC2 meta data
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-instance-data">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextInstanceDataPropertySourceBeanDefinitionParser">
+				<![CDATA[
+				Configures a property placeholder that is capable to resolver instance data specific placeholder (like instance id)
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.context.config.AmazonEc2InstanceDataPropertySourcePostProcessor"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attributeGroup ref="userTagsAttributeGroup"/>
+			<xsd:attribute name="instance-id-provider" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>Instance id provider, by default the instance id is
+						taken from the instance
+						meta-data. Might be changed with another strategy
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.cloud.aws.core.env.ec2.InstanceIdProvider"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-ec2" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a custom Amazon EC2 client bean if
+						user tags should be retrieved
+						from EC2 meta-data. This attribute is ignored if there is no
+						user-tags-map attribute configured
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.ec2.AmazonEC2"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="value-separator" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Value separator used to separate the values inside
+						the user data (same default
+						like property place holders default)
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="attribute-separator" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Attribute separator used to separate the attributes
+						inside the global user data
+						string
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="locationAttributeGroup">
+		<xsd:annotation>
+			<xsd:documentation>
+				Attribute group that can be used by components which are region aware.
+				This group
+				allows users to configure the particular region.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="region" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>The region that will be used, must be one of the valid
+					regions.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="region-provider" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.cloud.aws.core.region.RegionProvider"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="userTagsAttributeGroup">
+		<xsd:attribute name="user-tags-map" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Exposed map that contains all user tags to be accessed
+					via EL expression
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:complexType name="simpleCredentialsType">
+		<xsd:attribute name="access-key" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					The access key used to make the request. An access key is assigned to
+					one account or IAM user.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="secret-key" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					The secret key which is assigned for the particular access key.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="stack-configuration">
+		<xsd:annotation>
+			<xsd:documentation
+				source="org.springframework.cloud.aws.context.config.xml.StackConfigurationBeanDefinitionParser">
+				Configures an Amazon Cloud Formation stack and enables lookup of physical
+				ids by logical ids for
+				resources defined in the specified stack.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.core.env.stack.StackResourceRegistry"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attributeGroup ref="userTagsAttributeGroup"/>
+			<xsd:attribute name="stack-name" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The name of the stack to be configured. The corresponding stack
+						must exist and must be
+						available. If no stack name is configured, the stack name is
+						automatically detected
+						based on the stack the current Amazon EC2 instance is part of.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-cloud-formation" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to an externally configured AmazonCloudFormation
+						client, to be used to retrieve
+						stack information from the CloudFormation service.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.cloudformation.AmazonCloudFormation"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/context/config/xml/spring-cloud-aws-context-1.2.xsd
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns="http://www.springframework.org/schema/cloud/aws/context"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/context"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+
+	<xsd:element name="context-credentials">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.core.credentials.credentials.CredentialsProviderFactoryBean">
+				<![CDATA[
+	Creates the authentication configuration which will be used to authenticate the request made from this application context to the particular service.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.amazonaws.auth.AWSCredentialsProvider"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all>
+				<xsd:element name="simple-credentials" type="simpleCredentialsType"
+							 minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							Simple credentials which can be used to configure the static
+							credentials. This credentials
+							can be either hard-coded in the XML (not recommended),
+							evaluated through an EL expression or
+							replaced by a property place holder variable.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="instance-profile-credentials" minOccurs="0"
+							 maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							This credentials will be fetched through the particular
+							instance profile. So there is no
+							need to define any additional information. NOTE: In order to
+							use the instance profile
+							credentials, the application context must run inside an EC2
+							instance.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="profile-credentials" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							Profile based credentials provider that allows to configure
+							the profiles inside an
+							AWS SDK specific configuration file using different profile
+							names.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:attribute name="profileName" use="required">
+							<xsd:annotation>
+								<xsd:documentation>
+									Configures the profile name used by the profile
+									credentials provider. The profile
+									name is specified according to the profile file
+									format.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="profilePath" use="optional">
+							<xsd:annotation>
+								<xsd:documentation>
+									Allows to configure the profile path. By default the
+									profile file will be read
+									inside
+									the users directory in the folder .aws/credentials .
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:all>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-resource-loader">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParser">
+				Configures a resource loader that supports amazon S3 resources to be
+				loaded by the application context
+				resource loader.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.core.io.ResourceLoader"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an external task-executor bean used to upload file with the WritableResource interface.
+									]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.core.task.TaskExecutor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-s3" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured com.amazonaws.services.s3.AmazonS3 instance used to call the
+					Amazon S3 service
+									]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.s3.AmazonS3"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-region">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextRegionBeanDefinitionParser">
+				<![CDATA[
+				Configures the application context wide region provider used for all webservice access to the amazon webservices
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.core.region.RegionProvider"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attribute name="auto-detect" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Defines that the region should be auto detected
+						through the EC2 meta data
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="context-instance-data">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.context.config.xml.ContextInstanceDataPropertySourceBeanDefinitionParser">
+				<![CDATA[
+				Configures a property placeholder that is capable to resolver instance data specific placeholder (like instance id)
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.context.config.AmazonEc2InstanceDataPropertySourcePostProcessor"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attributeGroup ref="userTagsAttributeGroup"/>
+			<xsd:attribute name="instance-id-provider" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>Instance id provider, by default the instance id is
+						taken from the instance
+						meta-data. Might be changed with another strategy
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.cloud.aws.core.env.ec2.InstanceIdProvider"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-ec2" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a custom Amazon EC2 client bean if
+						user tags should be retrieved
+						from EC2 meta-data. This attribute is ignored if there is no
+						user-tags-map attribute configured
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.ec2.AmazonEC2"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="value-separator" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Value separator used to separate the values inside
+						the user data (same default
+						like property place holders default)
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="attribute-separator" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>Attribute separator used to separate the attributes
+						inside the global user data
+						string
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="locationAttributeGroup">
+		<xsd:annotation>
+			<xsd:documentation>
+				Attribute group that can be used by components which are region aware.
+				This group
+				allows users to configure the particular region.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="region" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>The region that will be used, must be one of the valid
+					regions.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="region-provider" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.cloud.aws.core.region.RegionProvider"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="userTagsAttributeGroup">
+		<xsd:attribute name="user-tags-map" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>Exposed map that contains all user tags to be accessed
+					via EL expression
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:complexType name="simpleCredentialsType">
+		<xsd:attribute name="access-key" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					The access key used to make the request. An access key is assigned to
+					one account or IAM user.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="secret-key" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					The secret key which is assigned for the particular access key.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="stack-configuration">
+		<xsd:annotation>
+			<xsd:documentation
+				source="org.springframework.cloud.aws.context.config.xml.StackConfigurationBeanDefinitionParser">
+				Configures an Amazon Cloud Formation stack and enables lookup of physical
+				ids by logical ids for
+				resources defined in the specified stack.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.cloud.aws.core.env.stack.StackResourceRegistry"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="locationAttributeGroup"/>
+			<xsd:attributeGroup ref="userTagsAttributeGroup"/>
+			<xsd:attribute name="stack-name" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The name of the stack to be configured. The corresponding stack
+						must exist and must be
+						available. If no stack name is configured, the stack name is
+						automatically detected
+						based on the stack the current Amazon EC2 instance is part of.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-cloud-formation" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to an externally configured AmazonCloudFormation
+						client, to be used to retrieve
+						stack information from the CloudFormation service.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.cloudformation.AmazonCloudFormation"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.0.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/mail"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/mail"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="mail-sender">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a mail sender for Amazon Simple Mail Service
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.mail.javamail.JavaMailSender"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The id of the mail sender
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="amazon-ses" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to an externally configured AmazonSimpleEmailService
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.simpleemail.AmazonSimpleEmailService"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
+++ b/spring-cloud-aws-context/src/main/resources/org/springframework/cloud/aws/mail/config/xml/spring-cloud-aws-mail-1.2.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/mail"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/mail"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="mail-sender">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a mail sender for Amazon Simple Mail Service
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.mail.javamail.JavaMailSender"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The id of the mail sender
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="amazon-ses" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to an externally configured AmazonSimpleEmailService
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.simpleemail.AmazonSimpleEmailService"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.cache.config.xml;
+
+import com.amazonaws.services.elasticache.AmazonElastiCache;
+import com.amazonaws.services.elasticache.AmazonElastiCacheClient;
+import com.amazonaws.services.elasticache.model.CacheCluster;
+import com.amazonaws.services.elasticache.model.DescribeCacheClustersRequest;
+import com.amazonaws.services.elasticache.model.DescribeCacheClustersResult;
+import com.amazonaws.services.elasticache.model.Endpoint;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cloud.aws.cache.config.TestMemcacheServer;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Agim Emruli
+ */
+public class CacheBeanDefinitionParserTest {
+
+	@BeforeAll
+	public static void setupMemcachedServerAndClient() throws Exception {
+		// Get next free port for the test server
+		int availableTcpPort = TestMemcacheServer.startServer();
+
+		// Set the port as system property to easily fetch it in the Spring config
+		System.setProperty("memcachedPort", String.valueOf(availableTcpPort));
+	}
+
+	@AfterAll
+	public static void tearDownMemcachedServerAndClient() throws Exception {
+		TestMemcacheServer.stopServer();
+		System.clearProperty("memcachedPort");
+	}
+
+	@Test
+	public void parseInternal_cacheConfigWithExpiration_returnsConfiguredCacheThatRespectExpiration() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Register a mock object which will be used to replay service calls
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonElastiCache.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-cacheConfigWithExpiration.xml", getClass()));
+
+		AmazonElastiCache client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				AmazonElastiCache.class);
+
+		// Replay invocation that will be called
+		DescribeCacheClustersRequest memcached = new DescribeCacheClustersRequest().withCacheClusterId("memcached");
+		memcached.setShowCacheNodeInfo(true);
+
+		when(client.describeCacheClusters(memcached)).thenReturn(
+				new DescribeCacheClustersResult().withCacheClusters(new CacheCluster().withCacheClusterId("memcached")
+						.withConfigurationEndpoint(new Endpoint().withAddress("localhost")
+								.withPort(Integer.parseInt(System.getProperty("memcachedPort"))))
+						.withCacheClusterStatus("available").withEngine("memcached")));
+
+		// Act
+		CacheManager cacheManager = beanFactory.getBean(CacheManager.class);
+		Cache cache = cacheManager.getCache("memcached");
+		cache.put("foo", "bar");
+		Thread.sleep(2000);
+
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(cache).isNotNull();
+		assertThat(cache.get("foo")).isNull();
+	}
+
+	@Test
+	public void parseInternal_customCache_returnsCacheManagerWithCustomCache() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customCache.xml", getClass());
+
+		// Act
+		CacheManager cacheManager = applicationContext.getBean(CacheManager.class);
+		Cache cache = cacheManager.getCache("memc");
+		cache.put("foo", "bar");
+		cache.evict("foo");
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(cache).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_mixedCacheConfig_returnsBothCaches() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Register a mock object which will be used to replay service calls
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonElastiCache.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		BeanDefinitionBuilder cacheBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		cacheBuilder.setFactoryMethod("mock");
+		cacheBuilder.addConstructorArgValue(AmazonElastiCache.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				cacheBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-mixedCacheConfig.xml", getClass()));
+
+		AmazonElastiCache client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				AmazonElastiCache.class);
+
+		// Replay invocation that will be called
+
+		DescribeCacheClustersRequest memcached1 = new DescribeCacheClustersRequest().withCacheClusterId("memcached");
+		memcached1.setShowCacheNodeInfo(true);
+
+		when(client.describeCacheClusters(memcached1)).thenReturn(
+				new DescribeCacheClustersResult().withCacheClusters(new CacheCluster().withCacheClusterId("memcached")
+						.withConfigurationEndpoint(new Endpoint().withAddress("localhost")
+								.withPort(Integer.parseInt(System.getProperty("memcachedPort"))))
+						.withCacheClusterStatus("available").withEngine("memcached")));
+
+		Cache cache = beanFactory.getBean("memc", Cache.class);
+		when(cache.getName()).thenReturn("memc");
+
+		// Act
+		CacheManager cacheManager = beanFactory.getBean(CacheManager.class);
+		Cache memc = cacheManager.getCache("memc");
+		Cache memcached = cacheManager.getCache("memcached");
+
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(memcached).isNotNull();
+
+		memc.put("foo", "bar");
+		memc.evict("foo");
+
+		memcached.put("foo", "bar");
+		memcached.evict("foo");
+	}
+
+	@Test
+	public void parseInternal_clusterCacheConfiguration_returnsConfiguredClusterCache() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Register a mock object which will be used to replay service calls
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonElastiCache.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		// Load xml file
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-elastiCacheConfig.xml", getClass()));
+
+		AmazonElastiCache client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				AmazonElastiCache.class);
+
+		// Replay invocation that will be called
+		DescribeCacheClustersRequest memcached = new DescribeCacheClustersRequest().withCacheClusterId("memcached");
+		memcached.setShowCacheNodeInfo(true);
+
+		when(client.describeCacheClusters(memcached)).thenReturn(
+				new DescribeCacheClustersResult().withCacheClusters(new CacheCluster().withCacheClusterId("memcached")
+						.withConfigurationEndpoint(new Endpoint().withAddress("localhost")
+								.withPort(Integer.parseInt(System.getProperty("memcachedPort"))))
+						.withCacheClusterStatus("available").withEngine("memcached")));
+
+		// Act
+		CacheManager cacheManager = beanFactory.getBean(CacheManager.class);
+		Cache cache = cacheManager.getCache("memcached");
+		cache.put("foo", "bar");
+		cache.evict("foo");
+
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(cache).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_clusterCacheConfigurationWithLogicalName_returnsConfiguredClusterCacheWithPhysicalName()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Register a mock object which will be used to replay service calls
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonElastiCache.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		BeanDefinitionBuilder resourceIdBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		resourceIdBuilder.setFactoryMethod("mock");
+		resourceIdBuilder.addConstructorArgValue(ResourceIdResolver.class);
+		beanFactory.registerBeanDefinition(GlobalBeanDefinitionUtils.RESOURCE_ID_RESOLVER_BEAN_NAME,
+				resourceIdBuilder.getBeanDefinition());
+
+		// Load xml file
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
+				getClass().getSimpleName() + "-elastiCacheConfigStackConfigured.xml", getClass()));
+
+		AmazonElastiCache client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()),
+				AmazonElastiCache.class);
+
+		ResourceIdResolver resourceIdResolver = beanFactory
+				.getBean(GlobalBeanDefinitionUtils.RESOURCE_ID_RESOLVER_BEAN_NAME, ResourceIdResolver.class);
+
+		when(resourceIdResolver.resolveToPhysicalResourceId("testMemcached")).thenReturn("memcached");
+
+		// Replay invocation that will be called
+		DescribeCacheClustersRequest memcached = new DescribeCacheClustersRequest().withCacheClusterId("memcached");
+		memcached.setShowCacheNodeInfo(true);
+
+		when(client.describeCacheClusters(memcached)).thenReturn(
+				new DescribeCacheClustersResult().withCacheClusters(new CacheCluster().withCacheClusterId("memcached")
+						.withConfigurationEndpoint(new Endpoint().withAddress("localhost")
+								.withPort(Integer.parseInt(System.getProperty("memcachedPort"))))
+						.withCacheClusterStatus("available").withEngine("memcached")));
+
+		// Act
+		CacheManager cacheManager = beanFactory.getBean(CacheManager.class);
+		Cache cache = cacheManager.getCache("testMemcached");
+		cache.put("foo", "bar");
+		cache.evict("foo");
+
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(cache).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_clusterCacheConfigurationWithRegion_returnsConfiguredClusterCacheWithRegion()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Load xml file
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
+				getClass().getSimpleName() + "-elastiCacheConfigRegionConfigured.xml", getClass()));
+
+		// Act
+		BeanDefinition beanDefinition = beanFactory.getBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonElastiCacheClient.class.getName()));
+
+		// Assert
+		assertThat(beanDefinition).isNotNull();
+		assertThat(beanDefinition.getPropertyValues().get("customRegion")).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_clusterCacheConfigurationWithCustomElastiCacheClient_returnsConfigurationWithCustomClient()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		// Load xml file
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(new ClassPathResource(
+				getClass().getSimpleName() + "-elastiCacheConfigWithCustomElastiCacheClient.xml", getClass()));
+
+		AmazonElastiCache amazonElastiCacheMock = beanFactory.getBean("customClient", AmazonElastiCache.class);
+
+		DescribeCacheClustersRequest memcached = new DescribeCacheClustersRequest().withCacheClusterId("memcached");
+		memcached.setShowCacheNodeInfo(true);
+
+		when(amazonElastiCacheMock.describeCacheClusters(memcached)).thenReturn(
+				new DescribeCacheClustersResult().withCacheClusters(new CacheCluster().withCacheClusterId("memcached")
+						.withConfigurationEndpoint(new Endpoint().withAddress("localhost")
+								.withPort(Integer.parseInt(System.getProperty("memcachedPort"))))
+						.withCacheClusterStatus("available").withEngine("memcached")));
+
+		// Act
+		CacheManager cacheManager = beanFactory.getBean(CacheManager.class);
+		Cache cache = cacheManager.getCache("memcached");
+		cache.put("foo", "bar");
+		cache.evict("foo");
+
+		// Assert
+		assertThat(cacheManager).isNotNull();
+		assertThat(cache).isNotNull();
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.cache.config.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Alain Sahli
+ */
+public class CacheSchemaWithoutVersionTest {
+
+	@Test
+	public void cacheXsd_withoutVersion_shouldNotThrowAnException() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act & Assert
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + ".xml", getClass()));
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import org.apache.http.client.CredentialsProvider;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ContextCredentialsBeanDefinitionParser}.
+ *
+ * @author Agim Emruli
+ */
+public class ContextCredentialsBeanDefinitionParserTest {
+
+	@Test
+	public void testCreateBeanDefinition() throws Exception {
+		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-context.xml", getClass());
+
+		// Check that the result of the factory bean is available
+		AWSCredentialsProvider awsCredentialsProvider = applicationContext.getBean(AWSCredentialsProvider.class);
+
+		assertThat(AWSCredentialsProviderChain.class.isInstance(awsCredentialsProvider)).isTrue();
+
+		// Using reflection to really test if the chain is stable
+		AWSCredentialsProviderChain awsCredentialsProviderChain = (AWSCredentialsProviderChain) awsCredentialsProvider;
+
+		@SuppressWarnings("unchecked")
+		List<AWSCredentialsProvider> providerChain = (List<AWSCredentialsProvider>) ReflectionTestUtils
+				.getField(awsCredentialsProviderChain, "credentialsProviders");
+
+		assertThat(providerChain).isNotNull();
+		assertThat(providerChain.size()).isEqualTo(2);
+
+		assertThat(InstanceProfileCredentialsProvider.class.isInstance(providerChain.get(0))).isTrue();
+		assertThat(AWSStaticCredentialsProvider.class.isInstance(providerChain.get(1))).isTrue();
+
+		AWSStaticCredentialsProvider staticCredentialsProvider = (AWSStaticCredentialsProvider) providerChain.get(1);
+		assertThat(staticCredentialsProvider.getCredentials().getAWSAccessKeyId()).isEqualTo("staticAccessKey");
+		assertThat(staticCredentialsProvider.getCredentials().getAWSSecretKey()).isEqualTo("staticSecretKey");
+
+	}
+
+	@Test
+	public void testMultipleElements() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(
+				() -> new ClassPathXmlApplicationContext(getClass().getSimpleName() + "-testMultipleElements.xml",
+						getClass())).isInstanceOf(BeanDefinitionParsingException.class)
+								.hasMessageContaining("only allowed once per");
+	}
+
+	@Test
+	public void testWithEmptyAccessKey() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(
+				() -> new ClassPathXmlApplicationContext(getClass().getSimpleName() + "-testWithEmptyAccessKey.xml",
+						getClass())).isInstanceOf(BeanDefinitionParsingException.class)
+								.hasMessageContaining("The 'access-key' attribute must not be empty");
+	}
+
+	@Test
+	public void testWithEmptySecretKey() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(
+				() -> new ClassPathXmlApplicationContext(getClass().getSimpleName() + "-testWithEmptySecretKey.xml",
+						getClass())).isInstanceOf(BeanDefinitionParsingException.class)
+								.hasMessageContaining("The 'secret-key' attribute must not be empty");
+	}
+
+	@Test
+	public void testWithPlaceHolder() throws Exception {
+		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testWithPlaceHolder.xml", getClass());
+
+		AWSCredentialsProvider awsCredentialsProvider = applicationContext.getBean(AWSCredentialsProvider.class);
+		AWSCredentials credentials = awsCredentialsProvider.getCredentials();
+		assertThat(credentials.getAWSAccessKeyId()).isEqualTo("foo");
+		assertThat(credentials.getAWSSecretKey()).isEqualTo("bar");
+	}
+
+	@Test
+	public void testWithExpressions() throws Exception {
+		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testWithExpressions.xml", getClass());
+
+		AWSCredentialsProvider awsCredentialsProvider = applicationContext.getBean(AWSCredentialsProvider.class);
+		AWSCredentials credentials = awsCredentialsProvider.getCredentials();
+		assertThat(credentials.getAWSAccessKeyId()).isEqualTo("foo");
+		assertThat(credentials.getAWSSecretKey()).isEqualTo("bar");
+	}
+
+	@Test
+	public void parseBean_withProfileCredentialsProvider_createProfileCredentialsProvider() {
+		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-profileCredentialsProvider.xml", getClass());
+
+		AWSCredentialsProvider awsCredentialsProvider = applicationContext.getBean(
+				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME, AWSCredentialsProvider.class);
+		assertThat(awsCredentialsProvider).isNotNull();
+
+		@SuppressWarnings("unchecked")
+		List<CredentialsProvider> credentialsProviders = (List<CredentialsProvider>) ReflectionTestUtils
+				.getField(awsCredentialsProvider, "credentialsProviders");
+		assertThat(credentialsProviders.size()).isEqualTo(1);
+		assertThat(ProfileCredentialsProvider.class.isInstance(credentialsProviders.get(0))).isTrue();
+
+		assertThat(ReflectionTestUtils.getField(credentialsProviders.get(0), "profileName")).isEqualTo("test");
+	}
+
+	@Test
+	public void parseBean_withProfileCredentialsProviderAndProfileFile_createProfileCredentialsProvider()
+			throws IOException {
+		GenericApplicationContext applicationContext = new GenericApplicationContext();
+
+		Map<String, Object> secretAndAccessKeyMap = new HashMap<>();
+		secretAndAccessKeyMap.put("profilePath",
+				new ClassPathResource(getClass().getSimpleName() + "-profile", getClass()).getFile().getAbsolutePath());
+
+		applicationContext.getEnvironment().getPropertySources()
+				.addLast(new MapPropertySource("test", secretAndAccessKeyMap));
+		PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+		configurer.setPropertySources(applicationContext.getEnvironment().getPropertySources());
+
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(applicationContext);
+		reader.loadBeanDefinitions(new ClassPathResource(
+				getClass().getSimpleName() + "-profileCredentialsProviderWithFile.xml", getClass()));
+
+		applicationContext.refresh();
+
+		AWSCredentialsProvider provider = applicationContext.getBean(
+				AmazonWebserviceClientConfigurationUtils.CREDENTIALS_PROVIDER_BEAN_NAME, AWSCredentialsProvider.class);
+		assertThat(provider).isNotNull();
+
+		assertThat(provider.getCredentials().getAWSAccessKeyId()).isEqualTo("testAccessKey");
+		assertThat(provider.getCredentials().getAWSSecretKey()).isEqualTo("testSecretKey");
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import java.lang.reflect.Field;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.BeanReference;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.context.MetaDataServer;
+import org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Agim Emruli
+ */
+public class ContextInstanceDataPropertySourceBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_singleElementDefined_beanDefinitionCreated() throws Exception {
+		// Arrange
+		HttpServer httpServer = MetaDataServer.setupHttpServer();
+		HttpContext instanceIdHttpContext = httpServer.createContext("/latest/meta-data/instance-id",
+				new MetaDataServer.HttpResponseWriterHandler("testInstanceId"));
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-context.xml", getClass()));
+
+		// Assert
+		BeanFactoryPostProcessor postProcessor = beanFactory.getBean("AmazonEc2InstanceDataPropertySourcePostProcessor",
+				BeanFactoryPostProcessor.class);
+		assertThat(postProcessor).isNotNull();
+		assertThat(beanFactory.getBeanDefinitionCount()).isEqualTo(1);
+
+		httpServer.removeContext(instanceIdHttpContext);
+	}
+
+	@Test
+	public void parseInternal_missingAwsCloudEnvironment_missingBeanDefinition() throws Exception {
+		// Arrange
+		HttpServer httpServer = MetaDataServer.setupHttpServer();
+		HttpContext instanceIdHttpContext = httpServer.createContext("/latest/meta-data/instance-id",
+				new MetaDataServer.HttpResponseWriterHandler(null));
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-context.xml", getClass()));
+
+		// Assert
+		assertThat(beanFactory.containsBean("AmazonEc2InstanceDataPropertySourcePostProcessor")).isFalse();
+
+		httpServer.removeContext(instanceIdHttpContext);
+	}
+
+	@Test
+	public void parseInternal_singleElementWithUserTagsMapDefined_userTagMapCreatedAlongWithPostProcessor()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-userTagsMap.xml", getClass()));
+
+		// Assert
+		assertThat(beanFactory.containsBeanDefinition("myUserTags")).isTrue();
+		assertThat(beanFactory.containsBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonEC2Client.class.getName()))).isTrue();
+	}
+
+	@Test
+	public void parseInternal_singleElementWithCustomAmazonEc2Client_userTagMapCreatedWithCustomEc2Client()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-customEc2Client.xml", getClass()));
+
+		// Assert
+		assertThat(beanFactory.containsBeanDefinition("myUserTags")).isTrue();
+
+		ConstructorArgumentValues.ValueHolder valueHolder = beanFactory.getBeanDefinition("myUserTags")
+				.getConstructorArgumentValues().getArgumentValue(0, BeanReference.class);
+		BeanReference beanReference = (BeanReference) valueHolder.getValue();
+		assertThat(beanReference.getBeanName()).isEqualTo("amazonEC2Client");
+		assertThat(beanFactory.containsBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonEC2Client.class.getName()))).isFalse();
+	}
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_singleElementWithCustomAttributeAndValueSeparator_postProcessorCreatedWithCustomAttributeAndValueSeparator()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		HttpServer httpServer = MetaDataServer.setupHttpServer();
+		HttpContext instanceIdHttpContext = httpServer.createContext("/latest/meta-data/instance-id",
+				new MetaDataServer.HttpResponseWriterHandler("testInstanceId"));
+		HttpContext userDataHttpContext = httpServer.createContext("/latest/user-data",
+				new MetaDataServer.HttpResponseWriterHandler("a=b/c=d"));
+
+		GenericApplicationContext applicationContext = new GenericApplicationContext();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(applicationContext);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(
+				getClass().getSimpleName() + "-customAttributeAndValueSeparator.xml", getClass()));
+
+		applicationContext.refresh();
+
+		// Assert
+		assertThat(applicationContext.getEnvironment().getProperty("a")).isEqualTo("b");
+		assertThat(applicationContext.getEnvironment().getProperty("c")).isEqualTo("d");
+
+		httpServer.removeContext(instanceIdHttpContext);
+		httpServer.removeContext(userDataHttpContext);
+	}
+
+	@BeforeEach
+	public void restContextInstanceDataCondition() throws IllegalAccessException {
+		Field field = ReflectionUtils.findField(AwsCloudEnvironmentCheckUtils.class, "isCloudEnvironment");
+		assertThat(field).isNotNull();
+		ReflectionUtils.makeAccessible(field);
+		field.set(null, null);
+	}
+
+	@AfterEach
+	public void destroyMetaDataServer() throws Exception {
+		MetaDataServer.shutdownHttpServer();
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.cloud.aws.core.region.Ec2MetadataRegionProvider;
+import org.springframework.cloud.aws.core.region.RegionProvider;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Agim Emruli
+ */
+public class ContextRegionBeanDefinitionParserTest {
+
+	@Test
+	public void parse_staticConfiguredRegion_createsStaticRegionProviderWithSpecifiedRegion() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-context.xml", getClass());
+
+		// Act
+		RegionProvider myRegionProvider = context
+				.getBean(ContextRegionBeanDefinitionParser.CONTEXT_REGION_PROVIDER_BEAN_NAME, RegionProvider.class);
+
+		// Assert
+		assertThat(myRegionProvider).isNotNull();
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+	}
+
+	@Test
+	public void parse_staticConfiguredRegion_createsStaticRegionProviderWithSpecifiedRegionAsExpression()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testWithExpression.xml", getClass());
+
+		// Act
+		RegionProvider myRegionProvider = context
+				.getBean(ContextRegionBeanDefinitionParser.CONTEXT_REGION_PROVIDER_BEAN_NAME, RegionProvider.class);
+
+		// Assert
+		assertThat(myRegionProvider).isNotNull();
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+	}
+
+	@Test
+	public void parse_staticConfiguredRegion_createsStaticRegionProviderWithSpecifiedRegionAsPlaceHolder()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testWithPlaceHolder.xml", getClass());
+
+		// Act
+		RegionProvider myRegionProvider = context
+				.getBean(ContextRegionBeanDefinitionParser.CONTEXT_REGION_PROVIDER_BEAN_NAME, RegionProvider.class);
+
+		// Assert
+		assertThat(myRegionProvider).isNotNull();
+		assertThat(myRegionProvider.getRegion()).isEqualTo(Region.getRegion(Regions.SA_EAST_1));
+	}
+
+	@Test
+	public void parse_autoDetectRegion_returnEc2MetadataRegionProvider() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testAutoDetection.xml", getClass());
+
+		// Act
+		RegionProvider myRegionProvider = context
+				.getBean(ContextRegionBeanDefinitionParser.CONTEXT_REGION_PROVIDER_BEAN_NAME, RegionProvider.class);
+
+		// Assert
+		assertThat(myRegionProvider).isNotNull();
+		assertThat(myRegionProvider instanceof Ec2MetadataRegionProvider).isTrue();
+	}
+
+	@Test
+	public void parse_customRegionProvider_returnAliasToCustomRegionProvider() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testCustomRegionProvider.xml", getClass());
+
+		// Act
+		RegionProvider defaultRegionProvider = context
+				.getBean(ContextRegionBeanDefinitionParser.CONTEXT_REGION_PROVIDER_BEAN_NAME, RegionProvider.class);
+		RegionProvider myRegionProvider = context.getBean("myRegionProvider", RegionProvider.class);
+
+		// Assert
+		assertThat(defaultRegionProvider).isNotNull();
+		assertThat(myRegionProvider).isNotNull();
+		assertThat(myRegionProvider).isSameAs(defaultRegionProvider);
+	}
+
+	@Test
+	public void parse_autoDetectionAndStaticRegionProvider_reportsError() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(() -> new ClassPathXmlApplicationContext(getClass().getSimpleName()
+				+ "-testAutoDetectionWithConfiguredRegion.xml",
+				getClass())).isInstanceOf(BeanDefinitionParsingException.class).hasMessageContaining(
+						"The attribute 'auto-detect' can only be enabled without a region or region-provider specified");
+	}
+
+	@Test
+	public void parse_noValidRegionProviderConfigured_reportsError() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(() -> new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testNoValidRegionProviderConfigurationSpecified.xml", getClass()))
+						.isInstanceOf(BeanDefinitionParsingException.class).hasMessageContaining(
+								"Either auto-detect must be enabled, or a region or region-provider must be specified");
+	}
+
+	@Test
+	public void parse_twoRegionProviderConfigured_reportsError() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(() -> new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-testTwoRegionProviderConfigured.xml", getClass()))
+						.isInstanceOf(BeanDefinitionParsingException.class)
+						.hasMessageContaining("Multiple <context-region/> elements detected. "
+								+ "The <context-region/> element is only allowed once per application context");
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.cloud.aws.core.io.s3.SimpleStorageProtocolResolver;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ProtocolResolver;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Alain Sahli
+ * @author Agim Emruli
+ * @since 1.0
+ */
+public class ContextResourceLoaderBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_defaultConfiguration_createsAmazonS3ClientWithoutRegionConfigured() {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-context.xml", getClass());
+
+		// Act
+		ResourceLoader resourceLoader = applicationContext.getBean(ResourceLoaderBean.class).getResourceLoader();
+
+		// Assert
+		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
+
+		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
+		assertThat(SimpleStorageProtocolResolver.class
+				.isInstance(defaultResourceLoader.getProtocolResolvers().iterator().next())).isTrue();
+
+	}
+
+	@Test
+	public void parseInternal_configurationWithRegion_createsAmazonS3ClientWithRegionConfigured() {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-withRegionConfigured.xml", getClass());
+
+		// Act
+		ResourceLoader resourceLoader = applicationContext.getBean(ResourceLoaderBean.class).getResourceLoader();
+		AmazonS3Client webServiceClient = applicationContext.getBean(AmazonS3Client.class);
+
+		// Assert
+		assertThat(webServiceClient.getRegion().toAWSRegion()).isEqualTo(Region.getRegion(Regions.EU_WEST_1));
+
+		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
+		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
+		assertThat(SimpleStorageProtocolResolver.class
+				.isInstance(defaultResourceLoader.getProtocolResolvers().iterator().next())).isTrue();
+	}
+
+	@Test
+	public void parseInternal_configurationWithCustomRegionProvider_createsAmazonS3ClientWithRegionConfigured() {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-withCustomRegionProvider.xml", getClass());
+
+		// Act
+		ResourceLoader resourceLoader = applicationContext.getBean(ResourceLoaderBean.class).getResourceLoader();
+		AmazonS3Client webServiceClient = applicationContext.getBean(AmazonS3Client.class);
+
+		// Assert
+		assertThat(webServiceClient.getRegion().toAWSRegion()).isEqualTo(Region.getRegion(Regions.US_WEST_2));
+
+		assertThat(DefaultResourceLoader.class.isInstance(resourceLoader)).isTrue();
+		DefaultResourceLoader defaultResourceLoader = (DefaultResourceLoader) resourceLoader;
+		assertThat(SimpleStorageProtocolResolver.class
+				.isInstance(defaultResourceLoader.getProtocolResolvers().iterator().next())).isTrue();
+	}
+
+	@Test
+	public void parseInternal_configurationWithCustomTaskExecutor_createsResourceLoaderWithCustomTaskExecutor() {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-withCustomTaskExecutor.xml", getClass());
+
+		// Act
+
+		// Assert
+		assertThat(DefaultResourceLoader.class.isInstance(applicationContext)).isTrue();
+		ProtocolResolver protocolResolver = applicationContext.getProtocolResolvers().iterator().next();
+		assertThat(SimpleStorageProtocolResolver.class.isInstance(protocolResolver)).isTrue();
+
+		assertThat(ReflectionTestUtils.getField(protocolResolver, "taskExecutor"))
+				.isSameAs(applicationContext.getBean("taskExecutor"));
+	}
+
+	@Test
+	public void parseInternal_configurationWithCustomAmazonS3Client_createResourceLoaderWithCustomS3Client()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-withCustomS3Client.xml", getClass());
+
+		// Act
+		assertThat(DefaultResourceLoader.class.isInstance(applicationContext)).isTrue();
+		ProtocolResolver protocolResolver = applicationContext.getProtocolResolvers().iterator().next();
+		assertThat(SimpleStorageProtocolResolver.class.isInstance(protocolResolver)).isTrue();
+
+		// Assert that the proxied AmazonS2 instances are the same as the customS3Client
+		// in the app context.
+		AmazonS3 customS3Client = applicationContext.getBean(AmazonS3.class);
+
+		SimpleStorageProtocolResolver resourceLoader = (SimpleStorageProtocolResolver) protocolResolver;
+		AmazonS3 amazonS3FromResourceLoader = (AmazonS3) ReflectionTestUtils.getField(resourceLoader, "amazonS3");
+
+		assertThat(AopUtils.isAopProxy(amazonS3FromResourceLoader)).isTrue();
+
+		Advised advised2 = (Advised) amazonS3FromResourceLoader;
+		AmazonS3 amazonS3WrappedInsideSimpleStorageResourceLoader = (AmazonS3) advised2.getTargetSource().getTarget();
+
+		assertThat(amazonS3WrappedInsideSimpleStorageResourceLoader).isSameAs(customS3Client);
+	}
+
+	static class ResourceLoaderBean implements ResourceLoaderAware {
+
+		private ResourceLoader resourceLoader;
+
+		public ResourceLoader getResourceLoader() {
+			return this.resourceLoader;
+		}
+
+		@Override
+		public void setResourceLoader(ResourceLoader resourceLoader) {
+			this.resourceLoader = resourceLoader;
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Alain Sahli
+ */
+public class ContextSchemaWithoutVersionTest {
+
+	@Test
+	public void contextXsd_withoutVersion_shouldNotThrowAnException() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act & Assert
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + ".xml", getClass()));
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.context.config.xml;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
+import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
+import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
+import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.StackResource;
+import com.amazonaws.services.cloudformation.model.StackResourceSummary;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.context.MetaDataServer;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
+import org.springframework.cloud.aws.core.env.stack.StackResourceRegistry;
+import org.springframework.context.support.GenericXmlApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName;
+
+/**
+ * @author Agim Emruli
+ * @author Alain Sahli
+ */
+public class StackConfigurationBeanDefinitionParserTest {
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_stackConfigurationWithExternallyConfiguredCloudFormationClient_returnsConfiguredStackWithExternallyConfiguredClient()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-withCustomCloudFormationClient.xml", getClass()));
+
+		AmazonCloudFormation amazonCloudFormationMock = beanFactory.getBean(AmazonCloudFormation.class);
+		when(amazonCloudFormationMock.listStackResources(new ListStackResourcesRequest().withStackName("test")))
+				.thenReturn(new ListStackResourcesResult().withStackResourceSummaries(new StackResourceSummary()));
+		when(amazonCloudFormationMock.describeStacks(new DescribeStacksRequest().withStackName("test")))
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack()));
+
+		// Act
+		StackResourceRegistry stackResourceRegistry = beanFactory.getBean(StackResourceRegistry.class);
+
+		// Assert
+		assertThat(stackResourceRegistry).isNotNull();
+		assertThat(beanFactory.containsBeanDefinition(getBeanName(AmazonCloudFormationClient.class.getName())))
+				.isFalse();
+		verify(amazonCloudFormationMock, times(1))
+				.listStackResources(new ListStackResourcesRequest().withStackName("test"));
+		beanFactory.getBean("customStackTags");
+		verify(amazonCloudFormationMock, times(1)).describeStacks(new DescribeStacksRequest().withStackName("test"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegion_shouldConfigureDefaultClientWithCustomRegion() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region.xml", getClass()));
+
+		// Assert
+		AmazonCloudFormationClient amazonCloudFormation = registry.getBean(AmazonCloudFormationClient.class);
+		assertThat(ReflectionTestUtils.getField(amazonCloudFormation, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.SA_EAST_1).getServiceEndpoint("cloudformation"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegionProvider_shouldConfigureDefaultClientWithCustomRegionReturnedByProvider()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
+
+		// Assert
+		AmazonCloudFormationClient amazonCloudFormation = registry.getBean(AmazonCloudFormationClient.class);
+		assertThat(ReflectionTestUtils.getField(amazonCloudFormation, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.AP_SOUTHEAST_2).getServiceEndpoint("cloudformation"));
+	}
+
+	@Test
+	public void resourceIdResolver_stackConfiguration_resourceIdResolverBeanExposed() {
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+
+		when(amazonCloudFormation
+				.listStackResources(new ListStackResourcesRequest().withStackName("IntegrationTestStack"))).thenReturn(
+						new ListStackResourcesResult().withStackResourceSummaries(new StackResourceSummary()));
+
+		applicationContext.load(new ClassPathResource(getClass().getSimpleName() + "-staticStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+
+		// Act
+		ResourceIdResolver resourceIdResolver = applicationContext.getBean(ResourceIdResolver.class);
+
+		// Assert
+		assertThat(resourceIdResolver).isNotNull();
+	}
+
+	// @checkstyle:off
+	@Test
+	public void stackResourceRegistry_stackConfigurationWithStaticName_stackResourceRegistryBeanExposedUnderStaticStackName()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+
+		when(amazonCloudFormation
+				.listStackResources(new ListStackResourcesRequest().withStackName("IntegrationTestStack"))).thenReturn(
+						new ListStackResourcesResult().withStackResourceSummaries(new StackResourceSummary()));
+
+		applicationContext.load(new ClassPathResource(getClass().getSimpleName() + "-staticStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+
+		// Act
+		StackResourceRegistry staticStackNameProviderBasedStackResourceRegistry = applicationContext
+				.getBean("IntegrationTestStack", StackResourceRegistry.class);
+
+		// Assert
+		assertThat(staticStackNameProviderBasedStackResourceRegistry).isNotNull();
+	}
+
+	// @checkstyle:off
+	@Test
+	public void stackResourceRegistry_stackConfigurationWithoutStaticName_stackResourceRegistryBeanExposedUnderGeneratedName()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		HttpServer server = MetaDataServer.setupHttpServer();
+		HttpContext httpContext = server.createContext("/latest/meta-data/instance-id",
+				new MetaDataServer.HttpResponseWriterHandler("foo"));
+
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+
+		when(amazonCloudFormation
+				.describeStackResources(new DescribeStackResourcesRequest().withPhysicalResourceId("foo")))
+						.thenReturn(new DescribeStackResourcesResult()
+								.withStackResources(new StackResource().withStackName("test")));
+
+		when(amazonCloudFormation.listStackResources(new ListStackResourcesRequest().withStackName("test")))
+				.thenReturn(new ListStackResourcesResult().withStackResourceSummaries(new StackResourceSummary()));
+
+		applicationContext
+				.load(new ClassPathResource(getClass().getSimpleName() + "-autoDetectStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+
+		// Act
+		StackResourceRegistry autoDetectingStackNameProviderBasedStackResourceRegistry = applicationContext.getBean(
+				"org.springframework.cloud.aws.core.env.stack.config.StackResourceRegistryFactoryBean#0",
+				StackResourceRegistry.class);
+
+		// Assert
+		assertThat(autoDetectingStackNameProviderBasedStackResourceRegistry).isNotNull();
+
+		server.removeContext(httpContext);
+	}
+
+	// @checkstyle:off
+	@Test
+	public void resourceIdResolverResolveToPhysicalResourceId_stackConfigurationWithStaticNameAndLogicalResourceIdOfExistingResourceProvided_returnsPhysicalResourceId() {
+		// @checkstyle:on
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+
+		when(amazonCloudFormation
+				.listStackResources(new ListStackResourcesRequest().withStackName("IntegrationTestStack")))
+						.thenReturn(new ListStackResourcesResult().withStackResourceSummaries(
+								new StackResourceSummary().withLogicalResourceId("EmptyBucket")
+										.withPhysicalResourceId("integrationteststack-emptybucket-foo")));
+
+		applicationContext.load(new ClassPathResource(getClass().getSimpleName() + "-staticStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+
+		ResourceIdResolver resourceIdResolver = applicationContext.getBean(ResourceIdResolver.class);
+
+		// Act
+		String physicalResourceId = resourceIdResolver.resolveToPhysicalResourceId("EmptyBucket");
+
+		// Assert
+		assertThat(physicalResourceId).startsWith("integrationteststack-emptybucket-");
+	}
+
+	// @checkstyle:off
+	@Test
+	public void resourceIdResolverResolveToPhysicalResourceId_stackConfigurationWithoutStaticNameAndLogicalResourceIdOfExistingResourceProvided_returnsPhysicalResourceId()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		HttpServer server = MetaDataServer.setupHttpServer();
+		HttpContext httpContext = server.createContext("/latest/meta-data/instance-id",
+				new MetaDataServer.HttpResponseWriterHandler("foo"));
+
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+		when(amazonCloudFormation
+				.describeStackResources(new DescribeStackResourcesRequest().withPhysicalResourceId("foo")))
+						.thenReturn(new DescribeStackResourcesResult()
+								.withStackResources(new StackResource().withStackName("test")));
+
+		when(amazonCloudFormation.listStackResources(new ListStackResourcesRequest().withStackName("test")))
+				.thenReturn(new ListStackResourcesResult()
+						.withStackResourceSummaries(new StackResourceSummary().withLogicalResourceId("EmptyBucket")
+								.withPhysicalResourceId("integrationteststack-emptybucket-foo")));
+
+		applicationContext
+				.load(new ClassPathResource(getClass().getSimpleName() + "-autoDetectStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+
+		ResourceIdResolver resourceIdResolver = applicationContext.getBean(ResourceIdResolver.class);
+
+		// Act
+		String physicalResourceId = resourceIdResolver.resolveToPhysicalResourceId("EmptyBucket");
+
+		// Assert
+		assertThat(physicalResourceId).startsWith("integrationteststack-emptybucket-");
+
+		server.removeContext(httpContext);
+	}
+
+	// @checkstyle:off
+	@Test
+	public void resourceIdResolverResolveToPhysicalResourceId_logicalResourceIdOfNonExistingResourceProvided_returnsLogicalResourceIdAsPhysicalResourceId() {
+		// @checkstyle:on
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		AmazonCloudFormation amazonCloudFormation = Mockito.mock(AmazonCloudFormation.class);
+
+		when(amazonCloudFormation
+				.listStackResources(new ListStackResourcesRequest().withStackName("IntegrationTestStack"))).thenReturn(
+						new ListStackResourcesResult().withStackResourceSummaries(new StackResourceSummary()));
+
+		applicationContext.load(new ClassPathResource(getClass().getSimpleName() + "-staticStackName.xml", getClass()));
+		applicationContext.getBeanFactory().registerSingleton(getBeanName(AmazonCloudFormation.class.getName()),
+				amazonCloudFormation);
+
+		applicationContext.refresh();
+		ResourceIdResolver resourceIdResolver = applicationContext.getBean(ResourceIdResolver.class);
+
+		// Act
+		String physicalResourceId = resourceIdResolver.resolveToPhysicalResourceId("nonExistingLogicalResourceId");
+
+		// Assert
+		assertThat(physicalResourceId).isEqualTo("nonExistingLogicalResourceId");
+	}
+
+	@AfterEach
+	public void destroyMetaDataServer() throws Exception {
+		MetaDataServer.shutdownHttpServer();
+
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.mail.config.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Alain Sahli
+ */
+public class MailSchemaWithoutVersionTest {
+
+	@Test
+	public void mailXsd_withoutVersion_shouldNotThrowAnException() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act & Assert
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + ".xml", getClass()));
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-context/src/test/java/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.mail.config.xml;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName;
+import static org.springframework.util.ReflectionUtils.findField;
+import static org.springframework.util.ReflectionUtils.makeAccessible;
+
+/**
+ * @author Agim Emruli
+ */
+public class SimpleEmailServiceBeanDefinitionParserTest {
+
+	private static String getEndpointUrlFromWebserviceClient(AmazonSimpleEmailServiceClient client) throws Exception {
+		Field field = findField(AmazonSimpleEmailServiceClient.class, "endpoint");
+		makeAccessible(field);
+		URI endpointUri = (URI) field.get(client);
+		return endpointUri.toASCIIString();
+	}
+
+	@Test
+	public void parse_MailSenderWithMinimalConfiguration_createMailSenderWithJavaMail() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-context.xml", getClass());
+
+		// Act
+		AmazonSimpleEmailServiceClient emailService = context.getBean(
+				getBeanName(AmazonSimpleEmailServiceClient.class.getName()), AmazonSimpleEmailServiceClient.class);
+
+		MailSender mailSender = context.getBean(MailSender.class);
+
+		// Assert
+		assertThat(getEndpointUrlFromWebserviceClient(emailService)).isEqualTo("https://email.us-west-2.amazonaws.com");
+
+		assertThat(mailSender instanceof JavaMailSender).isTrue();
+	}
+
+	@Test
+	public void parse_MailSenderWithRegionConfiguration_createMailSenderWithJavaMailAndRegion() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-region.xml", getClass());
+
+		// Act
+		AmazonSimpleEmailServiceClient emailService = context.getBean(
+				getBeanName(AmazonSimpleEmailServiceClient.class.getName()), AmazonSimpleEmailServiceClient.class);
+
+		MailSender mailSender = context.getBean(MailSender.class);
+
+		// Assert
+		assertThat(getEndpointUrlFromWebserviceClient(emailService)).isEqualTo("https://email.eu-west-1.amazonaws.com");
+
+		assertThat(mailSender instanceof JavaMailSender).isTrue();
+	}
+
+	@Test
+	public void parse_MailSenderWithRegionProviderConfiguration_createMailSenderWithJavaMailAndRegionFromRegionProvider()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-regionProvider.xml", getClass());
+
+		// Act
+		AmazonSimpleEmailServiceClient emailService = context.getBean(
+				getBeanName(AmazonSimpleEmailServiceClient.class.getName()), AmazonSimpleEmailServiceClient.class);
+
+		MailSender mailSender = context.getBean(MailSender.class);
+
+		// Assert
+		assertThat(getEndpointUrlFromWebserviceClient(emailService))
+				.isEqualTo("https://email.ap-southeast-2.amazonaws.com");
+
+		assertThat(mailSender instanceof JavaMailSender).isTrue();
+	}
+
+	@Test
+	public void parse_MailSenderWithCustomSesClient_createMailSenderWithCustomSesClient() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-ses-client.xml", getClass());
+
+		// Act
+		AmazonSimpleEmailServiceClient emailService = context.getBean("emailServiceClient",
+				AmazonSimpleEmailServiceClient.class);
+
+		MailSender mailSender = context.getBean(MailSender.class);
+
+		// Assert
+		assertThat(ReflectionTestUtils.getField(mailSender, "emailService")).isSameAs(emailService);
+	}
+
+}

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-cacheConfigWithExpiration.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		http://www.springframework.org/schema/cloud/aws/cache
+	   		http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="memcached" expiration="1"/>
+	</aws-cache:cache-manager>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-customCache.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+           	http://www.springframework.org/schema/cloud/aws/cache
+           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-ref ref="memc"/>
+	</aws-cache:cache-manager>
+
+
+	<bean id="memc"
+		  class="org.springframework.cloud.aws.cache.memcached.SimpleSpringMemcached">
+		<constructor-arg name="cacheName" value="memc"/>
+		<constructor-arg>
+			<bean class="net.spy.memcached.MemcachedClient">
+				<constructor-arg>
+					<bean class="net.spy.memcached.AddrUtil"
+						  factory-method="getAddresses">
+						<constructor-arg
+							value="localhost:#{systemProperties['memcachedPort']}"/>
+					</bean>
+				</constructor-arg>
+			</bean>
+		</constructor-arg>
+	</bean>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfig.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		http://www.springframework.org/schema/cloud/aws/cache
+           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="memcached"/>
+	</aws-cache:cache-manager>
+
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigRegionConfigured.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		http://www.springframework.org/schema/cloud/aws/cache
+           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="memcached" region="eu-west-1"/>
+	</aws-cache:cache-manager>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigStackConfigured.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+           	http://www.springframework.org/schema/cloud/aws/cache
+           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="testMemcached"/>
+	</aws-cache:cache-manager>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-elastiCacheConfigWithCustomElastiCacheClient.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
+	   		http://www.springframework.org/schema/cloud/aws/cache
+           	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="memcached" amazon-elasti-cache="customClient"/>
+	</aws-cache:cache-manager>
+
+	<bean id="customClient" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.amazonaws.services.elasticache.AmazonElastiCache"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheBeanDefinitionParserTest-mixedCacheConfig.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans 
+	   https://www.springframework.org/schema/beans/spring-beans.xsd 
+	   http://www.springframework.org/schema/cloud/aws/cache
+	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<aws-cache:cache-manager id="cacheManager">
+		<aws-cache:cache-cluster name="memcached"/>
+		<aws-cache:cache-ref ref="memc"/>
+	</aws-cache:cache-manager>
+
+	<bean id="memc" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.cache.Cache"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/cache/config/xml/CacheSchemaWithoutVersionTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   http://www.springframework.org/schema/cloud/aws/cache
+			     	   	   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd">
+
+	<cache:cache-manager>
+		<cache:cache-cluster name="test"/>
+	</cache:cache-manager>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:instance-profile-credentials/>
+		<context:simple-credentials access-key="staticAccessKey"
+									secret-key="staticSecretKey"/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profile
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profile
@@ -1,0 +1,9 @@
+[default]
+aws_access_key_id=defaultKey
+aws_secret_access_key=defaultKey
+aws_session_token=defaultToken
+
+[customProfile]
+aws_access_key_id=testAccessKey
+aws_secret_access_key=testSecretKey
+aws_session_token=testSessionToken

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProvider.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:profile-credentials profileName="test"/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-profileCredentialsProviderWithFile.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/context
+	   					   https://www.springframework.org/schema/context/spring-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:profile-credentials profileName="customProfile"
+										 profilePath="${profilePath}"/>
+	</aws-context:context-credentials>
+
+	<context:property-placeholder/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testMultipleElements.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="first" secret-key="first"/>
+	</context:context-credentials>
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="second" secret-key="second"/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptyAccessKey.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key=" " secret-key="staticSecretKey"/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithEmptySecretKey.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="staticAccessKey" secret-key=" "/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithExpressions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="#{configuration['accessKey']}"
+									secret-key="#{configuration['secretKey']}"/>
+	</context:context-credentials>
+
+
+	<util:properties id="configuration">
+		<prop key="accessKey">foo</prop>
+		<prop key="secretKey">bar</prop>
+	</util:properties>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextCredentialsBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:spc="http://www.springframework.org/schema/context"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/cloud/aws/context http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="${accessKey}" secret-key="${secretKey}"/>
+	</context:context-credentials>
+
+	<spc:property-placeholder properties-ref="config"/>
+
+	<util:properties id="config">
+		<prop key="accessKey">foo</prop>
+		<prop key="secretKey">bar</prop>
+	</util:properties>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-instance-data/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customAttributeAndValueSeparator.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-instance-data attribute-separator="/" value-separator="="/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-customEc2Client.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-instance-data user-tags-map="myUserTags"
+								   amazon-ec2="amazonEC2Client"/>
+
+	<bean id="amazonEC2Client" class="com.amazonaws.services.ec2.AmazonEC2Client"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextInstanceDataPropertySourceBeanDefinitionParserTest-userTagsMap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-instance-data user-tags-map="myUserTags"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-context.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-region region="sa-east-1"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetection.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-region auto-detect="true"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testAutoDetectionWithConfiguredRegion.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<context:context-region auto-detect="true" region="sa-east-1"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testCustomRegionProvider.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-region region-provider="myRegionProvider"/>
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="eu-west-1"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testNoValidRegionProviderConfigurationSpecified.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<context:context-region/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testTwoRegionProviderConfigured.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-region region="sa-east-1"/>
+
+	<context:context-region region="sa-east-1"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithExpression.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/util
+	   					   https://www.springframework.org/schema/util/spring-util.xsd">
+
+	<context:context-region region="#{configuration['region']}"/>
+
+
+	<util:properties id="configuration">
+		<prop key="region">sa-east-1</prop>
+	</util:properties>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextRegionBeanDefinitionParserTest-testWithPlaceHolder.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/util
+	   					   https://www.springframework.org/schema/util/spring-util.xsd
+	   					   http://www.springframework.org/schema/context
+	   					   https://www.springframework.org/schema/context/spring-context.xsd">
+
+	<aws-context:context-region region="${region}"/>
+
+	<context:property-placeholder properties-ref="configuration"/>
+
+	<util:properties id="configuration">
+		<prop key="region">sa-east-1</prop>
+	</util:properties>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-context.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="first" secret-key="first"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-resource-loader/>
+
+	<bean
+		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomRegionProvider.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="first" secret-key="first"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-resource-loader region-provider="customRegionProvider"/>
+
+	<bean id="customRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="us-west-2"/>
+	</bean>
+
+	<bean
+		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomS3Client.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="first" secret-key="first"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-resource-loader amazon-s3="customS3Client"/>
+
+	<bean id="customS3Client" class="com.amazonaws.services.s3.AmazonS3Client"/>
+
+	<bean
+		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withCustomTaskExecutor.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/task
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="first" secret-key="first"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-resource-loader task-executor="taskExecutor"/>
+
+	<task:executor id="taskExecutor" pool-size="10" rejection-policy="CALLER_RUNS"
+				   queue-capacity="0"/>
+
+	<bean
+		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextResourceLoaderBeanDefinitionParserTest-withRegionConfigured.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="first" secret-key="first"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-resource-loader region="eu-west-1"/>
+
+	<bean
+		class="org.springframework.cloud.aws.context.config.xml.ContextResourceLoaderBeanDefinitionParserTest$ResourceLoaderBean"/>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/ContextSchemaWithoutVersionTest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   http://www.springframework.org/schema/cloud/aws/context
+			     	   	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="staticAccessKey"
+									secret-key="staticSecretKey"/>
+	</context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-autoDetectStackName.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	   				   http://www.springframework.org/schema/cloud/aws/context
+	   	   				   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:stack-configuration/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region-provider.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myCustomRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="ap-southeast-2"/>
+	</bean>
+
+	<aws-context:stack-configuration stack-name="test"
+									 region-provider="myCustomRegionProvider"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-custom-region.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-context:stack-configuration stack-name="test" region="sa-east-1"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-staticStackName.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:stack-configuration stack-name="IntegrationTestStack"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParserTest-withCustomCloudFormationClient.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:stack-configuration amazon-cloud-formation="customCloudFormationClient"
+									 stack-name="test"
+									 user-tags-map="customStackTags"/>
+
+	<bean id="customCloudFormationClient" class="org.mockito.Mockito"
+		  factory-method="mock">
+		<constructor-arg
+			value="com.amazonaws.services.cloudformation.AmazonCloudFormation"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/MailSchemaWithoutVersionTest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+			     	   	   https://www.springframework.org/schema/beans/spring-beans.xsd
+			     	   	   http://www.springframework.org/schema/cloud/aws/mail
+			     	   	   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+	<mail:mail-sender id="mailSender"/>
+
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-context.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/mail
+	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+	<aws-mail:mail-sender id="test"/>
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="test" secret-key="abc"/>
+	</aws-context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-region.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/mail
+	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+	<aws-mail:mail-sender id="test" region="eu-west-1"/>
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="test" secret-key="abc"/>
+	</aws-context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-regionProvider.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/mail
+	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg name="configuredRegion" value="ap-southeast-2"/>
+	</bean>
+
+	<aws-mail:mail-sender id="test" region-provider="myRegionProvider"/>
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="test" secret-key="abc"/>
+	</aws-context:context-credentials>
+</beans>

--- a/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
+++ b/spring-cloud-aws-context/src/test/resources/org/springframework/cloud/aws/mail/config/xml/SimpleEmailServiceBeanDefinitionParserTest-ses-client.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/mail
+	   					   http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+	<aws-mail:mail-sender id="test" amazon-ses="emailServiceClient"/>
+
+	<bean id="emailServiceClient"
+		  class="com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient"/>
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="test" secret-key="abc"/>
+	</aws-context:context-credentials>
+</beans>

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.core.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getAmazonWebserviceClientBeanDefinition;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.registerAmazonWebserviceClient;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+public final class XmlWebserviceConfigurationUtils {
+
+	private static final String REGION_ATTRIBUTE_NAME = "region";
+
+	private static final String REGION_PROVIDER_ATTRIBUTE_NAME = "region-provider";
+
+	private XmlWebserviceConfigurationUtils() {
+		// Avoid instantiation
+	}
+
+	public static String getCustomClientOrDefaultClientBeanName(Element element, ParserContext parserContext,
+			String customClientAttributeName, String serviceClassName) {
+		if (StringUtils.hasText(element.getAttribute(customClientAttributeName))) {
+			return element.getAttribute(customClientAttributeName);
+		}
+		else {
+			return parseAndRegisterDefaultAmazonWebserviceClient(element, parserContext, serviceClassName)
+					.getBeanName();
+		}
+	}
+
+	public static AbstractBeanDefinition parseCustomClientElement(Element element, ParserContext parserContext,
+			String serviceClassName) {
+		Object source = parserContext.extractSource(element);
+		try {
+			return getAmazonWebserviceClientBeanDefinition(source, serviceClassName,
+					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME), element.getAttribute(REGION_ATTRIBUTE_NAME),
+					parserContext.getRegistry());
+		}
+		catch (Exception e) {
+			parserContext.getReaderContext().error(e.getMessage(), source, e);
+			return null;
+		}
+	}
+
+	private static BeanDefinitionHolder parseAndRegisterDefaultAmazonWebserviceClient(Element element,
+			ParserContext parserContext, String serviceClassName) {
+		Object source = parserContext.extractSource(element);
+		try {
+			return registerAmazonWebserviceClient(source, parserContext.getRegistry(), serviceClassName,
+					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME), element.getAttribute(REGION_ATTRIBUTE_NAME));
+		}
+		catch (Exception e) {
+			parserContext.getReaderContext().error(e.getMessage(), source, e);
+			return null;
+		}
+	}
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/cache/XmlElastiCacheAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/cache/XmlElastiCacheAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.cache;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlElastiCacheAwsTest extends ElastiCacheAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/CustomS3ClientTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/CustomS3ClientTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.aws.context.support.io;
+package org.springframework.cloud.aws.it.context.support.io;
 
 import javax.annotation.PostConstruct;
 

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/XmlPathMatchingResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/XmlPathMatchingResourceLoaderAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.context.support.io;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlPathMatchingResourceLoaderAwsTest extends PathMatchingResourceLoaderAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/XmlResourceLoaderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/context/support/io/XmlResourceLoaderAwsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CHECKSTYLE:OFF
+// Checkstyle is disabled because in test 'testUploadBigFileAndCompareChecksum'
+// there is a needed while loop without a statement inside.
+
+package org.springframework.cloud.aws.it.context.support.io;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlResourceLoaderAwsTest extends ResourceLoaderAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.core.env.ec2;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlAmazonEc2InstanceDataPropertySourceAwsTest extends AmazonEc2InstanceDataPropertySourceAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/core/env/stack/XmlStackConfigurationAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/core/env/stack/XmlStackConfigurationAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.core.env.stack;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlStackConfigurationAwsTest extends StackConfigurationAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/jdbc/XmlDataSourceFactoryBeanAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/jdbc/XmlDataSourceFactoryBeanAwsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlDataSourceFactoryBeanAwsTest extends DataSourceFactoryBeanAwsTest {
+
+	@Value("#{dbTags['aws:cloudformation:logical-id']}")
+	private String dbLogicalName;
+
+	@Test
+	public void testDatabaseInstanceUserProperties() throws Exception {
+		assertThat(this.dbLogicalName).isEqualTo("RdsSingleMicroInstance");
+	}
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/mail/XmlMailSenderAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/mail/XmlMailSenderAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.mail;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Agim Emruli
+ */
+@ContextConfiguration
+public class XmlMailSenderAwsTest extends MailSenderAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlMessageListenerContainerAwsTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlMessageListenerContainerAwsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.messaging;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Alain Sahli
+ */
+@ContextConfiguration
+public class XmlMessageListenerContainerAwsTest extends MessageListenerContainerAwsTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlNotificationMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlNotificationMessagingTemplateIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.messaging;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Alain Sahli
+ */
+@ContextConfiguration
+public class XmlNotificationMessagingTemplateIntegrationTest extends NotificationMessagingTemplateIntegrationTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlQueueListenerTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlQueueListenerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.messaging;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Alain Sahli
+ */
+@ContextConfiguration
+public class XmlQueueListenerTest extends QueueListenerTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlQueueMessagingTemplateIntegrationTest.java
+++ b/spring-cloud-aws-integration-test/src/test/java/org/springframework/cloud/aws/it/messaging/XmlQueueMessagingTemplateIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.it.messaging;
+
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Alain Sahli
+ */
+@ContextConfiguration
+public class XmlQueueMessagingTemplateIntegrationTest extends QueueMessagingTemplateIntegrationTest {
+
+}

--- a/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/Integration-test-context.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           https://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/cloud/aws/context
+                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:simple-credentials access-key="${aws-integration-tests.access-key}"
+										secret-key="${aws-integration-tests.secret-key}"/>
+	</aws-context:context-credentials>
+
+	<aws-context:context-region region="eu-west-1"/>
+
+	<context:property-placeholder location="file://${els.config.dir}/access.properties"/>
+
+	<bean id="testStackEnvironment"
+		  class="org.springframework.cloud.aws.it.support.TestStackEnvironment">
+		<!--suppress SpringModelInspection -->
+		<constructor-arg name="amazonCloudFormationClient" ref="amazonCloudFormation"/>
+	</bean>
+
+	<aws-context:stack-configuration stack-name="IntegrationTestStack"
+									 user-tags-map="stackTags"/>
+
+	<bean id="testStackInstanceIdService"
+		  class="org.springframework.cloud.aws.it.support.TestStackInstanceIdService"
+		  factory-method="fromStackOutputKey">
+		<constructor-arg name="stackName"
+						 value="#{T(org.springframework.cloud.aws.it.support.TestStackEnvironment).DEFAULT_STACK_NAME}"/>
+		<constructor-arg name="outputKey"
+						 value="#{T(org.springframework.cloud.aws.it.support.TestStackEnvironment).INSTANCE_ID_STACK_OUTPUT_KEY}"/>
+		<!--suppress SpringModelInspection -->
+		<constructor-arg name="amazonCloudFormationClient" ref="amazonCloudFormation"/>
+	</bean>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/cache/XmlElastiCacheAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/cache/XmlElastiCacheAwsTest-context.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-cache="http://www.springframework.org/schema/cloud/aws/cache"
+	   xmlns:cache="http://www.springframework.org/schema/cache"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+       					   https://www.springframework.org/schema/beans/spring-beans.xsd
+       					   http://www.springframework.org/schema/cloud/aws/cache
+       					   http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+       					   http://www.springframework.org/schema/cache
+       					   https://www.springframework.org/schema/cache/spring-cache.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<aws-cache:cache-manager>
+		<aws-cache:cache-cluster expiration="10000" name="CacheCluster"/>
+		<aws-cache:cache-cluster expiration="10000" name="RedisCacheCluster"/>
+	</aws-cache:cache-manager>
+
+	<cache:annotation-driven/>
+
+	<bean class="org.springframework.cloud.aws.it.cache.CachingService"/>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/context/support/io/XmlPathMatchingResourceLoaderAwsTest-context.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/task
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-context:context-resource-loader task-executor="executor"/>
+
+	<task:executor id="executor" pool-size="2-10" queue-capacity="0"
+				   rejection-policy="CALLER_RUNS"/>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/context/support/io/XmlResourceLoaderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/context/support/io/XmlResourceLoaderAwsTest-context.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/task
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-context:context-resource-loader task-executor="executor"/>
+
+	<task:executor id="executor" pool-size="2-10" queue-capacity="0"
+				   rejection-policy="CALLER_RUNS"/>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/ec2/AmazonEc2InstanceUserTagsFactoryBeanAwsTest-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/cloud/aws/context
+                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-context:context-instance-data instance-id-provider="testStackEnvironment"
+									   user-tags-map="instanceData"/>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/ec2/XmlAmazonEc2InstanceDataPropertySourceAwsTest-context.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/cloud/aws/context
+                           http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-context:context-instance-data/>
+
+	<bean class="org.springframework.cloud.aws.it.core.env.ec2.SimpleConfigurationBean"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/stack/StackResourceUserTagsAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/stack/StackResourceUserTagsAwsTest-context.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/stack/XmlStackConfigurationAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/core/env/stack/XmlStackConfigurationAwsTest-context.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/jdbc/XmlDataSourceFactoryBeanAwsTest-context.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:tx="http://www.springframework.org/schema/tx"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/tx
+	   					   https://www.springframework.org/schema/tx/spring-tx.xsd
+	   					   http://www.springframework.org/schema/aop
+	   					   https://www.springframework.org/schema/aop/spring-aop.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<jdbc:data-source
+		db-instance-identifier="RdsSingleMicroInstance"
+		password="${rdsPassword}" read-replica-support="true" user-tags-map="dbTags">
+		<jdbc:pool-attributes initialSize="1"
+							  connectionProperties="logger=com.mysql.cj.log.Slf4JLogger;profileSQL=true;socketTimeout=1000"
+							  testOnBorrow="true" validationQuery="SELECT 1"/>
+	</jdbc:data-source>
+
+	<jdbc:retry-interceptor db-instance-identifier="RdsSingleMicroInstance"
+							id="myInterceptor" back-off-policy="backOffPolicy"
+							max-number-of-retries="10"/>
+
+	<bean id="backOffPolicy" class="org.springframework.retry.backoff.FixedBackOffPolicy">
+		<property name="backOffPeriod" value="12"/>
+	</bean>
+
+	<bean class="org.springframework.cloud.aws.it.jdbc.SimpleDatabaseService"/>
+
+	<tx:annotation-driven/>
+
+	<bean id="transactionManager"
+		  class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+		<!--suppress SpringModelInspection -->
+		<property name="dataSource" ref="RdsSingleMicroInstance"/>
+	</bean>
+
+	<aop:config>
+		<aop:advisor advice-ref="myInterceptor" pointcut="bean(simpleDatabaseService)"
+					 order="1"/>
+	</aop:config>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/mail/XmlMailSenderAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/mail/XmlMailSenderAwsTest-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/cloud/aws/mail
+                           http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd">
+
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-mail:mail-sender id="testSender"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlMessageListenerContainerAwsTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlMessageListenerContainerAwsTest-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--suppress UnparsedCustomBeanInspection -->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<aws-messaging:annotation-driven-queue-listener task-executor="taskExecutor"/>
+
+	<task:executor id="taskExecutor" pool-size="10-200" queue-capacity="0"
+				   rejection-policy="CALLER_RUNS"/>
+
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.MessageListenerContainerAwsTest$MessageReceiver"/>
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlNotificationMessagingTemplateIntegrationTest-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<aws-messaging:annotation-driven-queue-listener/>
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"
+												   default-destination="SqsReceivingSnsTopic"/>
+
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.NotificationMessagingTemplateIntegrationTest$NotificationReceiver"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlQueueListenerTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlQueueListenerTest-context.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+	<aws-context:stack-configuration stack-name="IntegrationTestStack"/>
+	<aws-messaging:annotation-driven-queue-listener
+		send-to-message-template="queueMessagingTemplate"
+		visibility-timeout="5"/>
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"/>
+
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.QueueListenerTest$MessageListener"/>
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.QueueListenerTest$MessageListenerWithSendTo"/>
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.QueueListenerTest$RedrivePolicyTestListener"/>
+	<bean
+		class="org.springframework.cloud.aws.it.messaging.QueueListenerTest$ManualDeletionPolicyTestListener"/>
+
+</beans>

--- a/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
+++ b/spring-cloud-aws-integration-test/src/test/resources/org/springframework/cloud/aws/it/messaging/XmlQueueMessagingTemplateIntegrationTest-context.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<import resource="classpath:Integration-test-context.xml"/>
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<aws-context:stack-configuration stack-name="IntegrationTestStack"/>
+
+	<aws-messaging:queue-messaging-template id="defaultQueueMessagingTemplate"
+											default-destination="JsonQueue"/>
+
+	<!--suppress UnparsedCustomBeanInspection -->
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplateWithCustomConverter"
+											message-converter="objectMessageConverter"
+											default-destination="StreamQueue"/>
+	<bean id="objectMessageConverter"
+		  class="org.springframework.cloud.aws.messaging.support.converter.ObjectMessageConverter"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParser.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.cloud.aws.jdbc.datasource.TomcatJdbcDataSourceFactory;
+import org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean;
+import org.springframework.cloud.aws.jdbc.rds.AmazonRdsReadReplicaAwareDataSourceFactoryBean;
+import org.springframework.core.Conventions;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} parser
+ * implementation for the datasource element. Parses the element and constructs a fully
+ * configured {@link AmazonRdsDataSourceFactoryBean} bean definition. Also creates a bean
+ * definition for the {@link com.amazonaws.services.rds.AmazonRDSClient} if there is not
+ * already an existing one this application context.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@Deprecated
+class AmazonRdsDataSourceBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	static final String DB_INSTANCE_IDENTIFIER = "db-instance-identifier";
+
+	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "com.amazonaws.services.rds.AmazonRDSClient";
+
+	// @checkstyle:off
+	private static final String IDENTITY_MANAGEMENT_CLIENT_CLASS_NAME = "com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	private static final String USER_TAG_FACTORY_BEAN_CLASS_NAME = "org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceUserTagsFactoryBean";
+
+	// @checkstyle:on
+
+	private static final String USERNAME = "username";
+
+	private static final String PASSWORD = "password";
+
+	private static final String DATABASE_NAME = "database-name";
+
+	/**
+	 * Creates a {@link org.springframework.cloud.aws.jdbc.datasource.DataSourceFactory}
+	 * implementation. Uses the TomcatJdbcDataSourceFactory implementation and passes all
+	 * pool attributes from the xml directly to the class (through setting the bean
+	 * properties).
+	 * @param element - The datasource element which may contain a pool-attributes element
+	 * @return - fully configured bean definition for the DataSourceFactory
+	 */
+	private static AbstractBeanDefinition createDataSourceFactoryBeanDefinition(Element element) {
+		BeanDefinitionBuilder datasourceFactoryBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(TomcatJdbcDataSourceFactory.class);
+		Element poolAttributes = DomUtils.getChildElementByTagName(element, "pool-attributes");
+		if (poolAttributes != null) {
+			NamedNodeMap attributes = poolAttributes.getAttributes();
+			for (int i = 0, x = attributes.getLength(); i < x; i++) {
+				Node item = attributes.item(i);
+				datasourceFactoryBuilder.addPropertyValue(item.getNodeName(), item.getNodeValue());
+			}
+		}
+
+		return datasourceFactoryBuilder.getBeanDefinition();
+	}
+
+	private static void registerUserTagsMapIfNecessary(Element element, ParserContext parserContext,
+			String rdsClientBeanName) {
+		if (!StringUtils.hasText(element.getAttribute("user-tags-map"))) {
+			return;
+		}
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(USER_TAG_FACTORY_BEAN_CLASS_NAME);
+		builder.addConstructorArgReference(rdsClientBeanName);
+		builder.addConstructorArgValue(element.getAttribute(DB_INSTANCE_IDENTIFIER));
+		builder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(element, parserContext,
+				"amazon-identity-management", IDENTITY_MANAGEMENT_CLIENT_CLASS_NAME));
+
+		// Use custom region-provider of data source
+		if (StringUtils.hasText(element.getAttribute("region"))) {
+			BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+					.genericBeanDefinition("com.amazonaws.regions.Region");
+			beanDefinitionBuilder.setFactoryMethod("getRegion");
+			beanDefinitionBuilder.addConstructorArgValue(element.getAttribute("region"));
+			builder.addPropertyValue("region", beanDefinitionBuilder.getBeanDefinition());
+		}
+		else {
+			BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+					.genericBeanDefinition(MethodInvokingFactoryBean.class);
+			if (StringUtils.hasText(element.getAttribute("region-provider"))) {
+				beanDefinitionBuilder.addPropertyValue("targetObject",
+						new RuntimeBeanReference(element.getAttribute("region-provider")));
+			}
+			else {
+				beanDefinitionBuilder.addPropertyValue("targetObject",
+						new RuntimeBeanReference(AmazonWebserviceClientConfigurationUtils
+								.getRegionProviderBeanName(parserContext.getRegistry())));
+			}
+			beanDefinitionBuilder.addPropertyValue("targetMethod", "getRegion");
+			builder.addPropertyValue("region", beanDefinitionBuilder.getBeanDefinition());
+		}
+
+		String resourceResolverBeanName = GlobalBeanDefinitionUtils
+				.retrieveResourceIdResolverBeanName(parserContext.getRegistry());
+		builder.addPropertyReference("resourceIdResolver", resourceResolverBeanName);
+
+		parserContext.getRegistry().registerBeanDefinition(element.getAttribute("user-tags-map"),
+				builder.getBeanDefinition());
+	}
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder datasourceBuilder = getBeanDefinitionBuilderForDataSource(element);
+
+		// Constructor (mandatory) args
+		String amazonRdsClientBeanName = getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-rds",
+				AMAZON_RDS_CLIENT_CLASS_NAME);
+		datasourceBuilder.addConstructorArgReference(amazonRdsClientBeanName);
+		datasourceBuilder.addConstructorArgValue(element.getAttribute(DB_INSTANCE_IDENTIFIER));
+		datasourceBuilder.addConstructorArgValue(element.getAttribute(PASSWORD));
+
+		// optional args
+		if (StringUtils.hasText(element.getAttribute(USERNAME))) {
+			datasourceBuilder.addPropertyValue(USERNAME, element.getAttribute(USERNAME));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(DATABASE_NAME))) {
+			datasourceBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(DATABASE_NAME),
+					element.getAttribute(DATABASE_NAME));
+		}
+
+		datasourceBuilder.addPropertyValue("dataSourceFactory", createDataSourceFactoryBeanDefinition(element));
+
+		// Register registry to enable cloud formation support
+		String resourceResolverBeanName = GlobalBeanDefinitionUtils
+				.retrieveResourceIdResolverBeanName(parserContext.getRegistry());
+		datasourceBuilder.addPropertyReference("resourceIdResolver", resourceResolverBeanName);
+
+		registerUserTagsMapIfNecessary(element, parserContext, amazonRdsClientBeanName);
+
+		return datasourceBuilder.getBeanDefinition();
+	}
+
+	private BeanDefinitionBuilder getBeanDefinitionBuilderForDataSource(Element element) {
+		BeanDefinitionBuilder datasourceBuilder;
+		if (Boolean.TRUE.toString().equalsIgnoreCase(element.getAttribute("read-replica-support"))) {
+			datasourceBuilder = BeanDefinitionBuilder
+					.rootBeanDefinition(AmazonRdsReadReplicaAwareDataSourceFactoryBean.class);
+		}
+		else {
+			datasourceBuilder = BeanDefinitionBuilder.rootBeanDefinition(AmazonRdsDataSourceFactoryBean.class);
+		}
+		return datasourceBuilder;
+	}
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return element.getAttribute(DB_INSTANCE_IDENTIFIER);
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParser.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.jdbc.retry.DatabaseInstanceStatusRetryPolicy;
+import org.springframework.cloud.aws.jdbc.retry.RdbmsRetryOperationsInterceptor;
+import org.springframework.cloud.aws.jdbc.retry.SqlRetryPolicy;
+import org.springframework.core.Conventions;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} implementation for
+ * the <code>retry-interceptor</code> element. This parser produces a
+ * {@link org.aopalliance.intercept.MethodInterceptor} which can be used by advice to
+ * intercept method calls and retry their particular operation.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@Deprecated
+class AmazonRdsRetryInterceptorBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	/**
+	 * Class name for the RetryTemplate. String because retry support is optional.
+	 */
+	private static final String RETRY_OPERATIONS_CLASS_NAME = "org.springframework.retry.support.RetryTemplate";
+
+	/**
+	 * Class name used for the policy, which is a composition of two policies (database
+	 * instance status and SQL error code).
+	 */
+	// @checkstyle:off
+	private static final String COMPOSITE_RETRY_POLICY_CLASS_NAME = "org.springframework.retry.policy.CompositeRetryPolicy";
+
+	// @checkstyle:on
+
+	/**
+	 * Attribute name for the number of retries that should be done.
+	 */
+	private static final String MAX_NUMBER_OF_RETRIES = "max-number-of-retries";
+
+	/**
+	 * Attribute name to a custom back off policy.
+	 */
+	private static final String BACK_OFF_POLICY = "back-off-policy";
+
+	private static final String AMAZON_RDS_CLIENT_CLASS_NAME = "com.amazonaws.services.rds.AmazonRDSClient";
+
+	/**
+	 * Builds the RetryOperation {@link BeanDefinition} with its collaborators.
+	 * @param element - <code>retry-interceptor Element</code>
+	 * @param parserContext - ParserContext used to query the
+	 * {@link org.springframework.beans.factory.support.BeanDefinitionRegistry}
+	 * @return Configured but non registered bean definition
+	 */
+	private static BeanDefinition buildRetryOperationDefinition(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(RETRY_OPERATIONS_CLASS_NAME);
+		builder.addPropertyValue("retryPolicy", buildRetryPolicyDefinition(element, parserContext));
+
+		if (StringUtils.hasText(element.getAttribute(BACK_OFF_POLICY))) {
+			String backOffPolicyBeanName = element.getAttribute(BACK_OFF_POLICY);
+			builder.addPropertyReference(Conventions.attributeNameToPropertyName(BACK_OFF_POLICY),
+					backOffPolicyBeanName);
+		}
+
+		return builder.getBeanDefinition();
+	}
+
+	private static BeanDefinition buildRetryPolicyDefinition(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(COMPOSITE_RETRY_POLICY_CLASS_NAME);
+
+		ManagedList<BeanDefinition> policies = new ManagedList<>(2);
+		policies.add(buildDatabaseInstancePolicy(element, parserContext));
+		policies.add(buildSQLRetryPolicy(element));
+
+		builder.addPropertyValue("policies", policies);
+
+		return builder.getBeanDefinition();
+	}
+
+	private static BeanDefinition buildDatabaseInstancePolicy(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(DatabaseInstanceStatusRetryPolicy.class);
+
+		String amazonRdsClientBeanName = getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-rds",
+				AMAZON_RDS_CLIENT_CLASS_NAME);
+
+		beanDefinitionBuilder.addConstructorArgReference(amazonRdsClientBeanName);
+		beanDefinitionBuilder.addConstructorArgValue(
+				element.getAttribute(AmazonRdsDataSourceBeanDefinitionParser.DB_INSTANCE_IDENTIFIER));
+
+		String resourceIdResolverBeanName = GlobalBeanDefinitionUtils
+				.retrieveResourceIdResolverBeanName(parserContext.getRegistry());
+		beanDefinitionBuilder.addPropertyReference("resourceIdResolver", resourceIdResolverBeanName);
+
+		return beanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static BeanDefinition buildSQLRetryPolicy(Element element) {
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(SqlRetryPolicy.class);
+		if (StringUtils.hasText(element.getAttribute(MAX_NUMBER_OF_RETRIES))) {
+			beanDefinitionBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(MAX_NUMBER_OF_RETRIES),
+					element.getAttribute(MAX_NUMBER_OF_RETRIES));
+		}
+		return beanDefinitionBuilder.getBeanDefinition();
+	}
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return RdbmsRetryOperationsInterceptor.class;
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		builder.addPropertyValue("retryOperations", buildRetryOperationDefinition(element, parserContext));
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcNamespaceHandler.java
+++ b/spring-cloud-aws-jdbc/src/main/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcNamespaceHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+import org.springframework.cloud.aws.core.support.documentation.RuntimeUse;
+
+/**
+ * {@link org.springframework.beans.factory.xml.NamespaceHandler} implementation for the
+ * Spring Cloud AWS jdbc namespace.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+@RuntimeUse
+@Deprecated
+public class JdbcNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		registerBeanDefinitionParser("data-source", new AmazonRdsDataSourceBeanDefinitionParser());
+		registerBeanDefinitionParser("retry-interceptor", new AmazonRdsRetryInterceptorBeanDefinitionParser());
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,16 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/jdbc=org.springframework.cloud.aws.jdbc.config.xml.JdbcNamespaceHandler

--- a/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-jdbc/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,18 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.0.xsd=org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
+http\://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc-1.2.xsd=org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd=org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.0.xsd
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/jdbc"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/jdbc"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="data-source">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean">
+				<![CDATA[
+	Creates an Amazon RDS backed datasource to other beans as a javax.sql.DataSource.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="javax.sql.DataSource"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="pool-attributes" type="poolAttributesType"
+							 minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							The pool properties used for the underlying connection pool
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="db-instance-identifier" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The name of the database identifier in Amazon RDS
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The user name that will be used to connect to the database
+												]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="database-name" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The database name to be used if not the default database configured in RDS
+												]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The password that will be used to connect to the database
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="read-replica-support" type="xsd:boolean" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Defines if the read replica support should be enabled for mysql
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="user-tags-map" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Defines the bean name for the user tags that should be made available as a map for the instance
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-rds" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon RDS instance used to retrieve instance details
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.rds.AmazonRDS"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-identity-management" type="xsd:string"
+						   use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon identity management instance to retrieve account information.
+					This bean is only used if the user tags of a data source will be used. Otherwise this bean reference
+					will be ignored.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.identitymanagement.AmazonIdentityManagement"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="retry-interceptor">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.jdbc.retry.RdbmsRetryOperationsInterceptor">
+				<![CDATA[
+	Creates an AOP Interceptor which can be used to retry database operations which failed due to transient error (e.g. connection lost due to failover)
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.aopalliance.intercept.MethodInterceptor"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+										The unique identifier for a bean. A bean id may not be used more than once
+										within the same <beans> element.
+													]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-instance-identifier" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The name of the database identifier in Amazon RDS instance. Should be the same as the database instance used inside the operations that will be retried.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="max-number-of-retries" type="xsd:int" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The maximum number of retries the interceptor will re-execute the call after an error happened
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="back-off-policy" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The reference to a BackOffPolicy which defines what should happen between retry approaches. Normally a back-off-policy will sleep in between the retry attempts.
+						]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.retry.backoff.BackOffPolicy"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-rds" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon RDS instance used to retrieve instance status during retry
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.rds.AmazonRDS"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="poolAttributesType">
+		<xsd:attribute name="defaultAutoCommit" type="xsd:boolean" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default auto-commit state of connections created by this pool.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="defaultReadOnly" type="xsd:boolean" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default read-only state of connections created by this pool. If
+					not set then the setReadOnly
+					method will not be called.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="defaultTransactionIsolation" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default TransactionIsolation state of connections created by this
+					pool. If not set,
+					the method will not be called and it defaults to the JDBC driver.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:int">
+					<xsd:enumeration value="0"/>
+					<xsd:enumeration value="1"/>
+					<xsd:enumeration value="2"/>
+					<xsd:enumeration value="4"/>
+					<xsd:enumeration value="8"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="defaultTransactionIsolationName" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default TransactionIsolation names of connections created by this
+					pool. If not set,
+					the method will not be called and it defaults to the JDBC driver.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="NONE"/>
+					<xsd:enumeration value="READ_COMMITTED"/>
+					<xsd:enumeration value="READ_UNCOMMITTED"/>
+					<xsd:enumeration value="READ_COMMITTED"/>
+					<xsd:enumeration value="SERIALIZABLE"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="defaultCatalog" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default catalog of connections created by this pool.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxActive" type="xsd:int" use="optional" default="100">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of active connections that can be allocated from
+					this pool at the same time.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxIdle" type="xsd:int" use="optional" default="100">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of active connections that can be allocated from
+					this pool at the same time.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="minIdle" type="xsd:int" use="optional" default="10">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of connections that should be kept in the pool at
+					all times. Default value is
+					maxActive:100 Idle connections are checked periodically (if enabled)
+					and connections that been idle
+					for longer than minEvictableIdleTimeMillis will be released. (also see
+					testWhileIdle)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initialSize" type="xsd:int" use="optional" default="10">
+			<xsd:annotation>
+				<xsd:documentation>
+					The initial number of connections that are created when the pool is
+					started.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxWait" type="xsd:int" use="optional" default="30000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of milliseconds that the pool will wait (when there
+					are no available connections)
+					for a connection to be returned before throwing an exception.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testOnBorrow" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated before being
+					borrowed from the pool. If the
+					object fails to validate, it will be dropped from the pool, and we
+					will attempt to borrow another.
+					NOTE - for a true value to have any effect, the validationQuery
+					attribute must be set to a non-null
+					string. In order to have a more efficient validation, see
+					validationInterval.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testOnReturn" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated before being
+					returned to the pool. NOTE - for a
+					true value to have any effect, the validationQuery parameter must be
+					set to a non-null string.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testWhileIdle" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated by the idle object
+					evictor (if any). If an
+					object fails to validate, it will be dropped from the pool. NOTE - for
+					a true value to have any
+					effect, the validationQuery attribute must be set to a non-null
+					string. This attribute has to be set
+					in order for the pool cleaner/test thread is to run (also see
+					timeBetweenEvictionRunsMillis)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="validationQuery" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The SQL query that will be used to validate connections from this pool
+					before returning them to the
+					caller. If specified, this query does not have to return any data, it
+					just can't throw a
+					SQLException. The default value is null. Example values are SELECT
+					1(mysql), select 1 from
+					dual(oracle), SELECT 1(MS Sql Server)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="validatorClassName" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The name of a class which implements the
+					org.apache.tomcat.jdbc.pool.Validator interface and
+					provides a no-arg constructor (may be implicit). If specified, the
+					class will be used to create a
+					Validator instance which is then used instead of any validation query
+					to validate connections. The
+					default value is null. An example value is
+					com.company.project.SimpleValidator.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="timeBetweenEvictionRunsMillis" type="xsd:int" use="optional"
+					   default="5000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The number of milliseconds to sleep between runs of the idle
+					connection validation/cleaner thread.
+					This value should not be set under 1 second. It dictates how often we
+					check for idle, abandoned
+					connections, and how often we validate idle connections.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="minEvictableIdleTimeMillis" type="xsd:int" use="optional"
+					   default="60000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The minimum amount of time an object may sit idle in the pool before
+					it is eligible for eviction.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="removeAbandoned" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to remove abandoned connections if they exceed the
+					removeAbandonedTimeout. If set to true a
+					connection is considered abandoned and eligible for removal if it has
+					been in use longer than the
+					removeAbandonedTimeout Setting this to true can recover db connections
+					from applications that fail
+					to close a connection. See also logAbandoned.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="removeAbandonedTimeout" type="xsd:int" use="optional"
+					   default="60">
+			<xsd:annotation>
+				<xsd:documentation>
+					Timeout in seconds before an abandoned(in use) connection can be
+					removed. The default value is 60
+					(seconds). The value should be set to the longest running query your
+					applications might have.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="logAbandoned" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to log stack traces for application code which abandoned a
+					Connection. Logging of abandoned
+					Connections adds overhead for every Connection borrow because a stack
+					trace has to be generated.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connectionProperties" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The connection properties that will be sent to our JDBC driver when
+					establishing new connections.
+					Format of the string must be [propertyName=property;]*
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initSQL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					A custom query to be run when a connection is first created.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
+++ b/spring-cloud-aws-jdbc/src/main/resources/org/springframework/cloud/aws/jdbc/config/xml/spring-cloud-aws-jdbc-1.2.xsd
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/jdbc"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/jdbc"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="data-source">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.jdbc.rds.AmazonRdsDataSourceFactoryBean">
+				<![CDATA[
+	Creates an Amazon RDS backed datasource to other beans as a javax.sql.DataSource.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="javax.sql.DataSource"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="pool-attributes" type="poolAttributesType"
+							 minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							The pool properties used for the underlying connection pool
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="db-instance-identifier" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The name of the database identifier in Amazon RDS
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The user name that will be used to connect to the database
+												]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="database-name" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The database name to be used if not the default database configured in RDS
+												]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The password that will be used to connect to the database
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="read-replica-support" type="xsd:boolean" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Defines if the read replica support should be enabled for mysql
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="user-tags-map" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Defines the bean name for the user tags that should be made available as a map for the instance
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-rds" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon RDS instance used to retrieve instance details
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.rds.AmazonRDS"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-identity-management" type="xsd:string"
+						   use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon identity management instance to retrieve account information.
+					This bean is only used if the user tags of a data source will be used. Otherwise this bean reference
+					will be ignored.
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.identitymanagement.AmazonIdentityManagement"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="retry-interceptor">
+		<xsd:annotation>
+			<xsd:documentation
+				source="java:org.springframework.cloud.aws.jdbc.retry.RdbmsRetryOperationsInterceptor">
+				<![CDATA[
+	Creates an AOP Interceptor which can be used to retry database operations which failed due to transient error (e.g. connection lost due to failover)
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.aopalliance.intercept.MethodInterceptor"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+										The unique identifier for a bean. A bean id may not be used more than once
+										within the same <beans> element.
+													]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="db-instance-identifier" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The name of the database identifier in Amazon RDS instance. Should be the same as the database instance used inside the operations that will be retried.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="max-number-of-retries" type="xsd:int" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The maximum number of retries the interceptor will re-execute the call after an error happened
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="back-off-policy" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					The reference to a BackOffPolicy which defines what should happen between retry approaches. Normally a back-off-policy will sleep in between the retry attempts.
+						]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.retry.backoff.BackOffPolicy"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-rds" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+					Reference to an externally configured Amazon RDS instance used to retrieve instance status during retry
+					]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.rds.AmazonRDS"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="poolAttributesType">
+		<xsd:attribute name="defaultAutoCommit" type="xsd:boolean" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default auto-commit state of connections created by this pool.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="defaultReadOnly" type="xsd:boolean" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default read-only state of connections created by this pool. If
+					not set then the setReadOnly
+					method will not be called.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="defaultTransactionIsolation" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default TransactionIsolation state of connections created by this
+					pool. If not set,
+					the method will not be called and it defaults to the JDBC driver.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:int">
+					<xsd:enumeration value="0"/>
+					<xsd:enumeration value="1"/>
+					<xsd:enumeration value="2"/>
+					<xsd:enumeration value="4"/>
+					<xsd:enumeration value="8"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="defaultTransactionIsolationName" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default TransactionIsolation names of connections created by this
+					pool. If not set,
+					the method will not be called and it defaults to the JDBC driver.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="NONE"/>
+					<xsd:enumeration value="READ_COMMITTED"/>
+					<xsd:enumeration value="READ_UNCOMMITTED"/>
+					<xsd:enumeration value="READ_COMMITTED"/>
+					<xsd:enumeration value="SERIALIZABLE"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="defaultCatalog" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The default catalog of connections created by this pool.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxActive" type="xsd:int" use="optional" default="100">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of active connections that can be allocated from
+					this pool at the same time.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxIdle" type="xsd:int" use="optional" default="100">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of active connections that can be allocated from
+					this pool at the same time.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="minIdle" type="xsd:int" use="optional" default="10">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of connections that should be kept in the pool at
+					all times. Default value is
+					maxActive:100 Idle connections are checked periodically (if enabled)
+					and connections that been idle
+					for longer than minEvictableIdleTimeMillis will be released. (also see
+					testWhileIdle)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initialSize" type="xsd:int" use="optional" default="10">
+			<xsd:annotation>
+				<xsd:documentation>
+					The initial number of connections that are created when the pool is
+					started.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="maxWait" type="xsd:int" use="optional" default="30000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The maximum number of milliseconds that the pool will wait (when there
+					are no available connections)
+					for a connection to be returned before throwing an exception.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testOnBorrow" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated before being
+					borrowed from the pool. If the
+					object fails to validate, it will be dropped from the pool, and we
+					will attempt to borrow another.
+					NOTE - for a true value to have any effect, the validationQuery
+					attribute must be set to a non-null
+					string. In order to have a more efficient validation, see
+					validationInterval.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testOnReturn" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated before being
+					returned to the pool. NOTE - for a
+					true value to have any effect, the validationQuery parameter must be
+					set to a non-null string.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="testWhileIdle" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					The indication of whether objects will be validated by the idle object
+					evictor (if any). If an
+					object fails to validate, it will be dropped from the pool. NOTE - for
+					a true value to have any
+					effect, the validationQuery attribute must be set to a non-null
+					string. This attribute has to be set
+					in order for the pool cleaner/test thread is to run (also see
+					timeBetweenEvictionRunsMillis)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="validationQuery" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The SQL query that will be used to validate connections from this pool
+					before returning them to the
+					caller. If specified, this query does not have to return any data, it
+					just can't throw a
+					SQLException. The default value is null. Example values are SELECT
+					1(mysql), select 1 from
+					dual(oracle), SELECT 1(MS Sql Server)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="validatorClassName" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The name of a class which implements the
+					org.apache.tomcat.jdbc.pool.Validator interface and
+					provides a no-arg constructor (may be implicit). If specified, the
+					class will be used to create a
+					Validator instance which is then used instead of any validation query
+					to validate connections. The
+					default value is null. An example value is
+					com.company.project.SimpleValidator.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="timeBetweenEvictionRunsMillis" type="xsd:int" use="optional"
+					   default="5000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The number of milliseconds to sleep between runs of the idle
+					connection validation/cleaner thread.
+					This value should not be set under 1 second. It dictates how often we
+					check for idle, abandoned
+					connections, and how often we validate idle connections.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="minEvictableIdleTimeMillis" type="xsd:int" use="optional"
+					   default="60000">
+			<xsd:annotation>
+				<xsd:documentation>
+					The minimum amount of time an object may sit idle in the pool before
+					it is eligible for eviction.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="removeAbandoned" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to remove abandoned connections if they exceed the
+					removeAbandonedTimeout. If set to true a
+					connection is considered abandoned and eligible for removal if it has
+					been in use longer than the
+					removeAbandonedTimeout Setting this to true can recover db connections
+					from applications that fail
+					to close a connection. See also logAbandoned.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="removeAbandonedTimeout" type="xsd:int" use="optional"
+					   default="60">
+			<xsd:annotation>
+				<xsd:documentation>
+					Timeout in seconds before an abandoned(in use) connection can be
+					removed. The default value is 60
+					(seconds). The value should be set to the longest running query your
+					applications might have.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="logAbandoned" type="xsd:boolean" use="optional"
+					   default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to log stack traces for application code which abandoned a
+					Connection. Logging of abandoned
+					Connections adds overhead for every Connection borrow because a stack
+					trace has to be generated.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connectionProperties" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The connection properties that will be sent to our JDBC driver when
+					establishing new connections.
+					Format of the string must be [propertyName=property;]*
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="initSQL" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					A custom query to be run when a connection is first created.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.GetUserResult;
+import com.amazonaws.services.identitymanagement.model.User;
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.AmazonRDSClient;
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.Endpoint;
+import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
+import com.amazonaws.services.rds.model.ListTagsForResourceResult;
+import com.amazonaws.services.rds.model.Tag;
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.beans.PropertyValue;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.cloud.aws.jdbc.rds.AmazonRdsReadReplicaAwareDataSourceFactoryBean;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link AmazonRdsDataSourceBeanDefinitionParser} bean definition parser.
+ *
+ * @author Agim Emruli
+ * @since 1.0
+ */
+public class AmazonRdsDataSourceBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_minimalConfiguration_createsBeanDefinitionWithoutReadReplicas() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader
+				.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-minimal.xml", getClass()));
+
+		AmazonRDS client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+
+		when(client.describeDBInstances(new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
+				.thenReturn(new DescribeDBInstancesResult()
+						.withDBInstances(new DBInstance().withDBInstanceStatus("available").withDBName("test")
+								.withDBInstanceIdentifier("test").withEngine("mysql").withMasterUsername("admin")
+								.withEndpoint(new Endpoint().withAddress("localhost").withPort(3306))
+								.withReadReplicaDBInstanceIdentifiers("read1")));
+
+		// Act
+		DataSource dataSource = beanFactory.getBean(DataSource.class);
+
+		// Assert
+		assertThat(dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource).isTrue();
+	}
+
+	@Test
+	public void parseInternal_readReplicaSupportEnabled_configuresReadReplicaEnabledFactoryBean() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-readReplicaEnabled.xml", getClass()));
+
+		// Act
+		BeanDefinition beanDefinition = beanFactory.getBeanDefinition("test");
+
+		// Assert
+		assertThat(beanDefinition.getBeanClassName())
+				.isEqualTo(AmazonRdsReadReplicaAwareDataSourceFactoryBean.class.getName());
+	}
+
+	@Test
+	public void parseInternal_noCredentialsDefined_returnsClientWithDefaultCredentialsProvider() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-noCredentials.xml", getClass()));
+
+		AmazonRDS client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+
+		when(client.describeDBInstances(new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
+				.thenReturn(new DescribeDBInstancesResult()
+						.withDBInstances(new DBInstance().withDBInstanceStatus("available").withDBName("test")
+								.withDBInstanceIdentifier("test").withEngine("mysql").withMasterUsername("admin")
+								.withEndpoint(new Endpoint().withAddress("localhost").withPort(3306))
+								.withReadReplicaDBInstanceIdentifiers("read1")));
+
+		// Act
+		DataSource dataSource = beanFactory.getBean(DataSource.class);
+
+		// Assert
+		assertThat(dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource).isTrue();
+	}
+
+	@Test
+	public void parseInternal_fullConfiguration_createsBeanDefinitionWithoutReadReplicas() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-fullConfiguration.xml", getClass()));
+
+		AmazonRDS client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+
+		when(client.describeDBInstances(new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
+				.thenReturn(new DescribeDBInstancesResult().withDBInstances(new DBInstance()
+						.withDBInstanceStatus("available").withDBName("test").withDBInstanceIdentifier("test")
+						.withEngine("mysql").withEndpoint(new Endpoint().withAddress("localhost").withPort(3306))));
+
+		BeanDefinition definition = beanFactory.getBeanDefinition("test");
+		assertThat(definition.getConstructorArgumentValues().getArgumentValue(1, String.class).getValue())
+				.isEqualTo("test");
+		assertThat(definition.getConstructorArgumentValues().getArgumentValue(2, String.class).getValue())
+				.isEqualTo("password");
+		assertThat(definition.getPropertyValues().getPropertyValue("username").getValue()).isEqualTo("myUser");
+		assertThat(definition.getPropertyValues().getPropertyValue("databaseName").getValue()).isEqualTo("fooDb");
+
+		DataSource dataSource = beanFactory.getBean(DataSource.class);
+
+		// Assert
+		assertThat(dataSource).isNotNull();
+		assertThat(dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource).isTrue();
+	}
+
+	@Test
+	public void parseInternal_dataSourceWithConfiguredPoolAttributes_poolAttributesConfigured() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-poolAttributes.xml", getClass()));
+
+		BeanDefinition definition = beanFactory.getBeanDefinition("test");
+
+		// Act
+		BeanDefinition dataSourceFactory = (BeanDefinition) definition.getPropertyValues()
+				.getPropertyValue("dataSourceFactory").getValue();
+
+		// Assert
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("connectionProperties").getValue())
+				.isEqualTo("foo=bar");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("defaultAutoCommit").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("defaultCatalog").getValue())
+				.isEqualTo("mySchema");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("defaultReadOnly").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("defaultTransactionIsolation").getValue())
+				.isEqualTo("2");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("initialSize").getValue()).isEqualTo("10");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("initSQL").getValue())
+				.isEqualTo("SET CURRENT SCHEMA");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("logAbandoned").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("maxActive").getValue()).isEqualTo("10");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("maxIdle").getValue()).isEqualTo("5");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("maxWait").getValue()).isEqualTo("10000");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("minEvictableIdleTimeMillis").getValue())
+				.isEqualTo("60000");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("minIdle").getValue()).isEqualTo("20");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("removeAbandonedTimeout").getValue())
+				.isEqualTo("61");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("testOnBorrow").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("testOnReturn").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("testWhileIdle").getValue())
+				.isEqualTo(Boolean.TRUE.toString());
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("timeBetweenEvictionRunsMillis").getValue())
+				.isEqualTo("4000");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("validationQuery").getValue())
+				.isEqualTo("SELECT 1");
+		assertThat(dataSourceFactory.getPropertyValues().getPropertyValue("validatorClassName").getValue())
+				.isEqualTo(SampleValidator.class.getName());
+	}
+
+	@Test
+	// As we provide default in the schema for better code completion we should check if
+	// they match to the underlying pool defaults
+	public void parseInternal_defaultPoolAttribute_matchesPoolConfiguration() throws Exception {
+		// Arrange
+		PoolProperties poolProperties = new PoolProperties();
+
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-defaultPoolAttributes.xml", getClass()));
+
+		// Act
+		BeanDefinition definition = beanFactory.getBeanDefinition("test");
+		BeanDefinition dataSourceFactory = (BeanDefinition) definition.getPropertyValues()
+				.getPropertyValue("dataSourceFactory").getValue();
+
+		// Assert
+		BeanWrapper beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(poolProperties);
+
+		for (PropertyValue propertyValue : dataSourceFactory.getPropertyValues().getPropertyValueList()) {
+			assertThat(propertyValue.getValue())
+					.isEqualTo(beanWrapper.getPropertyValue(propertyValue.getName()).toString());
+		}
+	}
+
+	@Test
+	public void parseInternal_customRegionConfigured_amazonRdsClientWithCustomRegionConfigured() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-customRegion.xml", getClass()));
+
+		// Act
+		AmazonRDS amazonRDS = beanFactory.getBean(AmazonRDS.class);
+
+		// Assert
+		// have to use reflection utils
+		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
+	}
+
+	@Test
+	public void parseInternal_custRegionProviderConf_amazRdsClientWithCustomRegionConfThatIsReturnedFromRegionProvider()
+			throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-customRegionProvider.xml", getClass()));
+
+		// Act
+		AmazonRDS amazonRDS = beanFactory.getBean(AmazonRDS.class);
+
+		// Assert
+		// have to use reflection utils
+		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
+
+	}
+
+	@Test
+	public void parseInternal_customRegionProviderAndRegionConfigured_reportsError() throws Exception {
+		// noinspection ResultOfObjectAllocationIgnored
+		assertThatThrownBy(() -> new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRegionProviderAndRegion.xml", getClass()))
+						.isInstanceOf(BeanDefinitionStoreException.class);
+	}
+
+	@Test
+	public void parseInternal_userTagsDefined_createsUserTagBeanDefinition() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		beanDefinitionBuilder.setFactoryMethod("mock");
+		beanDefinitionBuilder.addConstructorArgValue(AmazonRDS.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()),
+				beanDefinitionBuilder.getBeanDefinition());
+
+		BeanDefinitionBuilder identityBuilder = BeanDefinitionBuilder.rootBeanDefinition(Mockito.class);
+		identityBuilder.setFactoryMethod("mock");
+		identityBuilder.addConstructorArgValue(AmazonIdentityManagement.class);
+		beanFactory.registerBeanDefinition(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonIdentityManagement.class.getName()),
+				identityBuilder.getBeanDefinition());
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader
+				.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-userTags.xml", getClass()));
+
+		AmazonRDS client = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName()), AmazonRDS.class);
+		AmazonIdentityManagement amazonIdentityManagement = beanFactory.getBean(
+				AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonIdentityManagement.class.getName()),
+				AmazonIdentityManagement.class);
+
+		when(amazonIdentityManagement.getUser()).thenReturn(new GetUserResult().withUser(
+				new User("/", "aemruli", "123456789012", "arn:aws:iam::1234567890:user/aemruli", new Date())));
+		when(client.listTagsForResource(
+				new ListTagsForResourceRequest().withResourceName("arn:aws:rds:us-west-2:1234567890:db:test")))
+						.thenReturn(new ListTagsForResourceResult()
+								.withTagList(new Tag().withKey("key1").withValue("value2")));
+
+		// Act
+		Map<?, ?> dsTags = beanFactory.getBean("dsTags", Map.class);
+
+		// Assert
+		assertThat(dsTags.get("key1")).isEqualTo("value2");
+	}
+
+	@Test
+	public void parseInternal_customRdsInstance_createsRdsBeanAndUserTagsWithCustomRdsInstance() throws Exception {
+
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-customRdsInstance.xml", getClass()));
+
+		AmazonRDS clientMock = beanFactory.getBean("amazonRds", AmazonRDS.class);
+
+		when(clientMock.describeDBInstances(new DescribeDBInstancesRequest().withDBInstanceIdentifier("test")))
+				.thenReturn(new DescribeDBInstancesResult()
+						.withDBInstances(new DBInstance().withDBInstanceStatus("available").withDBName("test")
+								.withDBInstanceIdentifier("test").withEngine("mysql").withMasterUsername("admin")
+								.withEndpoint(new Endpoint().withAddress("localhost").withPort(3306))
+								.withReadReplicaDBInstanceIdentifiers("read1")));
+
+		AmazonIdentityManagement amazonIdentityManagement = beanFactory.getBean("myIdentityService",
+				AmazonIdentityManagement.class);
+
+		when(amazonIdentityManagement.getUser()).thenReturn(new GetUserResult().withUser(
+				new User("/", "aemruli", "123456789012", "arn:aws:iam::1234567890:user/aemruli", new Date())));
+		when(clientMock.listTagsForResource(
+				new ListTagsForResourceRequest().withResourceName("arn:aws:rds:us-west-2:1234567890:db:test")))
+						.thenReturn(new ListTagsForResourceResult()
+								.withTagList(new Tag().withKey("key1").withValue("value2")));
+
+		// Act
+		Map<?, ?> dsTags = beanFactory.getBean("dsTags", Map.class);
+		DataSource dataSource = beanFactory.getBean(DataSource.class);
+
+		// Assert
+		assertThat(dsTags.get("key1")).isEqualTo("value2");
+		assertThat(dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource).isTrue();
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import java.util.List;
+
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.AmazonRDSClient;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Agim Emruli
+ */
+public class AmazonRdsRetryInterceptorBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_minimalConfiguration_createsRetryInterceptor() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-minimal.xml", getClass());
+
+		// Act
+		MethodInterceptor interceptor = classPathXmlApplicationContext.getBean(MethodInterceptor.class);
+
+		// Assert
+		assertThat(interceptor).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_customRegionConfigured_createsAmazonRdsClientWithCustomRegionConfigured()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRegion.xml", getClass());
+
+		// Act
+		AmazonRDS amazonRDS = classPathXmlApplicationContext.getBean(AmazonRDS.class);
+
+		// Assert
+		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
+	}
+
+	@Test
+	public void parseInternal_customRegionProviderConfigured_createAmazonRdsClientWithCustomRegionConfigured()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRegionProvider.xml", getClass());
+
+		// Act
+		AmazonRDS amazonRDS = classPathXmlApplicationContext.getBean(AmazonRDS.class);
+
+		// Assert
+		assertThat(ReflectionTestUtils.getField(amazonRDS, "endpoint").toString())
+				.isEqualTo("https://rds.eu-west-1.amazonaws.com");
+	}
+
+	@Test
+	public void parseInternal_customRDsClientConfigured_createInterceptorWithCustomRdsClient() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRdsClient.xml", getClass());
+
+		// Act
+		classPathXmlApplicationContext.getBean(MethodInterceptor.class);
+
+		// Assert
+		assertThat(classPathXmlApplicationContext
+				.containsBean(AmazonWebserviceClientConfigurationUtils.getBeanName(AmazonRDSClient.class.getName())))
+						.isFalse();
+	}
+
+	@Test
+	public void parseInternal_customBackOffPolicy_createInterceptorWithCustomBackOffPolicy() throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customBackOffPolicy.xml", getClass());
+		BeanDefinition beanDefinition = classPathXmlApplicationContext.getBeanFactory()
+				.getBeanDefinition("interceptor");
+
+		// Act
+		BeanDefinition retryOperations = (BeanDefinition) beanDefinition.getPropertyValues()
+				.getPropertyValue("retryOperations").getValue();
+
+		// Assert
+		assertThat(((RuntimeBeanReference) retryOperations.getPropertyValues().getPropertyValue("backOffPolicy")
+				.getValue()).getBeanName()).isEqualTo("policy");
+	}
+
+	@Test
+	public void parseInternal_customNumberOfRetiresConfigured_createRetryPolicyWithCustomNumberOfRetriesConfigured()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-maxNumberOfRetries.xml", getClass());
+
+		// Act
+		BeanDefinition beanDefinition = classPathXmlApplicationContext.getBeanFactory()
+				.getBeanDefinition("interceptor");
+
+		// Assert
+		BeanDefinition retryOperations = (BeanDefinition) beanDefinition.getPropertyValues()
+				.getPropertyValue("retryOperations").getValue();
+		BeanDefinition compositeRetryPolicy = (BeanDefinition) retryOperations.getPropertyValues()
+				.getPropertyValue("retryPolicy").getValue();
+		@SuppressWarnings("unchecked")
+		List<BeanDefinition> policies = (List<BeanDefinition>) compositeRetryPolicy.getPropertyValues()
+				.getPropertyValue("policies").getValue();
+		BeanDefinition sqlPolicy = policies.get(1);
+		assertThat(sqlPolicy.getPropertyValues().getPropertyValue("maxNumberOfRetries").getValue().toString())
+				.isEqualTo("4");
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Alain Sahli
+ */
+public class JdbcSchemaWithoutVersionTest {
+
+	@Test
+	public void jdbcXsd_withoutVersion_shouldNotThrowAnException() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act & Assert
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + ".xml", getClass()));
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/SampleValidator.java
+++ b/spring-cloud-aws-jdbc/src/test/java/org/springframework/cloud/aws/jdbc/config/xml/SampleValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.jdbc.config.xml;
+
+import java.sql.Connection;
+
+import org.apache.tomcat.jdbc.pool.Validator;
+
+/**
+ * @author Agim Emruli
+ */
+public class SampleValidator implements Validator {
+
+	@Override
+	public boolean validate(Connection connection, int i) {
+		return true;
+	}
+
+}

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRdsInstance.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  user-tags-map="dsTags"
+					  amazon-rds="amazonRds"
+					  amazon-identity-management="myIdentityService"/>
+
+	<bean id="amazonRds" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.amazonaws.services.rds.AmazonRDS"/>
+	</bean>
+
+	<bean id="myIdentityService" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg
+			value="com.amazonaws.services.identitymanagement.AmazonIdentityManagement"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegion.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  region="eu-west-1"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProvider.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  region-provider="myRegionProvider"/>
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="eu-west-1"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-customRegionProviderAndRegion.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  region-provider="myRegionProvider" region="eu-west-1"/>
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="eu-west-1"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-defaultPoolAttributes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password">
+		<jdbc:pool-attributes/>
+	</jdbc:data-source>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-fullConfiguration.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password" username="myUser"
+					  read-replica-support="false" database-name="fooDb">
+		<jdbc:pool-attributes connectionProperties="foo=bar" defaultAutoCommit="true"
+							  defaultCatalog="mySchema" defaultReadOnly="true"
+							  defaultTransactionIsolationName="READ_COMMITTED"
+							  initialSize="10"
+							  initSQL="SET CURRENT SCHEMA" logAbandoned="true"
+							  maxActive="10" maxIdle="5" maxWait="10000"
+							  minEvictableIdleTimeMillis="60000"
+							  minIdle="20" removeAbandoned="true"
+							  removeAbandonedTimeout="61" testOnBorrow="true"
+							  testOnReturn="true" testWhileIdle="true"
+							  timeBetweenEvictionRunsMillis="4000"
+							  validationQuery="SELECT 1"
+							  validatorClassName="org.springframework.cloud.aws.jdbc.config.xml.SampleValidator"/>
+	</jdbc:data-source>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"/>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-noCredentials.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/cloud/aws/jdbc
+	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+
+	<jdbc:data-source db-instance-identifier="test" password="password"/>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-poolAttributes.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password">
+		<jdbc:pool-attributes connectionProperties="foo=bar" defaultAutoCommit="true"
+							  defaultCatalog="mySchema" defaultReadOnly="true"
+							  defaultTransactionIsolation="2" initialSize="10"
+							  initSQL="SET CURRENT SCHEMA" logAbandoned="true"
+							  maxActive="10" maxIdle="5" maxWait="10000"
+							  minEvictableIdleTimeMillis="60000"
+							  minIdle="20" removeAbandoned="true"
+							  removeAbandonedTimeout="61" testOnBorrow="true"
+							  testOnReturn="true" testWhileIdle="true"
+							  timeBetweenEvictionRunsMillis="4000"
+							  validationQuery="SELECT 1"
+							  validatorClassName="org.springframework.cloud.aws.jdbc.config.xml.SampleValidator"/>
+	</jdbc:data-source>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-readReplicaEnabled.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  read-replica-support="true"/>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsDataSourceBeanDefinitionParserTest-userTags.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  user-tags-map="dsTags"/>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customBackOffPolicy.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"
+							back-off-policy="policy"/>
+
+	<bean id="policy" class="org.springframework.retry.backoff.NoBackOffPolicy"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRdsClient.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"
+							amazon-rds="customRdsClient"/>
+
+	<bean id="customRdsClient" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.amazonaws.services.rds.AmazonRDS"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegion.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"
+							region="eu-west-1"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-customRegionProvider.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"
+							region-provider="myRegionProvider"/>
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="eu-west-1"/>
+	</bean>
+
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-maxNumberOfRetries.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"
+							max-number-of-retries="4"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/AmazonRdsRetryInterceptorBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns:context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc
+	   					   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<context:context-credentials>
+		<context:simple-credentials access-key="foo" secret-key="bar"/>
+	</context:context-credentials>
+
+	<jdbc:retry-interceptor db-instance-identifier="test" id="interceptor"/>
+</beans>

--- a/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
+++ b/spring-cloud-aws-jdbc/src/test/resources/org/springframework/cloud/aws/jdbc/config/xml/JdbcSchemaWithoutVersionTest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+			   			   http://www.springframework.org/schema/cloud/aws/jdbc
+			   			   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd">
+
+	<jdbc:data-source db-instance-identifier="test" password="password"
+					  region="eu-west-1"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParser.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SendToHandlerMethodReturnValueHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.core.Conventions;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+
+import static org.springframework.cloud.aws.messaging.config.xml.BufferedSqsClientBeanDefinitionUtils.getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName;
+
+/**
+ * {@link org.springframework.beans.factory.xml.BeanDefinitionParser} for the
+ * &lt;annotation-driven-queue-listener/&gt; element.
+ *
+ * @author Agim Emruli
+ * @author Alain Sahli
+ * @since 1.0
+ */
+@Deprecated
+public class AnnotationDrivenQueueListenerBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	private static final String TASK_EXECUTOR_ATTRIBUTE = "task-executor";
+
+	private static final String MAX_NUMBER_OF_MESSAGES_ATTRIBUTE = "max-number-of-messages";
+
+	private static final String VISIBILITY_TIMEOUT_ATTRIBUTE = "visibility-timeout";
+
+	private static final String WAIT_TIME_OUT_ATTRIBUTE = "wait-time-out";
+
+	private static final String AUTO_STARTUP_ATTRIBUTE = "auto-startup";
+
+	private static final String DESTINATION_RESOLVER_ATTRIBUTE = "destination-resolver";
+
+	private static final String BACK_OFF_TIME = "back-off-time";
+
+	private static String getMessageHandlerBeanName(Element element, ParserContext parserContext,
+			String sqsClientBeanName) {
+		BeanDefinitionBuilder queueMessageHandlerDefinitionBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(QueueMessageHandler.class);
+
+		if (parserContext.getRegistry().containsBeanDefinition("jacksonObjectMapper")) {
+			queueMessageHandlerDefinitionBuilder.addConstructorArgReference("jacksonObjectMapper");
+		}
+		else {
+			BeanDefinitionBuilder mapper = BeanDefinitionBuilder
+					.genericBeanDefinition("org.springframework.messaging.converter.MappingJackson2MessageConverter");
+			mapper.addPropertyValue("serializedPayloadClass", "java.lang.String");
+			mapper.addPropertyValue("strictContentTypeMatch", true);
+			queueMessageHandlerDefinitionBuilder.addConstructorArgValue(mapper.getBeanDefinition());
+		}
+
+		ManagedList<?> argumentResolvers = getArgumentResolvers(element, parserContext);
+		if (!argumentResolvers.isEmpty()) {
+			queueMessageHandlerDefinitionBuilder.addPropertyValue("customArgumentResolvers", argumentResolvers);
+		}
+
+		ManagedList<BeanDefinition> returnValueHandlers = getReturnValueHandlers(element, parserContext);
+		returnValueHandlers.add(
+				createSendToHandlerMethodReturnValueHandlerBeanDefinition(element, parserContext, sqsClientBeanName));
+		queueMessageHandlerDefinitionBuilder.addPropertyValue("customReturnValueHandlers", returnValueHandlers);
+
+		String messageHandlerBeanName = parserContext.getReaderContext()
+				.generateBeanName(queueMessageHandlerDefinitionBuilder.getBeanDefinition());
+		parserContext.getRegistry().registerBeanDefinition(messageHandlerBeanName,
+				queueMessageHandlerDefinitionBuilder.getBeanDefinition());
+
+		return messageHandlerBeanName;
+	}
+
+	private static AbstractBeanDefinition createSendToHandlerMethodReturnValueHandlerBeanDefinition(Element element,
+			ParserContext parserContext, String sqsClientBeanName) {
+		BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(SendToHandlerMethodReturnValueHandler.class);
+		if (StringUtils.hasText(element.getAttribute("send-to-message-template"))) {
+			beanDefinitionBuilder.addConstructorArgReference(element.getAttribute("send-to-message-template"));
+		}
+		else {
+			// TODO consider creating a utils for setting up the queue messaging template
+			// as it also created in QueueMessagingTemplateBeanDefinitionParser
+			BeanDefinitionBuilder templateBuilder = BeanDefinitionBuilder
+					.rootBeanDefinition(QueueMessagingTemplate.class);
+			templateBuilder.addConstructorArgReference(sqsClientBeanName);
+			templateBuilder.addConstructorArgReference(
+					GlobalBeanDefinitionUtils.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
+
+			beanDefinitionBuilder.addConstructorArgValue(templateBuilder.getBeanDefinition());
+		}
+
+		return beanDefinitionBuilder.getBeanDefinition();
+	}
+
+	private static ManagedList<BeanDefinition> getArgumentResolvers(Element element, ParserContext parserContext) {
+		Element resolversElement = DomUtils.getChildElementByTagName(element, "argument-resolvers");
+		if (resolversElement != null) {
+			return extractBeanSubElements(resolversElement, parserContext);
+		}
+		else {
+			return new ManagedList<>(0);
+		}
+	}
+
+	private static ManagedList<BeanDefinition> getReturnValueHandlers(Element element, ParserContext parserContext) {
+		Element handlersElement = DomUtils.getChildElementByTagName(element, "return-value-handlers");
+		if (handlersElement != null) {
+			return extractBeanSubElements(handlersElement, parserContext);
+		}
+		else {
+			return new ManagedList<>(0);
+		}
+	}
+
+	private static ManagedList<BeanDefinition> extractBeanSubElements(Element parentElement,
+			ParserContext parserContext) {
+		ManagedList<BeanDefinition> list = new ManagedList<>();
+		list.setSource(parserContext.extractSource(parentElement));
+		for (Element beanElement : DomUtils.getChildElementsByTagName(parentElement, "bean")) {
+			BeanDefinitionHolder beanDef = parserContext.getDelegate().parseBeanDefinitionElement(beanElement);
+			beanDef = parserContext.getDelegate().decorateBeanDefinitionIfRequired(beanElement, beanDef);
+			list.add(beanDef.getBeanDefinition());
+		}
+		return list;
+	}
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder containerBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition(SimpleMessageListenerContainer.class);
+
+		if (StringUtils.hasText(element.getAttribute(TASK_EXECUTOR_ATTRIBUTE))) {
+			containerBuilder.addPropertyReference(Conventions.attributeNameToPropertyName(TASK_EXECUTOR_ATTRIBUTE),
+					element.getAttribute(TASK_EXECUTOR_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(MAX_NUMBER_OF_MESSAGES_ATTRIBUTE))) {
+			containerBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(MAX_NUMBER_OF_MESSAGES_ATTRIBUTE),
+					element.getAttribute(MAX_NUMBER_OF_MESSAGES_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(VISIBILITY_TIMEOUT_ATTRIBUTE))) {
+			containerBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(VISIBILITY_TIMEOUT_ATTRIBUTE),
+					element.getAttribute(VISIBILITY_TIMEOUT_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(WAIT_TIME_OUT_ATTRIBUTE))) {
+			containerBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(WAIT_TIME_OUT_ATTRIBUTE),
+					element.getAttribute(WAIT_TIME_OUT_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(AUTO_STARTUP_ATTRIBUTE))) {
+			containerBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(AUTO_STARTUP_ATTRIBUTE),
+					element.getAttribute(AUTO_STARTUP_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(DESTINATION_RESOLVER_ATTRIBUTE))) {
+			containerBuilder.addPropertyReference(
+					Conventions.attributeNameToPropertyName(DESTINATION_RESOLVER_ATTRIBUTE),
+					element.getAttribute(DESTINATION_RESOLVER_ATTRIBUTE));
+		}
+
+		if (StringUtils.hasText(element.getAttribute(BACK_OFF_TIME))) {
+			containerBuilder.addPropertyValue(Conventions.attributeNameToPropertyName(BACK_OFF_TIME),
+					element.getAttribute(BACK_OFF_TIME));
+		}
+
+		String amazonSqsClientBeanName = getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(element,
+				parserContext);
+
+		containerBuilder.addPropertyReference(Conventions.attributeNameToPropertyName("amazon-sqs"),
+				amazonSqsClientBeanName);
+
+		containerBuilder.addPropertyReference("resourceIdResolver",
+				GlobalBeanDefinitionUtils.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
+		containerBuilder.addPropertyReference("messageHandler",
+				getMessageHandlerBeanName(element, parserContext, amazonSqsClientBeanName));
+
+		return containerBuilder.getBeanDefinition();
+	}
+
+	@Override
+	protected boolean shouldGenerateId() {
+		return true;
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/BufferedSqsClientBeanDefinitionUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Alain Sahli
+ * @author Agim Emruli
+ */
+@Deprecated
+public final class BufferedSqsClientBeanDefinitionUtils {
+
+	/**
+	 * SQS client class name.
+	 */
+	// @checkstyle:off
+	public static final String SQS_CLIENT_CLASS_NAME = "com.amazonaws.services.sqs.AmazonSQSAsyncClient";
+
+	// @checkstyle:on
+
+	// @checkstyle:off
+	static final String BUFFERED_SQS_CLIENT_CLASS_NAME = "com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient";
+
+	// @checkstyle:on
+
+	private BufferedSqsClientBeanDefinitionUtils() {
+		// Avoid instantiation
+	}
+
+	static String getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(Element element,
+			ParserContext parserContext) {
+		String amazonSqsClientBeanName = XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName(element,
+				parserContext, "amazon-sqs", SQS_CLIENT_CLASS_NAME);
+		if (!StringUtils.hasText(element.getAttribute("amazon-sqs"))) {
+			BeanDefinition clientBeanDefinition = parserContext.getRegistry()
+					.getBeanDefinition(amazonSqsClientBeanName);
+			if (!clientBeanDefinition.getBeanClassName().equals(BUFFERED_SQS_CLIENT_CLASS_NAME)) {
+				BeanDefinitionBuilder bufferedClientBeanDefinitionBuilder = BeanDefinitionBuilder
+						.rootBeanDefinition(BUFFERED_SQS_CLIENT_CLASS_NAME);
+				bufferedClientBeanDefinitionBuilder.addConstructorArgValue(clientBeanDefinition);
+				parserContext.getRegistry().removeBeanDefinition(amazonSqsClientBeanName);
+				parserContext.getRegistry().registerBeanDefinition(amazonSqsClientBeanName,
+						bufferedClientBeanDefinitionBuilder.getBeanDefinition());
+			}
+		}
+		return amazonSqsClientBeanName;
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/MessagingNamespaceHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/MessagingNamespaceHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * {@link org.springframework.beans.factory.xml.NamespaceHandler} for the Spring Cloud AWS
+ * messaging namespace.
+ *
+ * @author Agim Emruli
+ * @author Alain Sahli
+ * @since 1.0
+ */
+@SuppressWarnings("UnusedDeclaration")
+@Deprecated
+public class MessagingNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		registerBeanDefinitionParser("annotation-driven-queue-listener",
+				new AnnotationDrivenQueueListenerBeanDefinitionParser());
+		registerBeanDefinitionParser("queue-messaging-template", new QueueMessagingTemplateBeanDefinitionParser());
+		registerBeanDefinitionParser("notification-messaging-template",
+				new NotificationMessagingTemplateBeanDefinitionParser());
+		registerBeanDefinitionParser("notification-argument-resolver",
+				new NotificationArgumentResolverBeanDefinitionParser());
+		registerBeanDefinitionParser("sqs-async-client", new SqsAsyncClientBeanDefinitionParser());
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * @author Agim Emruli
+ */
+@Deprecated
+class NotificationArgumentResolverBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	@Override
+	protected String getBeanClassName(Element element) {
+		return "org.springframework.cloud.aws.messaging.endpoint.config.NotificationHandlerMethodArgumentResolverFactoryBean";
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		builder.addConstructorArgReference(getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-sns",
+				"com.amazonaws.services.sns.AmazonSNSClient"));
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.messaging.core.NotificationMessagingTemplate;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.getCustomClientOrDefaultClientBeanName;
+
+/**
+ * @author Alain Sahli
+ */
+@Deprecated
+public class NotificationMessagingTemplateBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String DEFAULT_DESTINATION_ATTRIBUTE = "default-destination";
+
+	private static final String SNS_CLIENT_CLASS_NAME = "com.amazonaws.services.sns.AmazonSNSClient";
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return NotificationMessagingTemplate.class;
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		if (StringUtils.hasText(element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE))) {
+			builder.addPropertyValue("defaultDestinationName", element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE));
+		}
+
+		builder.addConstructorArgReference(
+				getCustomClientOrDefaultClientBeanName(element, parserContext, "amazon-sns", SNS_CLIENT_CLASS_NAME));
+		builder.addConstructorArgReference(
+				GlobalBeanDefinitionUtils.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.messaging.config.xml.BufferedSqsClientBeanDefinitionUtils.getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName;
+
+/**
+ * @author Alain Sahli
+ */
+@Deprecated
+public class QueueMessagingTemplateBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String DEFAULT_DESTINATION_ATTRIBUTE = "default-destination";
+
+	private static final String MESSAGE_CONVERTER_ATTRIBUTE = "message-converter";
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return QueueMessagingTemplate.class;
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		String amazonSqsClientBeanName = getCustomAmazonSqsClientOrDecoratedDefaultSqsClientBeanName(element,
+				parserContext);
+
+		if (StringUtils.hasText(element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE))) {
+			builder.addPropertyValue("defaultDestinationName", element.getAttribute(DEFAULT_DESTINATION_ATTRIBUTE));
+		}
+
+		builder.addConstructorArgReference(amazonSqsClientBeanName);
+		builder.addConstructorArgReference(
+				GlobalBeanDefinitionUtils.retrieveResourceIdResolverBeanName(parserContext.getRegistry()));
+
+		if (StringUtils.hasText(element.getAttribute(MESSAGE_CONVERTER_ATTRIBUTE))) {
+			builder.addConstructorArgReference(element.getAttribute(MESSAGE_CONVERTER_ATTRIBUTE));
+		}
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParser.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.aws.core.task.ShutdownSuppressingExecutorServiceAdapter;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.aws.core.config.xml.XmlWebserviceConfigurationUtils.parseCustomClientElement;
+
+/**
+ * @author Alain Sahli
+ * @author Agim Emruli
+ */
+@Deprecated
+public class SqsAsyncClientBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		AbstractBeanDefinition sqsAsyncClientDefinition = parseCustomClientElement(element, parserContext,
+				BufferedSqsClientBeanDefinitionUtils.SQS_CLIENT_CLASS_NAME);
+		if (StringUtils.hasText(element.getAttribute("task-executor"))) {
+			BeanDefinitionBuilder builder = BeanDefinitionBuilder
+					.genericBeanDefinition(ShutdownSuppressingExecutorServiceAdapter.class);
+			builder.addConstructorArgReference(element.getAttribute("task-executor"));
+			sqsAsyncClientDefinition.getPropertyValues().addPropertyValue("executor", builder.getBeanDefinition());
+		}
+		if (Boolean.parseBoolean(element.getAttribute("buffered"))) {
+			BeanDefinitionBuilder builder = BeanDefinitionBuilder
+					.genericBeanDefinition(BufferedSqsClientBeanDefinitionUtils.BUFFERED_SQS_CLIENT_CLASS_NAME);
+			builder.addConstructorArgValue(sqsAsyncClientDefinition);
+			return builder.getBeanDefinition();
+		}
+		else {
+			return sqsAsyncClientDefinition;
+		}
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
+++ b/spring-cloud-aws-messaging/src/main/java/org/springframework/cloud/aws/messaging/listener/QueueMessageHandler.java
@@ -84,6 +84,10 @@ public class QueueMessageHandler extends AbstractMethodMessageHandler<QueueMessa
 		this.sqsMessageDeletionPolicy = sqsMessageDeletionPolicy;
 	}
 
+	public QueueMessageHandler(List<MessageConverter> messageConverters) {
+		this(messageConverters, SqsMessageDeletionPolicy.NO_REDRIVE);
+	}
+
 	public QueueMessageHandler() {
 		this.messageConverters = Collections.emptyList();
 		this.sqsMessageDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;

--- a/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.handlers
+++ b/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,16 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/messaging=org.springframework.cloud.aws.messaging.config.xml.MessagingNamespaceHandler

--- a/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.schemas
+++ b/spring-cloud-aws-messaging/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,18 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+http\://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.0.xsd=org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
+http\://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging-1.2.xsd=org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
+http\://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd=org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.0.xsd
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:beans="http://www.springframework.org/schema/beans"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/messaging"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/messaging"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="annotation-driven-queue-listener">
+		<xsd:annotation>
+			<xsd:documentation>
+				Scans the classes annotated with
+				org.springframework.cloud.aws.messaging.config.annotation.QueueListener
+				and
+				registers them as endpoints for receiving messages from SQS.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all minOccurs="0">
+				<xsd:element name="argument-resolvers" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>
+							Configures HandlerMethodArgumentResolver types to support
+							custom queue messaging method argument types.
+							Using this option does not override the built-in support for
+							resolving handler method arguments.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element ref="beans:bean" minOccurs="1"
+										 maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>
+										The HandlerMethodArgumentResolver bean definition.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+
+				<xsd:element name="return-value-handlers" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>
+							Configures HandlerMethodReturnValueHandler types to support
+							custom queue messaging method return value handling.
+							Using this option does not override the built-in support for
+							handling return values.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element ref="beans:bean" minOccurs="1"
+										 maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>
+										The HandlerMethodReturnValueHandler bean
+										definition.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:all>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.core.task.TaskExecutor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Configures the TaskExecutor which is used to poll messages and
+						execute them
+						by calling the handler methods. If no TaskExecutor is set, a
+						default one is created.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-sqs" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.sqs.AmazonSQSAsync"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Sets the AmazonSQSAsync that is going to be used by the container
+						to interact with the messaging
+						(SQS) API.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="max-number-of-messages" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configure the maximum number of messages that should be retrieved
+						during one poll to the Amazon SQS system. This
+						number must be a positive, non-zero number that has a maximum
+						number of 10. Values higher then 10 are currently
+						not supported by the queueing system.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="visibility-timeout" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configures the duration (in seconds) that the received messages
+						are hidden from
+						subsequent poll requests after being retrieved from the system.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="wait-time-out" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
+						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
+						be between 1 and 20. For more information read the
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:boolean">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configures if this container should be automatically started. The
+						default value is true.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="send-to-message-template" type="xsd:string"
+						   use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to a bean that implements the
+						org.springframework.messaging.core.MessageSendingOperations
+						interface.
+						This message template will be used to send return values of
+						methods annotated with @SendTo.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.messaging.core.MessageSendingOperations"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="destination-resolver" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to a bean that implements the
+						org.springframework.messaging.core.DestinationResolver interface.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.messaging.core.DestinationResolver"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="delete-message-on-exception" type="xsd:boolean"
+						   use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Defines if a message must be deleted or not if the handler method
+						throws an exception and the exception handler
+						method is called. By default this value is set to true which means
+						that the message is deleted to avoid
+						poison messages. If this value is set to false it is the
+						responsibility of the exception handler method to delete
+						the message. The exception handler method can inject the message
+						headers with
+						org.springframework.messaging.handler.annotation.Headers
+						in order to get the receipt handle.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="back-off-time" type="xsd:long" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The number of milliseconds the polling thread must wait before
+						trying to recover when an error occurs
+						(e.g. connection timeout). Default value is 10000 milliseconds.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="queue-messaging-template">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a
+				org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attribute name="amazon-sqs" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sqs.AmazonSQSAsync"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.messaging.converter.MessageConverter"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="default-destination" type="xsd:string"/>
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-messaging-template">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a
+				org.springframework.cloud.aws.messaging.core.NotificationMessagingTemplate
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attribute name="amazon-sns" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sns.AmazonSNS"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="default-destination" type="xsd:string"/>
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-argument-resolver">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a HandlerMethodArgumentResolver to be used in Spring MVC to
+				support Notification endpoints in
+				Spring MVC. The configured bean must be registered as an custom argument
+				resolver in Spring MVC
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.web.method.support.HandlerMethodArgumentResolver"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+					<xsd:attribute name="amazon-sns" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sns.AmazonSNS"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="sqs-async-client">
+		<xsd:annotation>
+			<xsd:documentation>Configures an SQS client instance, with the configuration
+				parameter specified.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.core.task.TaskExecutor"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="buffered" type="xsd:boolean" default="true"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
+++ b/spring-cloud-aws-messaging/src/main/resources/org/springframework/cloud/aws/messaging/config/xml/spring-cloud-aws-messaging-1.2.xsd
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8" ?><!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:beans="http://www.springframework.org/schema/beans"
+			xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+			xmlns="http://www.springframework.org/schema/cloud/aws/messaging"
+			targetNamespace="http://www.springframework.org/schema/cloud/aws/messaging"
+			elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool"
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
+	<xsd:import namespace="http://www.springframework.org/schema/cloud/aws/context"
+				schemaLocation="http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"/>
+
+	<xsd:element name="annotation-driven-queue-listener">
+		<xsd:annotation>
+			<xsd:documentation>
+				Scans the classes annotated with
+				org.springframework.cloud.aws.messaging.config.annotation.QueueListener
+				and
+				registers them as endpoints for receiving messages from SQS.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all minOccurs="0">
+				<xsd:element name="argument-resolvers" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>
+							Configures HandlerMethodArgumentResolver types to support
+							custom queue messaging method argument types.
+							Using this option does not override the built-in support for
+							resolving handler method arguments.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element ref="beans:bean" minOccurs="1"
+										 maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>
+										The HandlerMethodArgumentResolver bean definition.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+
+				<xsd:element name="return-value-handlers" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>
+							Configures HandlerMethodReturnValueHandler types to support
+							custom queue messaging method return value handling.
+							Using this option does not override the built-in support for
+							handling return values.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element ref="beans:bean" minOccurs="1"
+										 maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>
+										The HandlerMethodReturnValueHandler bean
+										definition.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:all>
+			<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.core.task.TaskExecutor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Configures the TaskExecutor which is used to poll messages and
+						execute them
+						by calling the handler methods. If no TaskExecutor is set, a
+						default one is created.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="amazon-sqs" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="com.amazonaws.services.sqs.AmazonSQSAsync"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Sets the AmazonSQSAsync that is going to be used by the container
+						to interact with the messaging
+						(SQS) API.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="max-number-of-messages" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configure the maximum number of messages that should be retrieved
+						during one poll to the Amazon SQS system. This
+						number must be a positive, non-zero number that has a maximum
+						number of 10. Values higher then 10 are currently
+						not supported by the queueing system.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="visibility-timeout" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configures the duration (in seconds) that the received messages
+						are hidden from
+						subsequent poll requests after being retrieved from the system.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="wait-time-out" type="xsd:nonNegativeInteger">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Configures the wait timeout that the poll request will wait for new message to arrive if the are currently no
+						messages on the queue. Higher values will reduce poll request to the system significantly. The value should
+						be between 1 and 20. For more information read the
+						<a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:boolean">
+				<xsd:annotation>
+					<xsd:documentation>
+						Configures if this container should be automatically started. The
+						default value is true.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="send-to-message-template" type="xsd:string"
+						   use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to a bean that implements the
+						org.springframework.messaging.core.MessageSendingOperations
+						interface.
+						This message template will be used to send return values of
+						methods annotated with @SendTo.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.messaging.core.MessageSendingOperations"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="destination-resolver" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to a bean that implements the
+						org.springframework.messaging.core.DestinationResolver interface.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.messaging.core.DestinationResolver"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="back-off-time" type="xsd:long" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The number of milliseconds the polling thread must wait before
+						trying to recover when an error occurs
+						(e.g. connection timeout). Default value is 10000 milliseconds.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="queue-stop-timeout" type="xsd:integer" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The number of milliseconds to wait before interupting the polling
+						thread when a queue is stopped.
+						Default value is 10000 milliseconds.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="queue-messaging-template">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a
+				org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attribute name="amazon-sqs" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sqs.AmazonSQSAsync"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.messaging.converter.MessageConverter"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="default-destination" type="xsd:string"/>
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-messaging-template">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a
+				org.springframework.cloud.aws.messaging.core.NotificationMessagingTemplate
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attribute name="amazon-sns" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sns.AmazonSNS"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="default-destination" type="xsd:string"/>
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-argument-resolver">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures a HandlerMethodArgumentResolver to be used in Spring MVC to
+				support Notification endpoints in
+				Spring MVC. The configured bean must be registered as an custom argument
+				resolver in Spring MVC
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports
+						type="org.springframework.web.method.support.HandlerMethodArgumentResolver"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+					<xsd:attribute name="amazon-sns" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="com.amazonaws.services.sns.AmazonSNS"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="sqs-async-client">
+		<xsd:annotation>
+			<xsd:documentation>Configures an SQS client instance, with the configuration
+				parameter specified.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attributeGroup ref="aws-context:locationAttributeGroup"/>
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.core.task.TaskExecutor"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="buffered" type="xsd:boolean" default="true"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import java.util.List;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.core.env.StackResourceRegistryDetectingResourceIdResolver;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SendToHandlerMethodReturnValueHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.GenericXmlApplicationContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodReturnValueHandler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Agim Emruli
+ * @author Alain Sahli
+ * @since 1.0
+ */
+public class AnnotationDrivenQueueListenerBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_minimalConfiguration_shouldProduceContainerWithDefaultAmazonSqsBean() throws Exception {
+		// Act
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-minimal.xml", getClass());
+
+		// Assert
+		AmazonSQSAsync amazonSqsClient = applicationContext.getBean(AmazonSQSAsync.class);
+		assertThat(amazonSqsClient).isNotNull();
+
+		SimpleMessageListenerContainer container = applicationContext.getBean(SimpleMessageListenerContainer.class);
+		assertThat(container).isNotNull();
+
+		assertThat(ReflectionTestUtils.getField(container, "amazonSqs")).isSameAs(amazonSqsClient);
+		assertThat(ReflectionTestUtils.getField(container, "resourceIdResolver"))
+				.isSameAs(applicationContext.getBean(StackResourceRegistryDetectingResourceIdResolver.class));
+
+		QueueMessageHandler queueMessageHandler = (QueueMessageHandler) ReflectionTestUtils.getField(container,
+				"messageHandler");
+		HandlerMethodReturnValueHandler sendToReturnValueHandler = queueMessageHandler.getReturnValueHandlers().get(0);
+		assertThat(SendToHandlerMethodReturnValueHandler.class.isInstance(sendToReturnValueHandler)).isTrue();
+		QueueMessagingTemplate queueMessagingTemplate = (QueueMessagingTemplate) ReflectionTestUtils
+				.getField(sendToReturnValueHandler, "messageTemplate");
+
+		assertThat(CompositeMessageConverter.class.isInstance(queueMessagingTemplate.getMessageConverter())).isTrue();
+
+		@SuppressWarnings("unchecked")
+		List<MessageConverter> messageConverters = (List<MessageConverter>) ReflectionTestUtils
+				.getField(queueMessagingTemplate.getMessageConverter(), "converters");
+		assertThat(messageConverters.size()).isEqualTo(2);
+		assertThat(StringMessageConverter.class.isInstance(messageConverters.get(0))).isTrue();
+		assertThat(MappingJackson2MessageConverter.class.isInstance(messageConverters.get(1))).isTrue();
+
+		StringMessageConverter stringMessageConverter = (StringMessageConverter) messageConverters.get(0);
+		assertThat(stringMessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(stringMessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+
+		MappingJackson2MessageConverter jackson2MessageConverter = (MappingJackson2MessageConverter) messageConverters
+				.get(1);
+		assertThat(jackson2MessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(jackson2MessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+	}
+
+	@Test
+	public void parseInternal_customSqsClient_shouldProduceContainerWithCustomSqsClientUsed() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-amazon-sqs.xml", getClass()));
+
+		// Assert
+		BeanDefinition sqsAsync = registry.getBeanDefinition("myClient");
+		assertThat(sqsAsync).isNotNull();
+
+		BeanDefinition abstractContainerDefinition = registry
+				.getBeanDefinition(SimpleMessageListenerContainer.class.getName() + "#0");
+		assertThat(abstractContainerDefinition).isNotNull();
+
+		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(3);
+		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues().getPropertyValue("amazonSqs")
+				.getValue()).getBeanName()).isEqualTo("myClient");
+	}
+
+	@Test
+	public void parseInternal_customTaskExecutor_shouldCreateContainerAndClientWithCustomTaskExecutor()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-task-executor.xml", getClass()));
+
+		// Assert
+		BeanDefinition executor = beanFactory.getBeanDefinition("executor");
+		assertThat(executor).isNotNull();
+
+		BeanDefinition abstractContainerDefinition = beanFactory
+				.getBeanDefinition(SimpleMessageListenerContainer.class.getName() + "#0");
+		assertThat(abstractContainerDefinition).isNotNull();
+
+		assertThat(abstractContainerDefinition.getPropertyValues().size()).isEqualTo(4);
+		assertThat(((RuntimeBeanReference) abstractContainerDefinition.getPropertyValues()
+				.getPropertyValue("taskExecutor").getValue()).getBeanName()).isEqualTo("executor");
+
+		AmazonSQSBufferedAsyncClient bufferedAsyncClient = beanFactory.getBean(AmazonSQSBufferedAsyncClient.class);
+		assertThat(bufferedAsyncClient).isNotNull();
+	}
+
+	@Test
+	public void parseInternal_withSendToMessageTemplateAttribute_mustBeSetOnTheBeanDefinition() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-with-send-to-message-template.xml", getClass()));
+
+		// Assert
+		BeanDefinition queueMessageHandler = registry.getBeanDefinition(QueueMessageHandler.class.getName() + "#0");
+		assertThat(queueMessageHandler).isNotNull();
+
+		assertThat(queueMessageHandler.getPropertyValues().size()).isEqualTo(1);
+		ManagedList<?> returnValueHandlers = (ManagedList<?>) queueMessageHandler.getPropertyValues()
+				.getPropertyValue("customReturnValueHandlers").getValue();
+		assertThat(returnValueHandlers.size()).isEqualTo(1);
+		RootBeanDefinition sendToReturnValueHandler = (RootBeanDefinition) returnValueHandlers.get(0);
+
+		assertThat(((RuntimeBeanReference) sendToReturnValueHandler.getConstructorArgumentValues()
+				.getArgumentValue(0, RuntimeBeanReference.class).getValue()).getBeanName())
+						.isEqualTo("messageTemplate");
+	}
+
+	@Test
+	public void parseInternal_withCustomProperties_customPropertiesConfiguredOnContainer() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-properties.xml", getClass()));
+
+		// Assert
+		BeanDefinition abstractContainerDefinition = registry
+				.getBeanDefinition(SimpleMessageListenerContainer.class.getName() + "#0");
+		assertThat(abstractContainerDefinition).isNotNull();
+
+		assertThat(abstractContainerDefinition.getPropertyValues().getPropertyValue("autoStartup").getValue())
+				.isEqualTo("false");
+		assertThat(abstractContainerDefinition.getPropertyValues().getPropertyValue("maxNumberOfMessages").getValue())
+				.isEqualTo("9");
+		assertThat(abstractContainerDefinition.getPropertyValues().getPropertyValue("visibilityTimeout").getValue())
+				.isEqualTo("6");
+		assertThat(abstractContainerDefinition.getPropertyValues().getPropertyValue("waitTimeOut").getValue())
+				.isEqualTo("3");
+	}
+
+	@Test
+	public void parseInternal_customArgumentResolvers_parsedAndConfiguredInQueueMessageHandler() throws Exception {
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(applicationContext);
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-argument-resolvers.xml", getClass()));
+
+		// Act
+		applicationContext.refresh();
+
+		// Assert
+		assertThat(applicationContext.getBean(QueueMessageHandler.class)).isNotNull();
+		assertThat(applicationContext.getBean(QueueMessageHandler.class).getCustomArgumentResolvers().size())
+				.isEqualTo(1);
+		assertThat(TestHandlerMethodArgumentResolver.class
+				.isInstance(applicationContext.getBean(QueueMessageHandler.class).getCustomArgumentResolvers().get(0)))
+						.isTrue();
+	}
+
+	@Test
+	public void parseInternal_customReturnValueHandlers_parsedAndConfiguredInQueueMessageHandler() throws Exception {
+		// Arrange
+		GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(applicationContext);
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-return-value-handlers.xml", getClass()));
+
+		// Act
+		applicationContext.refresh();
+
+		// Assert
+		assertThat(applicationContext.getBean(QueueMessageHandler.class)).isNotNull();
+		assertThat(applicationContext.getBean(QueueMessageHandler.class).getCustomReturnValueHandlers().size())
+				.isEqualTo(2);
+		assertThat(TestHandlerMethodReturnValueHandler.class.isInstance(
+				applicationContext.getBean(QueueMessageHandler.class).getCustomReturnValueHandlers().get(0))).isTrue();
+	}
+
+	@Test
+	public void parseInternal_customerRegionConfigured_regionConfiguredAndParsedForInternalCreatedSqsClient()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSQSBufferedAsyncClient = registry
+				.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSQSBufferedAsyncClient, "realSQS");
+
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sqs"));
+	}
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_customerRegionProviderConfigured_regionProviderConfiguredAndParsedForInternalCreatedSqsClient()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSQSBufferedAsyncClient = registry
+				.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSQSBufferedAsyncClient, "realSQS");
+
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.AP_SOUTHEAST_2).getServiceEndpoint("sqs"));
+	}
+
+	@Test
+	public void contextRegion_clientWithoutRegion_shouldHaveTheRegionGloballyDefined() throws Exception {
+		// Arrange & Act
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-context-region.xml", getClass());
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSQSBufferedAsyncClient = applicationContext
+				.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSQSBufferedAsyncClient, "realSQS");
+
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.AP_SOUTHEAST_1).getServiceEndpoint("sqs"));
+	}
+
+	@Test
+	public void parseInternal_customDestinationResolver_isUsedOnTheContainer() throws Exception {
+		// Arrange & Act
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-custom-destination-resolver.xml", getClass());
+
+		// Assert
+		SimpleMessageListenerContainer container = applicationContext.getBean(SimpleMessageListenerContainer.class);
+		DestinationResolver<?> customDestinationResolver = applicationContext.getBean(DestinationResolver.class);
+		assertThat(customDestinationResolver == ReflectionTestUtils.getField(container, "destinationResolver"))
+				.isTrue();
+	}
+
+	@Test
+	public void parseInternal_definedBackOffTime_shouldBeSetOnContainer() throws Exception {
+		// Arrange & Act
+		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-back-off-time.xml", getClass());
+
+		// Assert
+		SimpleMessageListenerContainer container = applicationContext.getBean(SimpleMessageListenerContainer.class);
+		assertThat(container.getBackOffTime()).isEqualTo(5000L);
+	}
+
+	private static class TestHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+		@Override
+		public boolean supportsParameter(MethodParameter parameter) {
+			return false;
+		}
+
+		@Override
+		public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+			return null;
+		}
+
+	}
+
+	private static class TestHandlerMethodReturnValueHandler implements HandlerMethodReturnValueHandler {
+
+		@Override
+		public boolean supportsReturnType(MethodParameter returnType) {
+			return false;
+		}
+
+		@Override
+		public void handleReturnValue(Object returnValue, MethodParameter returnType, Message<?> message)
+				throws Exception {
+
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Alain Sahli
+ */
+public class MessagingSchemaWithoutSchemaTest {
+
+	@Test
+	public void messagingXsd_withoutVersion_shouldNotThrowAnException() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act & Assert
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + ".xml", getClass()));
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import java.net.URI;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sns.AmazonSNSClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.getBeanName;
+
+public class NotificationArgumentResolverBeanDefinitionParserTest {
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_minimalConfiguration_configuresHandlerMethodArgumentResolverWithAmazonSnsImplicitlyConfigured()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-minimal.xml", getClass());
+
+		// Act
+		HandlerMethodArgumentResolver argumentResolver = context.getBean(HandlerMethodArgumentResolver.class);
+
+		// Assert
+		assertThat(argumentResolver).isNotNull();
+		assertThat(context.containsBean(getBeanName(AmazonSNSClient.class.getName()))).isTrue();
+	}
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_customRegion_configuresHandlerMethodArgumentResolverWithAmazonSnsImplicitlyConfiguredAndCustomRegionSet()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRegion.xml", getClass());
+
+		// Act
+		AmazonSNSClient snsClient = context.getBean(AmazonSNSClient.class);
+
+		// Assert
+		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint"))
+				.isEqualTo(new URI("https", Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sns"), null, null));
+	}
+
+	// @checkstyle:off
+	@Test
+	public void parseInternal_customRegionProvider_configuresHandlerMethodArgumentResolverWithAmazonSnsImplicitlyConfiguredAndCustomRegionSet()
+			throws Exception {
+		// @checkstyle:on
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customRegionProvider.xml", getClass());
+
+		// Act
+		AmazonSNSClient snsClient = context.getBean(AmazonSNSClient.class);
+
+		// Assert
+		assertThat(ReflectionTestUtils.getField(snsClient, "endpoint"))
+				.isEqualTo(new URI("https", Region.getRegion(Regions.US_WEST_2).getServiceEndpoint("sns"), null, null));
+	}
+
+	@Test
+	public void parseInternal_customSnsClient_configuresHandlerMethodArgumentResolverWithCustomSnsClient()
+			throws Exception {
+		// Arrange
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				getClass().getSimpleName() + "-customSnsClient.xml", getClass());
+
+		// Act
+		AmazonSNSClient snsClient = context.getBean("customSnsClient", AmazonSNSClient.class);
+
+		// Assert
+		assertThat(snsClient).isNotNull();
+		assertThat(context.containsBean(getBeanName(AmazonSNSClient.class.getName()))).isFalse();
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import java.util.List;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sns.AmazonSNSClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.messaging.core.NotificationMessagingTemplate;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Alain Sahli
+ */
+public class NotificationMessagingTemplateBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_withMinimalConfig_shouldCreateDefaultTemplate() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-minimal.xml", getClass()));
+
+		// Assert
+		NotificationMessagingTemplate notificationMessagingTemplate = registry
+				.getBean(NotificationMessagingTemplate.class);
+		assertThat(ReflectionTestUtils.getField(notificationMessagingTemplate, "amazonSns"))
+				.isSameAs(registry.getBean(AmazonSNSClient.class));
+
+		Object cachingDestinationResolverProxy = ReflectionTestUtils.getField(notificationMessagingTemplate,
+				"destinationResolver");
+		Object targetDestinationResolver = ReflectionTestUtils.getField(cachingDestinationResolverProxy,
+				"targetDestinationResolver");
+		assertThat(ReflectionTestUtils.getField(targetDestinationResolver, "resourceIdResolver"))
+				.isEqualTo(registry.getBean(GlobalBeanDefinitionUtils.RESOURCE_ID_RESOLVER_BEAN_NAME));
+
+		assertThat(CompositeMessageConverter.class.isInstance(notificationMessagingTemplate.getMessageConverter()))
+				.isTrue();
+		@SuppressWarnings("unchecked")
+		List<MessageConverter> messageConverters = (List<MessageConverter>) ReflectionTestUtils
+				.getField(notificationMessagingTemplate.getMessageConverter(), "converters");
+		assertThat(messageConverters.size()).isEqualTo(2);
+		assertThat(StringMessageConverter.class.isInstance(messageConverters.get(0))).isTrue();
+		assertThat(MappingJackson2MessageConverter.class.isInstance(messageConverters.get(1))).isTrue();
+
+		StringMessageConverter stringMessageConverter = (StringMessageConverter) messageConverters.get(0);
+		assertThat(stringMessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(stringMessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+
+		MappingJackson2MessageConverter jackson2MessageConverter = (MappingJackson2MessageConverter) messageConverters
+				.get(1);
+		assertThat(jackson2MessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(jackson2MessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+	}
+
+	@Test
+	public void parseInternal_withCustomAmazonSnsClient_shouldPassItAsConstructorArg() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-amazon-sns.xml", getClass()));
+
+		// Assert
+		BeanDefinition notificationMessagingTemplateBeanDefinition = registry
+				.getBeanDefinition("notificationMessagingTemplate");
+		assertThat(((RuntimeBeanReference) notificationMessagingTemplateBeanDefinition.getConstructorArgumentValues()
+				.getArgumentValue(0, RuntimeBeanReference.class).getValue()).getBeanName()).isEqualTo("mySnsClient");
+	}
+
+	@Test
+	public void parseInternal_withDefaultDestination_mustBeSetOnTemplate() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-with-default-destination.xml", getClass()));
+
+		// Assert
+		BeanDefinition notificationMessagingTemplateBeanDefinition = registry
+				.getBeanDefinition("notificationMessagingTemplate");
+		assertThat(notificationMessagingTemplateBeanDefinition.getPropertyValues()
+				.getPropertyValue("defaultDestinationName").getValue()).isEqualTo("myDefaultDestination");
+	}
+
+	@Test
+	public void parseInternal_withCustomRegion_shouldConfigureDefaultClientWithCustomRegion() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region.xml", getClass()));
+
+		// Assert
+		AmazonSNSClient amazonSns = registry.getBean(AmazonSNSClient.class);
+		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sns"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegionProvider_shouldConfigureDefaultClientWithCustomRegionReturnedByProvider()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
+
+		// Assert
+		AmazonSNSClient amazonSns = registry.getBean(AmazonSNSClient.class);
+		assertThat(ReflectionTestUtils.getField(amazonSns, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.CN_NORTH_1).getServiceEndpoint("sns"));
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import java.util.List;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.context.config.xml.GlobalBeanDefinitionUtils;
+import org.springframework.cloud.aws.messaging.core.QueueMessagingTemplate;
+import org.springframework.cloud.aws.messaging.support.converter.ObjectMessageConverter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Alain Sahli
+ */
+public class QueueMessagingTemplateBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_withMinimalConfig_shouldProduceAQueueMessagingTemplateWithDefaults() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-minimal.xml", getClass()));
+
+		// Assert
+		QueueMessagingTemplate queueMessagingTemplate = registry.getBean(QueueMessagingTemplate.class);
+		assertThat(ReflectionTestUtils.getField(queueMessagingTemplate, "amazonSqs"))
+				.isSameAs(registry.getBean(AmazonSQSAsync.class));
+		Object cachingDestinationResolverProxy = ReflectionTestUtils.getField(queueMessagingTemplate,
+				"destinationResolver");
+		Object targetDestinationResolver = ReflectionTestUtils.getField(cachingDestinationResolverProxy,
+				"targetDestinationResolver");
+		assertThat(ReflectionTestUtils.getField(targetDestinationResolver, "resourceIdResolver"))
+				.isEqualTo(registry.getBean(GlobalBeanDefinitionUtils.RESOURCE_ID_RESOLVER_BEAN_NAME));
+		assertThat(CompositeMessageConverter.class.isInstance(queueMessagingTemplate.getMessageConverter())).isTrue();
+
+		assertThat(CompositeMessageConverter.class.isInstance(queueMessagingTemplate.getMessageConverter())).isTrue();
+		@SuppressWarnings("unchecked")
+		List<MessageConverter> messageConverters = (List<MessageConverter>) ReflectionTestUtils
+				.getField(queueMessagingTemplate.getMessageConverter(), "converters");
+		assertThat(messageConverters.size()).isEqualTo(2);
+		assertThat(StringMessageConverter.class.isInstance(messageConverters.get(0))).isTrue();
+		assertThat(MappingJackson2MessageConverter.class.isInstance(messageConverters.get(1))).isTrue();
+
+		StringMessageConverter stringMessageConverter = (StringMessageConverter) messageConverters.get(0);
+		assertThat(stringMessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(stringMessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+
+		MappingJackson2MessageConverter jackson2MessageConverter = (MappingJackson2MessageConverter) messageConverters
+				.get(1);
+		assertThat(jackson2MessageConverter.getSerializedPayloadClass()).isSameAs(String.class);
+		assertThat(ReflectionTestUtils.getField(jackson2MessageConverter, "strictContentTypeMatch")).isEqualTo(false);
+	}
+
+	@Test
+	public void parseInternal_withCustomAmazonSqsClient_shouldPassItAsConstructorArg() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-amazon-sqs.xml", getClass()));
+
+		// Assert
+		BeanDefinition queueMessagingTemplateBeanDefinition = registry.getBeanDefinition("queueMessagingTemplate");
+		assertThat(((RuntimeBeanReference) queueMessagingTemplateBeanDefinition.getConstructorArgumentValues()
+				.getArgumentValue(0, RuntimeBeanReference.class).getValue()).getBeanName()).isEqualTo("myClient");
+	}
+
+	@Test
+	public void parseInternal_withCustomConverter_mustBeSetOnTemplate() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-converter.xml", getClass()));
+
+		// Assert
+		QueueMessagingTemplate queueMessagingTemplateBeanDefinition = registry.getBean(QueueMessagingTemplate.class);
+		MessageConverter messageConverter = queueMessagingTemplateBeanDefinition.getMessageConverter();
+		assertThat(CompositeMessageConverter.class.isInstance(messageConverter)).isTrue();
+		CompositeMessageConverter compositeMessageConverter = (CompositeMessageConverter) messageConverter;
+		assertThat(compositeMessageConverter.getConverters().size()).isEqualTo(2);
+		assertThat(ObjectMessageConverter.class.isInstance(compositeMessageConverter.getConverters().get(1))).isTrue();
+	}
+
+	@Test
+	public void parseInternal_withDefaultDestination_mustBeSetOnTemplate() throws Exception {
+		// Arrange
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-with-default-destination.xml", getClass()));
+
+		// Assert
+		BeanDefinition queueMessagingTemplateBeanDefinition = registry.getBeanDefinition("queueMessagingTemplate");
+		assertThat(queueMessagingTemplateBeanDefinition.getPropertyValues().getPropertyValue("defaultDestinationName")
+				.getValue()).isEqualTo("myDefaultDestination");
+	}
+
+	@Test
+	public void parseInternal_withCustomRegion_shouldConfigureDefaultClientWithCustomRegion() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSqs = registry.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSqs, "realSQS");
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.SA_EAST_1).getServiceEndpoint("sqs"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegionProvider_shouldConfigureDefaultClientWithCustomRegionReturnedByProvider()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSqs = registry.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSqs, "realSQS");
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.AP_SOUTHEAST_2).getServiceEndpoint("sqs"));
+	}
+
+	@Test
+	public void parseInternal_withMultipleMessagingTemplatesDefined_shouldConfigureOnlyOneSqsClientAndDecorateOnlyOnce()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-multiple-templates.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSqs = registry.getBean(AmazonSQSBufferedAsyncClient.class);
+		assertThat(ReflectionTestUtils.getField(amazonSqs, "realSQS") instanceof AmazonSQSAsyncClient).isTrue();
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
+++ b/spring-cloud-aws-messaging/src/test/java/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.messaging.config.xml;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.cloud.aws.core.task.ShutdownSuppressingExecutorServiceAdapter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SqsAsyncClientBeanDefinitionParserTest {
+
+	@Test
+	public void parseInternal_minimalConfiguration_createsBufferedClientWithoutExplicitTaskExecutor() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-minimal.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient sqsBufferedAsyncClient = beanFactory.getBean("customClient",
+				AmazonSQSBufferedAsyncClient.class);
+		AmazonSQSAsyncClient asyncClient = (AmazonSQSAsyncClient) ReflectionTestUtils.getField(sqsBufferedAsyncClient,
+				"realSQS");
+		assertThat(asyncClient).isNotNull();
+		ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) ReflectionTestUtils.getField(asyncClient,
+				"executorService");
+		assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(50);
+	}
+
+	@Test
+	public void parseInternal_notBuffered_createsAsyncClientWithoutBufferedDecorator() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-not-buffered.xml", getClass()));
+
+		// Assert
+		AmazonSQSAsyncClient asyncClient = beanFactory.getBean("customClient", AmazonSQSAsyncClient.class);
+		assertThat(asyncClient).isNotNull();
+		assertThat(AmazonSQSAsyncClient.class.isInstance(asyncClient)).isTrue();
+	}
+
+	@Test
+	public void parseInternal_withCustomTasExecutor_createsBufferedClientWithCustomTaskExecutor() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-task-executor.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient sqsBufferedAsyncClient = beanFactory.getBean("customClient",
+				AmazonSQSBufferedAsyncClient.class);
+		AmazonSQSAsyncClient asyncClient = (AmazonSQSAsyncClient) ReflectionTestUtils.getField(sqsBufferedAsyncClient,
+				"realSQS");
+		assertThat(asyncClient).isNotNull();
+		ShutdownSuppressingExecutorServiceAdapter executor = (ShutdownSuppressingExecutorServiceAdapter) ReflectionTestUtils
+				.getField(asyncClient, "executorService");
+		assertThat(ReflectionTestUtils.getField(executor, "taskExecutor"))
+				.isSameAs(beanFactory.getBean("myThreadPoolTaskExecutor"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegion_shouldConfigureDefaultClientWithCustomRegion() throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSqs = registry.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSqs, "realSQS");
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.EU_WEST_1).getServiceEndpoint("sqs"));
+	}
+
+	@Test
+	public void parseInternal_withCustomRegionProvider_shouldConfigureDefaultClientWithCustomRegionReturnedByProvider()
+			throws Exception {
+		// Arrange
+		DefaultListableBeanFactory registry = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(registry);
+
+		// Act
+		reader.loadBeanDefinitions(
+				new ClassPathResource(getClass().getSimpleName() + "-custom-region-provider.xml", getClass()));
+
+		// Assert
+		AmazonSQSBufferedAsyncClient amazonSqs = registry.getBean(AmazonSQSBufferedAsyncClient.class);
+		Object amazonSqsAsyncClient = ReflectionTestUtils.getField(amazonSqs, "realSQS");
+		assertThat(ReflectionTestUtils.getField(amazonSqsAsyncClient, "endpoint").toString())
+				.isEqualTo("https://" + Region.getRegion(Regions.AP_SOUTHEAST_2).getServiceEndpoint("sqs"));
+	}
+
+}

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-back-off-time.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener back-off-time="5000"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-context-region.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-context:context-region region="ap-southeast-1"/>
+
+	<aws-messaging:annotation-driven-queue-listener/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<bean id="myClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient"/>
+
+	<aws-messaging:annotation-driven-queue-listener amazon-sqs="myClient"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-argument-resolvers.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+
+	<aws-messaging:annotation-driven-queue-listener>
+		<aws-messaging:argument-resolvers>
+			<bean
+				class="org.springframework.cloud.aws.messaging.config.xml.AnnotationDrivenQueueListenerBeanDefinitionParserTest$TestHandlerMethodArgumentResolver"/>
+		</aws-messaging:argument-resolvers>
+	</aws-messaging:annotation-driven-queue-listener>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-destination-resolver.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener
+		destination-resolver="destinationResolver"/>
+
+	<bean id="destinationResolver" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.messaging.core.DestinationResolver"/>
+	</bean>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-properties.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener auto-startup="false"
+													max-number-of-messages="9"
+													visibility-timeout="6"
+													wait-time-out="3"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region-provider.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<bean id="provider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="ap-southeast-2"/>
+	</bean>
+
+	<aws-messaging:annotation-driven-queue-listener region-provider="provider"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-region.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener region="eu-west-1"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-return-value-handlers.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+
+	<aws-messaging:annotation-driven-queue-listener>
+		<aws-messaging:return-value-handlers>
+			<bean
+				class="org.springframework.cloud.aws.messaging.config.xml.AnnotationDrivenQueueListenerBeanDefinitionParserTest$TestHandlerMethodReturnValueHandler"/>
+		</aws-messaging:return-value-handlers>
+	</aws-messaging:annotation-driven-queue-listener>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-custom-task-executor.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<bean id="executor" class="org.springframework.core.task.SimpleAsyncTaskExecutor"/>
+
+	<aws-messaging:annotation-driven-queue-listener task-executor="executor"/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener/>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/AnnotationDrivenQueueListenerBeanDefinitionParserTest-with-send-to-message-template.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd">
+
+	<aws-messaging:annotation-driven-queue-listener
+		send-to-message-template="messageTemplate"/>
+
+	<bean id="messageTemplate" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg
+			value="org.springframework.messaging.core.MessageSendingOperations"/>
+	</bean>
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/MessagingSchemaWithoutSchemaTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											region="sa-east-1"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegion.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-argument-resolver id="notificationArgumentResolver"
+												  region="eu-west-1"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customRegionProvider.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-argument-resolver id="notificationArgumentResolver"
+												  region-provider="myRegionProvider"/>
+
+	<bean id="myRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="us-west-2"/>
+	</bean>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-customSnsClient.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-argument-resolver id="notificationArgumentResolver"
+												  amazon-sns="customSnsClient"/>
+
+	<bean id="customSnsClient" class="com.amazonaws.services.sns.AmazonSNSClient"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationArgumentResolverBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-argument-resolver id="notificationArgumentResolver"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-amazon-sns.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="mySnsClient" class="com.amazonaws.services.sns.AmazonSNSAsyncClient"/>
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"
+												   amazon-sns="mySnsClient"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="customRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="cn-north-1"/>
+	</bean>
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"
+												   region-provider="customRegionProvider"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"
+												   region="eu-west-1"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/NotificationMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:notification-messaging-template id="notificationMessagingTemplate"
+												   default-destination="myDefaultDestination"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-amazon-sqs.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myClient" class="com.amazonaws.services.sqs.AmazonSQSAsyncClient"/>
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											amazon-sqs="myClient"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-converter.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myCustomConverter"
+		  class="org.springframework.cloud.aws.messaging.support.converter.ObjectMessageConverter"/>
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											message-converter="myCustomConverter"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region-provider.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myCustomRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="ap-southeast-2"/>
+	</bean>
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											region-provider="myCustomRegionProvider"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-custom-region.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											region="sa-east-1"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-multiple-templates.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"/>
+
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate2"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/QueueMessagingTemplateBeanDefinitionParserTest-with-default-destination.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myCustomConverter"
+		  class="org.springframework.cloud.aws.messaging.support.converter.ObjectMessageConverter"/>
+	<aws-messaging:queue-messaging-template id="queueMessagingTemplate"
+											default-destination="myDefaultDestination"/>
+
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region-provider.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<bean id="myCustomRegionProvider"
+		  class="org.springframework.cloud.aws.core.region.StaticRegionProvider">
+		<constructor-arg value="ap-southeast-2"/>
+	</bean>
+	<aws-messaging:sqs-async-client id="customClient"
+									region-provider="myCustomRegionProvider"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-region.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:sqs-async-client id="customClient" region="eu-west-1"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-custom-task-executor.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd
+	   					   http://www.springframework.org/schema/task
+	   					   https://www.springframework.org/schema/task/spring-task.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<task:executor id="myThreadPoolTaskExecutor" pool-size="20" queue-capacity="0"
+				   keep-alive="0"
+				   rejection-policy="CALLER_RUNS"/>
+
+	<aws-messaging:sqs-async-client id="customClient"
+									task-executor="myThreadPoolTaskExecutor"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-minimal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:sqs-async-client id="customClient"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/config/xml/SqsAsyncClientBeanDefinitionParserTest-not-buffered.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/context
+	   					   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+
+	<aws-context:context-credentials>
+		<aws-context:instance-profile-credentials/>
+	</aws-context:context-credentials>
+
+	<aws-messaging:sqs-async-client id="customClient" buffered="false"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/ComplexNotificationEndpointControllerTest-context.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:mvc="http://www.springframework.org/schema/mvc"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/mvc
+	   					   https://www.springframework.org/schema/mvc/spring-mvc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<mvc:annotation-driven>
+		<mvc:argument-resolvers>
+			<ref bean="notificationResolver"/>
+		</mvc:argument-resolvers>
+	</mvc:annotation-driven>
+
+	<aws-messaging:notification-argument-resolver id="notificationResolver"
+												  amazon-sns="amazonSns"/>
+
+	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>
+	</bean>
+
+	<bean
+		class="org.springframework.cloud.aws.messaging.endpoint.ComplexNotificationTestController"/>
+</beans>

--- a/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
+++ b/spring-cloud-aws-messaging/src/test/resources/org/springframework/cloud/aws/messaging/endpoint/NotificationEndpointControllerTest-context.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
+	   xmlns:mvc="http://www.springframework.org/schema/mvc"
+	   xmlns="http://www.springframework.org/schema/beans"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   					   https://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+	   					   http://www.springframework.org/schema/cloud/aws/messaging
+	   					   http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+
+	<mvc:annotation-driven>
+		<mvc:argument-resolvers>
+			<ref bean="notificationResolver"/>
+		</mvc:argument-resolvers>
+	</mvc:annotation-driven>
+
+	<aws-messaging:notification-argument-resolver id="notificationResolver"
+												  amazon-sns="amazonSns"/>
+
+	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>
+	</bean>
+
+	<bean
+		class="org.springframework.cloud.aws.messaging.endpoint.NotificationTestController"/>
+</beans>


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Bring back XML configuration and deprecate all related classes.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

XML support is planned to be removed but we should not remove it without deprecating it first. This PR brings back XML support and deprecates all classes.


## :green_heart: How did you test it?

Run unit & integration tests against real AWS environment.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Drop XML support in 3.0.