### PR TITLE
Add aws-secretsmanager: prefix config import

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -69,3 +69,19 @@ dots, dashes, forward slashes, backward slashes and underscores next to alphanum
 |`true`
 |Can be used to disable the Secrets Manager Configuration support even though the auto-configuration is on the classpath.
 |===
+
+In `spring-cloud` `2020.0.0` (aka Ilford), the bootstrap phase is no longer enabled by default. In order
+enable it you need an additional dependency:
+
+[source,xml,indent=0]
+----
+<dependency>
+  <groupId>org.springframework.cloud</groupId>
+  <artifactId>spring-cloud-starter-bootstrap</artifactId>
+  <version>{spring-cloud-version}</version>
+</dependency>
+----
+
+However, starting at `spring-cloud-aws` `2.3`, allows import default aws' secretsmanager keys
+(`spring.config.import=aws-secretsmanager:`) or individual keys
+(`spring.config.import=aws-secretsmanager:secret-key;other-secret-key`)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/><!-- lookup parent from repository -->
 	</parent>
 
@@ -48,7 +48,7 @@
 		<javax-mail.version>1.5.5</javax-mail.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<javax.activation.version>1.2.0</javax.activation.version>
-		<spring-cloud-commons.version>3.0.0-M4</spring-cloud-commons.version>
+		<spring-cloud-commons.version>3.0.0-SNAPSHOT</spring-cloud-commons.version>
 		<spring-javaformat.version>0.0.25</spring-javaformat.version>
 	</properties>
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>2.3.2.BUILD-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-aws-dependencies</artifactId>

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -69,7 +69,9 @@ public class AwsSecretsManagerPropertySources {
 	public AwsSecretsManagerPropertySource createPropertySource(String context, boolean optional,
 			AWSSecretsManager client) {
 		try {
-			return new AwsSecretsManagerPropertySource(context, client);
+			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(context, client);
+			propertySource.init();
+			return propertySource;
 			// TODO: howto call close when /refresh
 		}
 		catch (Exception e) {

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import org.apache.commons.logging.Log;
+
+import org.springframework.util.StringUtils;
+
+public class AwsSecretsManagerPropertySources {
+
+	private final AwsSecretsManagerProperties properties;
+
+	private final Log log;
+
+	public AwsSecretsManagerPropertySources(AwsSecretsManagerProperties properties, Log log) {
+		this.properties = properties;
+		this.log = log;
+	}
+
+	public List<String> getAutomaticContexts(List<String> profiles) {
+		List<String> contexts = new ArrayList<>();
+		String prefix = this.properties.getPrefix();
+		String defaultContext = getContext(prefix, this.properties.getDefaultContext());
+
+		String appName = this.properties.getName();
+
+		String appContext = prefix + "/" + appName;
+		addProfiles(contexts, appContext, profiles);
+		contexts.add(appContext);
+
+		addProfiles(contexts, defaultContext, profiles);
+		contexts.add(defaultContext);
+		return contexts;
+	}
+
+	protected String getContext(String prefix, String context) {
+		if (StringUtils.isEmpty(prefix)) {
+			return context;
+		}
+		else {
+			return prefix + "/" + context;
+		}
+	}
+
+	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+		}
+	}
+
+	public AwsSecretsManagerPropertySource createPropertySource(String context, boolean optional,
+			AWSSecretsManager client) {
+		try {
+			return new AwsSecretsManagerPropertySource(context, client);
+			// TODO: howto call close when /refresh
+		}
+		catch (Exception e) {
+			if (this.properties.isFailFast() || !optional) {
+				throw new AwsSecretsManagerPropertySourceNotFoundException(e);
+			}
+			else {
+				log.warn("Unable to load AWS secret from " + context, e);
+			}
+		}
+		return null;
+	}
+
+	static class AwsSecretsManagerPropertySourceNotFoundException extends RuntimeException {
+
+		AwsSecretsManagerPropertySourceNotFoundException(Exception source) {
+			super(source);
+		}
+
+	}
+
+}

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerPropertySources.java
@@ -52,12 +52,10 @@ public class AwsSecretsManagerPropertySources {
 	}
 
 	protected String getContext(String prefix, String context) {
-		if (StringUtils.isEmpty(prefix)) {
-			return context;
-		}
-		else {
+		if (StringUtils.hasLength(prefix)) {
 			return prefix + "/" + context;
 		}
+		return context;
 	}
 
 	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {

--- a/spring-cloud-starter-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager-config/pom.xml
@@ -45,6 +45,10 @@
 			<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>

--- a/spring-cloud-starter-aws-secrets-manager-config/pom.xml
+++ b/spring-cloud-starter-aws-secrets-manager-config/pom.xml
@@ -45,10 +45,6 @@
 			<artifactId>spring-cloud-aws-secrets-manager-config</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-aws-core</artifactId>
 		</dependency>

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerProperties;
 import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySourceLocator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 /**
  * Spring Cloud Bootstrap Configuration for setting up an
@@ -46,9 +47,18 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = AwsSecretsManagerProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
 public class AwsSecretsManagerBootstrapConfiguration {
 
+	private final Environment environment;
+
+	public AwsSecretsManagerBootstrapConfiguration(Environment environment) {
+		this.environment = environment;
+	}
+
 	@Bean
 	AwsSecretsManagerPropertySourceLocator awsSecretsManagerPropertySourceLocator(AWSSecretsManager smClient,
 			AwsSecretsManagerProperties properties) {
+		if (StringUtils.isNullOrEmpty(properties.getName())) {
+			properties.setName(this.environment.getProperty("spring.application.name"));
+		}
 		return new AwsSecretsManagerPropertySourceLocator(smClient, properties);
 	}
 

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerBootstrapConfiguration.java
@@ -55,6 +55,10 @@ public class AwsSecretsManagerBootstrapConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	AWSSecretsManager smClient(AwsSecretsManagerProperties properties) {
+		return createSecretsManagerClient(properties);
+	}
+
+	public static AWSSecretsManager createSecretsManagerClient(AwsSecretsManagerProperties properties) {
 		AWSSecretsManagerClientBuilder builder = AWSSecretsManagerClientBuilder.standard()
 				.withClientConfiguration(SpringCloudClientConfiguration.getClientConfiguration());
 		if (!StringUtils.isNullOrEmpty(properties.getRegion())) {

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
@@ -36,9 +36,8 @@ public class AwsSecretsManagerConfigDataLoader implements ConfigDataLoader<AwsSe
 	public ConfigData load(ConfigDataLoaderContext context, AwsSecretsManagerConfigDataResource resource) {
 		try {
 			AWSSecretsManager ssm = context.getBootstrapContext().get(AWSSecretsManager.class);
-			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(resource.getContext(),
-					ssm);
-			propertySource.init();
+			AwsSecretsManagerPropertySource propertySource = resource.getPropertySources()
+					.createPropertySource(resource.getContext(), resource.isOptional(), ssm);
 			return new ConfigData(Collections.singletonList(propertySource));
 		}
 		catch (Exception e) {

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
@@ -38,6 +38,7 @@ public class AwsSecretsManagerConfigDataLoader implements ConfigDataLoader<AwsSe
 			AWSSecretsManager ssm = context.getBootstrapContext().get(AWSSecretsManager.class);
 			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(resource.getContext(),
 					ssm);
+			propertySource.init();
 			return new ConfigData(Collections.singletonList(propertySource));
 		}
 		catch (Exception e) {

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import java.util.Collections;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigDataLoader;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySource;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsSecretsManagerConfigDataLoader implements ConfigDataLoader<AwsSecretsManagerConfigDataResource> {
+
+	@Override
+	public ConfigData load(ConfigDataLoaderContext context, AwsSecretsManagerConfigDataResource resource) {
+		try {
+			AWSSecretsManager ssm = context.getBootstrapContext().get(AWSSecretsManager.class);
+			AwsSecretsManagerPropertySource propertySource = new AwsSecretsManagerPropertySource(resource.getContext(),
+					ssm);
+			return new ConfigData(Collections.singletonList(propertySource));
+		}
+		catch (Exception e) {
+			throw new ConfigDataResourceNotFoundException(resource, e);
+		}
+	}
+
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
@@ -84,7 +84,7 @@ public class AwsSecretsManagerConfigDataLocationResolver
 				? sources.getAutomaticContexts(profiles.getAccepted())
 				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
 
-		ArrayList<AwsSecretsManagerConfigDataResource> locations = new ArrayList<>();
+		List<AwsSecretsManagerConfigDataResource> locations = new ArrayList<>();
 		contexts.forEach(propertySourceContext -> locations
 				.add(new AwsSecretsManagerConfigDataResource(propertySourceContext, location.isOptional())));
 

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
@@ -93,11 +93,10 @@ public class AwsSecretsManagerConfigDataLocationResolver
 	}
 
 	private List<String> getCustomContexts(String keys) {
-		if (StringUtils.isEmpty(keys)) {
-			return Collections.emptyList();
+		if (StringUtils.hasLength(keys)) {
+			return Arrays.asList(keys.split(";"));
 		}
-
-		return Arrays.asList(keys.split(";"));
+		return Collections.emptyList();
 	}
 
 	protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
@@ -129,7 +128,7 @@ public class AwsSecretsManagerConfigDataLocationResolver
 	protected AwsSecretsManagerProperties loadProperties(Binder binder) {
 		AwsSecretsManagerProperties awsSecretsManagerProperties = binder
 				.bind(AwsSecretsManagerProperties.CONFIG_PREFIX, Bindable.of(AwsSecretsManagerProperties.class))
-				.orElse(new AwsSecretsManagerProperties());
+				.orElseGet(AwsSecretsManagerProperties::new);
 
 		return awsSecretsManagerProperties;
 	}
@@ -137,9 +136,9 @@ public class AwsSecretsManagerConfigDataLocationResolver
 	protected AwsSecretsManagerProperties loadConfigProperties(Binder binder) {
 		AwsSecretsManagerProperties properties = binder
 				.bind(AwsSecretsManagerProperties.CONFIG_PREFIX, Bindable.of(AwsSecretsManagerProperties.class))
-				.orElse(new AwsSecretsManagerProperties());
+				.orElseGet(AwsSecretsManagerProperties::new);
 
-		if (StringUtils.isEmpty(properties.getName())) {
+		if (!StringUtils.hasLength(properties.getName())) {
 			properties.setName(binder.bind("spring.application.name", String.class).orElse("application"));
 		}
 

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
@@ -78,15 +78,16 @@ public class AwsSecretsManagerConfigDataLocationResolver
 
 		AwsSecretsManagerProperties properties = loadConfigProperties(resolverContext.getBinder());
 
-		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties, log);
+		AwsSecretsManagerPropertySources propertySources = new AwsSecretsManagerPropertySources(properties, log);
 
 		List<String> contexts = location.getValue().equals(PREFIX)
-				? sources.getAutomaticContexts(profiles.getAccepted())
+				? propertySources.getAutomaticContexts(profiles.getAccepted())
 				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
 
 		List<AwsSecretsManagerConfigDataResource> locations = new ArrayList<>();
-		contexts.forEach(propertySourceContext -> locations
-				.add(new AwsSecretsManagerConfigDataResource(propertySourceContext, location.isOptional())));
+		contexts.forEach(
+				propertySourceContext -> locations.add(new AwsSecretsManagerConfigDataResource(propertySourceContext,
+						location.isOptional(), propertySources)));
 
 		return locations;
 	}

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolver.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.BootstrapContext;
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.ConfigurableBootstrapContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
+import org.springframework.boot.context.config.ConfigDataLocationResolver;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerProperties;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySources;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsSecretsManagerConfigDataLocationResolver
+		implements ConfigDataLocationResolver<AwsSecretsManagerConfigDataResource> {
+
+	private static final Log log = LogFactory.getLog(AwsSecretsManagerConfigDataLocationResolver.class);
+
+	/**
+	 * AWS Parameter Store Config Data prefix.
+	 */
+	public static final String PREFIX = "aws-secretsmanager:";
+
+	@Override
+	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
+		if (!location.hasPrefix(PREFIX)) {
+			return false;
+		}
+		return context.getBinder().bind(AwsSecretsManagerProperties.CONFIG_PREFIX + ".enabled", Boolean.class)
+				.orElse(true);
+	}
+
+	@Override
+	public List<AwsSecretsManagerConfigDataResource> resolve(ConfigDataLocationResolverContext context,
+			ConfigDataLocation location) throws ConfigDataLocationNotFoundException {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<AwsSecretsManagerConfigDataResource> resolveProfileSpecific(
+			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
+			throws ConfigDataLocationNotFoundException {
+		registerBean(resolverContext, AwsSecretsManagerProperties.class, loadProperties(resolverContext.getBinder()));
+
+		registerAndPromoteBean(resolverContext, AWSSecretsManager.class, this::createAwsSecretsManagerClient);
+
+		AwsSecretsManagerProperties properties = loadConfigProperties(resolverContext.getBinder());
+
+		AwsSecretsManagerPropertySources sources = new AwsSecretsManagerPropertySources(properties, log);
+
+		List<String> contexts = location.getValue().equals(PREFIX)
+				? sources.getAutomaticContexts(profiles.getAccepted())
+				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
+
+		ArrayList<AwsSecretsManagerConfigDataResource> locations = new ArrayList<>();
+		contexts.forEach(propertySourceContext -> locations
+				.add(new AwsSecretsManagerConfigDataResource(propertySourceContext, location.isOptional())));
+
+		return locations;
+	}
+
+	private List<String> getCustomContexts(String keys) {
+		if (StringUtils.isEmpty(keys)) {
+			return Collections.emptyList();
+		}
+
+		return Arrays.asList(keys.split(";"));
+	}
+
+	protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
+			BootstrapRegistry.InstanceSupplier<T> supplier) {
+		registerBean(context, type, supplier);
+		context.getBootstrapContext().addCloseListener(event -> {
+			T instance = event.getBootstrapContext().get(type);
+			event.getApplicationContext().getBeanFactory().registerSingleton("configData" + type.getSimpleName(),
+					instance);
+		});
+	}
+
+	public <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type, T instance) {
+		context.getBootstrapContext().registerIfAbsent(type, BootstrapRegistry.InstanceSupplier.of(instance));
+	}
+
+	protected <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type,
+			BootstrapRegistry.InstanceSupplier<T> supplier) {
+		ConfigurableBootstrapContext bootstrapContext = context.getBootstrapContext();
+		bootstrapContext.registerIfAbsent(type, supplier);
+	}
+
+	protected AWSSecretsManager createAwsSecretsManagerClient(BootstrapContext context) {
+		AwsSecretsManagerProperties properties = context.get(AwsSecretsManagerProperties.class);
+
+		return AwsSecretsManagerBootstrapConfiguration.createSecretsManagerClient(properties);
+	}
+
+	protected AwsSecretsManagerProperties loadProperties(Binder binder) {
+		AwsSecretsManagerProperties awsSecretsManagerProperties = binder
+				.bind(AwsSecretsManagerProperties.CONFIG_PREFIX, Bindable.of(AwsSecretsManagerProperties.class))
+				.orElse(new AwsSecretsManagerProperties());
+
+		return awsSecretsManagerProperties;
+	}
+
+	protected AwsSecretsManagerProperties loadConfigProperties(Binder binder) {
+		AwsSecretsManagerProperties properties = binder
+				.bind(AwsSecretsManagerProperties.CONFIG_PREFIX, Bindable.of(AwsSecretsManagerProperties.class))
+				.orElse(new AwsSecretsManagerProperties());
+
+		if (StringUtils.isEmpty(properties.getName())) {
+			properties.setName(binder.bind("spring.application.name", String.class).orElse("application"));
+		}
+
+		return properties;
+	}
+
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataResource.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import java.util.Objects;
+
+import org.springframework.boot.context.config.ConfigDataResource;
+import org.springframework.core.style.ToStringCreator;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsSecretsManagerConfigDataResource extends ConfigDataResource {
+
+	private final String context;
+
+	private final boolean optional;
+
+	public AwsSecretsManagerConfigDataResource(String context, boolean optional) {
+		this.context = context;
+		this.optional = optional;
+	}
+
+	public String getContext() {
+		return this.context;
+	}
+
+	public boolean isOptional() {
+		return this.optional;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AwsSecretsManagerConfigDataResource that = (AwsSecretsManagerConfigDataResource) o;
+		return this.optional == that.optional && this.context.equals(that.context);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.optional, this.context);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this).append("context", context).append("optional", optional).toString();
+
+	}
+
+}

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataResource.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataResource.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.autoconfigure.secretsmanager;
 import java.util.Objects;
 
 import org.springframework.boot.context.config.ConfigDataResource;
+import org.springframework.cloud.aws.secretsmanager.AwsSecretsManagerPropertySources;
 import org.springframework.core.style.ToStringCreator;
 
 /**
@@ -31,9 +32,13 @@ public class AwsSecretsManagerConfigDataResource extends ConfigDataResource {
 
 	private final boolean optional;
 
-	public AwsSecretsManagerConfigDataResource(String context, boolean optional) {
+	private final AwsSecretsManagerPropertySources propertySources;
+
+	public AwsSecretsManagerConfigDataResource(String context, boolean optional,
+			AwsSecretsManagerPropertySources propertySources) {
 		this.context = context;
 		this.optional = optional;
+		this.propertySources = propertySources;
 	}
 
 	public String getContext() {
@@ -42,6 +47,10 @@ public class AwsSecretsManagerConfigDataResource extends ConfigDataResource {
 
 	public boolean isOptional() {
 		return this.optional;
+	}
+
+	public AwsSecretsManagerPropertySources getPropertySources() {
+		return this.propertySources;
 	}
 
 	@Override

--- a/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,10 @@
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.aws.autoconfigure.secretsmanager.AwsSecretsManagerBootstrapConfiguration
+
+# ConfigData Location Resolvers
+org.springframework.boot.context.config.ConfigDataLocationResolver=\
+org.springframework.cloud.aws.autoconfigure.secretsmanager.AwsSecretsManagerConfigDataLocationResolver
+
+# ConfigData Loaders
+org.springframework.boot.context.config.ConfigDataLoader=\
+org.springframework.cloud.aws.autoconfigure.secretsmanager.AwsSecretsManagerConfigDataLoader

--- a/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.aws.autoconfigure.secretsmanager;
 
 import java.util.Collections;

--- a/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 class AwsSecretsManagerConfigDataLocationResolverTest {
 
 	@Test
-	public void testResolveProfileSpecificWithAutomaticPaths() {
+	void testResolveProfileSpecificWithAutomaticPaths() {
 		String location = "aws-secretsmanager:";
 		List<AwsSecretsManagerConfigDataResource> locations = testResolveProfileSpecific(location);
 		assertThat(locations).hasSize(4);
@@ -45,7 +45,7 @@ class AwsSecretsManagerConfigDataLocationResolverTest {
 	}
 
 	@Test
-	public void testResolveProfileSpecificWithCustomPaths() {
+	void testResolveProfileSpecificWithCustomPaths() {
 		String location = "aws-secretsmanager:/mypath1;/mypath2;/mypath3";
 		List<AwsSecretsManagerConfigDataResource> locations = testResolveProfileSpecific(location);
 		assertThat(locations).hasSize(3);

--- a/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-secrets-manager-config/src/test/java/org/springframework/cloud/aws/autoconfigure/secretsmanager/AwsSecretsManagerConfigDataLocationResolverTest.java
@@ -1,0 +1,75 @@
+package org.springframework.cloud.aws.autoconfigure.secretsmanager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AwsSecretsManagerConfigDataLocationResolverTest {
+
+	@Test
+	public void testResolveProfileSpecificWithAutomaticPaths() {
+		String location = "aws-secretsmanager:";
+		List<AwsSecretsManagerConfigDataResource> locations = testResolveProfileSpecific(location);
+		assertThat(locations).hasSize(4);
+		assertThat(toContexts(locations)).containsExactly("/secret/testapp_dev", "/secret/testapp",
+				"/secret/application_dev", "/secret/application");
+	}
+
+	@Test
+	public void testResolveProfileSpecificWithCustomPaths() {
+		String location = "aws-secretsmanager:/mypath1;/mypath2;/mypath3";
+		List<AwsSecretsManagerConfigDataResource> locations = testResolveProfileSpecific(location);
+		assertThat(locations).hasSize(3);
+		assertThat(toContexts(locations)).containsExactly("/mypath1", "/mypath2", "/mypath3");
+	}
+
+	private List<String> toContexts(List<AwsSecretsManagerConfigDataResource> locations) {
+		return locations.stream().map(AwsSecretsManagerConfigDataResource::getContext).collect(Collectors.toList());
+	}
+
+	private List<AwsSecretsManagerConfigDataResource> testResolveProfileSpecific(String location) {
+		AwsSecretsManagerConfigDataLocationResolver resolver = createResolver();
+		ConfigDataLocationResolverContext context = mock(ConfigDataLocationResolverContext.class);
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.application.name", "testapp");
+		when(context.getBinder()).thenReturn(Binder.get(env));
+		Profiles profiles = mock(Profiles.class);
+		when(profiles.getAccepted()).thenReturn(Collections.singletonList("dev"));
+		return resolver.resolveProfileSpecific(context, ConfigDataLocation.of(location), profiles);
+	}
+
+	private AwsSecretsManagerConfigDataLocationResolver createResolver() {
+		return new AwsSecretsManagerConfigDataLocationResolver() {
+			@Override
+			public <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type, T instance) {
+				// do nothing
+			}
+
+			@Override
+			protected <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type,
+					BootstrapRegistry.InstanceSupplier<T> supplier) {
+				// do nothing
+			}
+
+			@Override
+			protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
+					BootstrapRegistry.InstanceSupplier<T> supplier) {
+				// do nothing
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
In `spring-boot` 2.4, `Volume Mounted Config Directory Trees` was
added. This commit introduces the prefix `aws-secretsmanager:` which
will resolve the values given the configuration properties supported
by secrets manager integration. Also, if keys are added after the
prefix then just these will be resolved.

Use: `aws-secretsmanager:` or `aws-secretsmanager:my-secret-key` or
`aws-secretsmanager:my-secret-key;my-anoter-secret-key`

Closes gh-655
Closes gh-515
