### PR TITLE
fix issue #686

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResource.java
@@ -38,9 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 
-import com.amazonaws.regions.Region;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
@@ -140,10 +138,8 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 
 	@Override
 	public URL getURL() throws IOException {
-		Region region = this.amazonS3.getRegion().toAWSRegion();
 		String encodedObjectName = URLEncoder.encode(this.objectName, StandardCharsets.UTF_8.toString());
-		return new URL("https", region.getServiceEndpoint(AmazonS3Client.S3_SERVICE_NAME),
-				"/" + this.bucketName + "/" + encodedObjectName);
+		return new URL("https", this.bucketName + ".s3.amazonaws.com", "/" + encodedObjectName);
 	}
 
 	public URI getS3Uri() {

--- a/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
+++ b/spring-cloud-aws-core/src/test/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageResourceTest.java
@@ -205,7 +205,7 @@ class SimpleStorageResourceTest {
 
 		// Assert
 		assertThat(simpleStorageResource.getURL())
-				.isEqualTo(new URL("https://s3.eu-west-1.amazonaws.com/bucket/object"));
+				.isEqualTo(new URL("https://bucket.s3.amazonaws.com/object"));
 
 	}
 
@@ -289,7 +289,7 @@ class SimpleStorageResourceTest {
 				new SyncTaskExecutor());
 
 		assertThat(resource.getURI())
-				.isEqualTo(new URI("https://s3.us-west-2.amazonaws.com/bucketName/some%2F%5BobjectName%5D"));
+				.isEqualTo(new URI("https://bucketName.s3.amazonaws.com/some%2F%5BobjectName%5D"));
 	}
 
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
In short, SimpleStorageResource.getURL() should return https://bucketname.s3.amazonws.com/path (e.g. https://mybucket.example.com.s3.amazonws.com/path/file.txt) instead of https://s3.region.amazonws.com/bucketname/path.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue #686

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
