### PR TITLE
Determine 'content-type' from S3 location

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.aws.core.io.s3;
 
+import java.net.URLConnection;
+
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Utility class that provides utility method to work with s3 storage resources.
@@ -95,6 +98,14 @@ final class SimpleStorageNameUtils {
 		}
 
 		return location.substring(++objectNameEndIndex, location.length());
+	}
+
+	static String getContentTypeFromLocation(String location) {
+		String objectName = getObjectNameFromLocation(location);
+		if (!StringUtils.isEmpty(objectName)) {
+			return URLConnection.guessContentTypeFromName(objectName);
+		}
+		return null;
 	}
 
 	static String getLocationForBucketAndObject(String bucketName, String objectName) {

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
@@ -76,7 +76,8 @@ public class SimpleStorageProtocolResolver implements ProtocolResolver, Initiali
 			return new SimpleStorageResource(this.getAmazonS3(),
 					SimpleStorageNameUtils.getBucketNameFromLocation(location),
 					SimpleStorageNameUtils.getObjectNameFromLocation(location), this.taskExecutor,
-					SimpleStorageNameUtils.getVersionIdFromLocation(location));
+					SimpleStorageNameUtils.getVersionIdFromLocation(location),
+					SimpleStorageNameUtils.getContentTypeFromLocation(location));
 		}
 		else {
 			return null;

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -76,6 +76,8 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 
 	private final String versionId;
 
+	private final String contentType;
+
 	private final AmazonS3 amazonS3;
 
 	private final TaskExecutor taskExecutor;
@@ -83,16 +85,17 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 	private volatile ObjectMetadata objectMetadata;
 
 	public SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor) {
-		this(amazonS3, bucketName, objectName, taskExecutor, null);
+		this(amazonS3, bucketName, objectName, taskExecutor, null, null);
 	}
 
 	public SimpleStorageResource(AmazonS3 amazonS3, String bucketName, String objectName, TaskExecutor taskExecutor,
-			String versionId) {
+			String versionId, String contentType) {
 		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 		this.bucketName = bucketName;
 		this.objectName = objectName;
 		this.taskExecutor = taskExecutor;
 		this.versionId = versionId;
+		this.contentType = contentType;
 	}
 
 	@Override
@@ -286,6 +289,9 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 				MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 				String md5Digest = BinaryUtils.toBase64(messageDigest.digest(content));
 				objectMetadata.setContentMD5(md5Digest);
+				if (SimpleStorageResource.this.contentType != null) {
+					objectMetadata.setContentType(SimpleStorageResource.this.contentType);
+				}
 			}
 			catch (NoSuchAlgorithmException e) {
 				throw new IllegalStateException(
@@ -325,9 +331,15 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 
 		private void initiateMultiPartIfNeeded() {
 			if (this.multiPartUploadResult == null) {
+
+				ObjectMetadata md = new ObjectMetadata();
+				if (SimpleStorageResource.this.contentType != null) {
+					md.setContentType(SimpleStorageResource.this.contentType);
+				}
+
 				this.multiPartUploadResult = SimpleStorageResource.this.amazonS3.initiateMultipartUpload(
 						new InitiateMultipartUploadRequest(SimpleStorageResource.this.bucketName,
-								SimpleStorageResource.this.objectName));
+								SimpleStorageResource.this.objectName, md));
 			}
 		}
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -332,14 +332,14 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 		private void initiateMultiPartIfNeeded() {
 			if (this.multiPartUploadResult == null) {
 
-				ObjectMetadata md = new ObjectMetadata();
+				ObjectMetadata metadata = new ObjectMetadata();
 				if (SimpleStorageResource.this.contentType != null) {
-					md.setContentType(SimpleStorageResource.this.contentType);
+					metadata.setContentType(SimpleStorageResource.this.contentType);
 				}
 
 				this.multiPartUploadResult = SimpleStorageResource.this.amazonS3.initiateMultipartUpload(
 						new InitiateMultipartUploadRequest(SimpleStorageResource.this.bucketName,
-								SimpleStorageResource.this.objectName, md));
+								SimpleStorageResource.this.objectName, metadata));
 			}
 		}
 

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtilsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getBucketNameFromLocation;
+import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getContentTypeFromLocation;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObject;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getLocationForBucketAndObjectAndVersionId;
 import static org.springframework.cloud.aws.core.io.s3.SimpleStorageNameUtils.getObjectNameFromLocation;
@@ -106,6 +107,14 @@ class SimpleStorageNameUtilsTest {
 	void testGetVersionIdFromLocation() throws Exception {
 		assertThat(getVersionIdFromLocation("s3://foo/bar^versionIdValue")).isEqualTo("versionIdValue");
 		assertThat(getVersionIdFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue")).isEqualTo("versionIdValue");
+	}
+
+	@Test
+	public void testGetContentTypeFromLocation() {
+		assertThat(getContentTypeFromLocation("s3://foo/bar")).isEqualTo(null);
+		assertThat(getContentTypeFromLocation("s3://foo/bar^versionIdValue")).isEqualTo(null);
+		assertThat(getContentTypeFromLocation("s3://foo/bar/baz/boo.txt")).isEqualTo("text/plain");
+		assertThat(getContentTypeFromLocation("s3://foo/bar/ba*/boo.txt/^versionIdValue")).isEqualTo("text/plain");
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -272,7 +272,6 @@ class SimpleStorageResourceTest {
 					byte[] content = new byte[messageContext.length()];
 					assertThat(((InputStream) invocation.getArguments()[2]).read(content)).isEqualTo(content.length);
 					assertThat(new String(content)).isEqualTo(messageContext);
-					return new PutObjectResult();
 					assertThat(((ObjectMetadata) invocation.getArgument(3)).getContentType()).isEqualTo(null);
 					return new PutObjectResult();
 				});

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -37,6 +37,7 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.Region;
 import com.amazonaws.services.s3.model.S3Object;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
 import org.springframework.core.task.SyncTaskExecutor;
@@ -45,8 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Agim Emruli
@@ -266,15 +266,7 @@ class SimpleStorageResourceTest {
 				new SyncTaskExecutor());
 		String messageContext = "myFileContent";
 		when(amazonS3.putObject(eq("bucketName"), eq("objectName"), any(InputStream.class), any(ObjectMetadata.class)))
-				.thenAnswer((Answer<PutObjectResult>) invocation -> {
-					assertThat(invocation.getArguments()[0]).isEqualTo("bucketName");
-					assertThat(invocation.getArguments()[1]).isEqualTo("objectName");
-					byte[] content = new byte[messageContext.length()];
-					assertThat(((InputStream) invocation.getArguments()[2]).read(content)).isEqualTo(content.length);
-					assertThat(new String(content)).isEqualTo(messageContext);
-					assertThat(((ObjectMetadata) invocation.getArgument(3)).getContentType()).isEqualTo(null);
-					return new PutObjectResult();
-				});
+				.thenReturn(new PutObjectResult());
 		OutputStream outputStream = simpleStorageResource.getOutputStream();
 
 		// Act
@@ -283,6 +275,14 @@ class SimpleStorageResourceTest {
 		outputStream.close();
 
 		// Assert
+		ArgumentCaptor<InputStream> inputStreamArgumentCaptor = ArgumentCaptor.forClass(InputStream.class);
+		ArgumentCaptor<ObjectMetadata> objectMetadataArgumentCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+		verify(amazonS3).putObject(eq("bucketName"), eq("objectName"), inputStreamArgumentCaptor.capture(),
+				objectMetadataArgumentCaptor.capture());
+		byte[] content = new byte[messageContext.length()];
+		assertThat(inputStreamArgumentCaptor.getValue().read(content)).isEqualTo(content.length);
+		assertThat(new String(content)).isEqualTo(messageContext);
+		assertThat(objectMetadataArgumentCaptor.getValue().getContentType()).isNull();
 	}
 
 	@Test
@@ -293,15 +293,7 @@ class SimpleStorageResourceTest {
 				new SyncTaskExecutor(), null, "text/plain");
 		String messageContext = "myFileContent";
 		when(amazonS3.putObject(eq("bucketName"), eq("objectName"), any(InputStream.class), any(ObjectMetadata.class)))
-				.thenAnswer((Answer<PutObjectResult>) invocation -> {
-					assertThat(invocation.getArguments()[0]).isEqualTo("bucketName");
-					assertThat(invocation.getArguments()[1]).isEqualTo("objectName");
-					byte[] content = new byte[messageContext.length()];
-					assertThat(((InputStream) invocation.getArguments()[2]).read(content)).isEqualTo(content.length);
-					assertThat(new String(content)).isEqualTo(messageContext);
-					assertThat(((ObjectMetadata) invocation.getArgument(3)).getContentType()).isEqualTo("text/plain");
-					return new PutObjectResult();
-				});
+				.thenReturn(new PutObjectResult());
 		OutputStream outputStream = simpleStorageResource.getOutputStream();
 
 		// Act
@@ -310,6 +302,11 @@ class SimpleStorageResourceTest {
 		outputStream.close();
 
 		// Assert
+
+		ArgumentCaptor<ObjectMetadata> objectMetadataArgumentCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+		verify(amazonS3).putObject(eq("bucketName"), eq("objectName"), any(InputStream.class),
+				objectMetadataArgumentCaptor.capture());
+		assertThat(objectMetadataArgumentCaptor.getValue().getContentType()).isEqualTo("text/plain");
 	}
 
 	@Test

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -24,11 +24,14 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.Date;
+import java.util.Random;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.Region;
@@ -270,6 +273,8 @@ class SimpleStorageResourceTest {
 					assertThat(((InputStream) invocation.getArguments()[2]).read(content)).isEqualTo(content.length);
 					assertThat(new String(content)).isEqualTo(messageContext);
 					return new PutObjectResult();
+					assertThat(((ObjectMetadata) invocation.getArgument(3)).getContentType()).isEqualTo(null);
+					return new PutObjectResult();
 				});
 		OutputStream outputStream = simpleStorageResource.getOutputStream();
 
@@ -277,6 +282,62 @@ class SimpleStorageResourceTest {
 		outputStream.write(messageContext.getBytes());
 		outputStream.flush();
 		outputStream.close();
+
+		// Assert
+	}
+
+	@Test
+	public void writeFile_simpleUpload_setsContentType() throws Exception {
+		// Arrange
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucketName", "objectName",
+				new SyncTaskExecutor(), null, "text/plain");
+		String messageContext = "myFileContent";
+		when(amazonS3.putObject(eq("bucketName"), eq("objectName"), any(InputStream.class), any(ObjectMetadata.class)))
+				.thenAnswer((Answer<PutObjectResult>) invocation -> {
+					assertThat(invocation.getArguments()[0]).isEqualTo("bucketName");
+					assertThat(invocation.getArguments()[1]).isEqualTo("objectName");
+					byte[] content = new byte[messageContext.length()];
+					assertThat(((InputStream) invocation.getArguments()[2]).read(content)).isEqualTo(content.length);
+					assertThat(new String(content)).isEqualTo(messageContext);
+					assertThat(((ObjectMetadata) invocation.getArgument(3)).getContentType()).isEqualTo("text/plain");
+					return new PutObjectResult();
+				});
+		OutputStream outputStream = simpleStorageResource.getOutputStream();
+
+		// Act
+		outputStream.write(messageContext.getBytes());
+		outputStream.flush();
+		outputStream.close();
+
+		// Assert
+	}
+
+	@Test
+	public void writeFile_multipartUpload_setsContentType() throws Exception {
+		// Arrange
+		AmazonS3 amazonS3 = mock(AmazonS3.class);
+		SimpleStorageResource simpleStorageResource = new SimpleStorageResource(amazonS3, "bucketName", "objectName",
+				new SyncTaskExecutor(), null, "text/plain");
+
+		byte[] messageContext = new byte[(1024 * 1024 * 5) + 1];
+		new Random().nextBytes(messageContext);
+
+		when(amazonS3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+				.thenAnswer((Answer<InitiateMultipartUploadResult>) invocation -> {
+					assertThat(((InitiateMultipartUploadRequest) invocation.getArguments()[0]).getBucketName())
+							.isEqualTo("bucketName");
+					assertThat(((InitiateMultipartUploadRequest) invocation.getArguments()[0]).getKey())
+							.isEqualTo("objectName");
+					assertThat(((InitiateMultipartUploadRequest) invocation.getArguments()[0]).getObjectMetadata()
+							.getContentType()).isEqualTo("text/plain");
+					return new InitiateMultipartUploadResult();
+				});
+		OutputStream outputStream = simpleStorageResource.getOutputStream();
+
+		// Act
+		outputStream.write(messageContext);
+		outputStream.flush();
 
 		// Assert
 	}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Sets content type to files uploaded to S3.

Fixes gh-262
Closes gh-419


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#419 rebased against 2.3.x

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes