### PR TITLE
Add issue triager action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+**Type**: Bug
+
+**Component**:
+<!-- Choose "CloudWatch", "ElastiCache", "Parameter Store", "RDS", "S3", "Secrets Manager", "SES", "SNS", "SQS" -->
+
 **Describe the bug**
 Please provide details of the problem, including the version of Spring Cloud that you
 are using. 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+**Type**: Feature
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/triage-rules.yml
+++ b/.github/triage-rules.yml
@@ -1,0 +1,36 @@
+rules:
+
+- valueFor: '**Component**'
+  contains: 'CloudWatch'
+  addLabels: ['component: cloudwatch']
+- valueFor: '**Component**'
+  contains: 'ElastiCache'
+  addLabels: ['component: elasticache']
+- valueFor: '**Component**'
+  contains: 'Parameter Store'
+  addLabels: ['component: parameter-store']
+- valueFor: '**Component**'
+  contains: 'RDS'
+  addLabels: ['component: rds']
+- valueFor: '**Component**'
+  contains: 'S3'
+  addLabels: ['component: s3']
+- valueFor: '**Component**'
+  contains: 'Secrets Manager'
+  addLabels: ['component: secrets-manager']
+- valueFor: '**Component**'
+  contains: 'SES'
+  addLabels: ['component: ses']
+- valueFor: '**Component**'
+  contains: 'SNS'
+  addLabels: ['component: sns']
+- valueFor: '**Component**'
+  contains: 'SQS'
+  addLabels: ['component: sqs']
+
+- valueFor: '**Type**'
+  contains: Feature
+  addLabels: ['type: enhancement']
+- valueFor: '**Type**'
+  contains: Bug
+  addLabels: ['type: bug']

--- a/.github/workflows/issue-triager.yml
+++ b/.github/workflows/issue-triager.yml
@@ -1,0 +1,29 @@
+name: Issue triager
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: damccorm/tag-ur-it@master
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: "./.github/triage-rules.yml"
+
+      - if: always()
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['status: waiting-for-triage']
+            })


### PR DESCRIPTION
Update the issue templates in order to get the info and allow the
action to triage issues automatically. Also, by default label
`status: waiting-for-triage` in order to let the owners know
that is pending from their side.
