### PR TITLE
Add aws-parameterstore: prefix config import

### DIFF
--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -88,3 +88,19 @@ turn on `DEBUG` logging on `org.springframework.cloud.aws.paramstore.AwsParamSto
 logging.level.org.springframework.cloud.aws.paramstore.AwsParamStorePropertySource=debug
 ----
 ====
+
+In `spring-cloud` `2020.0.0` (aka Ilford), the bootstrap phase is no longer enabled by default. In order
+enable it you need an additional dependency:
+
+[source,xml,indent=0]
+----
+<dependency>
+  <groupId>org.springframework.cloud</groupId>
+  <artifactId>spring-cloud-starter-bootstrap</artifactId>
+  <version>{spring-cloud-version}</version>
+</dependency>
+----
+
+However, starting at `spring-cloud-aws` `2.3`, allows import default aws' parameterstore keys
+(`spring.config.import=aws-parameterstore:`) or individual keys
+(`spring.config.import=aws-parameterstore:secret-key;other-secret-key`)

--- a/docs/src/main/asciidoc/parameter-store.adoc
+++ b/docs/src/main/asciidoc/parameter-store.adoc
@@ -103,4 +103,4 @@ enable it you need an additional dependency:
 
 However, starting at `spring-cloud-aws` `2.3`, allows import default aws' parameterstore keys
 (`spring.config.import=aws-parameterstore:`) or individual keys
-(`spring.config.import=aws-parameterstore:secret-key;other-secret-key`)
+(`spring.config.import=aws-parameterstore:config-key;other-config-key`)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/><!-- lookup parent from repository -->
 	</parent>
 
@@ -48,7 +48,7 @@
 		<javax-mail.version>1.5.5</javax-mail.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<javax.activation.version>1.2.0</javax.activation.version>
-		<spring-cloud-commons.version>3.0.0-M4</spring-cloud-commons.version>
+		<spring-cloud-commons.version>3.0.0-SNAPSHOT</spring-cloud-commons.version>
 		<spring-javaformat.version>0.0.25</spring-javaformat.version>
 	</properties>
 

--- a/spring-cloud-aws-dependencies/pom.xml
+++ b/spring-cloud-aws-dependencies/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>2.3.2.BUILD-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-aws-dependencies</artifactId>

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySource.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySource.java
@@ -34,15 +34,16 @@ import org.springframework.core.env.EnumerablePropertySource;
  * from the AWS Parameter Store using the provided SSM client.
  *
  * @author Joris Kuipers
+ * @author Eddú Meléndez
  * @since 2.0.0
  */
 public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSimpleSystemsManagement> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AwsParamStorePropertySource.class);
 
-	private String context;
+	private final String context;
 
-	private Map<String, Object> properties = new LinkedHashMap<>();
+	private final Map<String, Object> properties = new LinkedHashMap<>();
 
 	public AwsParamStorePropertySource(String context, AWSSimpleSystemsManagement ssmClient) {
 		super(context, ssmClient);
@@ -57,21 +58,21 @@ public class AwsParamStorePropertySource extends EnumerablePropertySource<AWSSim
 
 	@Override
 	public String[] getPropertyNames() {
-		Set<String> strings = properties.keySet();
+		Set<String> strings = this.properties.keySet();
 		return strings.toArray(new String[strings.size()]);
 	}
 
 	@Override
 	public Object getProperty(String name) {
-		return properties.get(name);
+		return this.properties.get(name);
 	}
 
 	private void getParameters(GetParametersByPathRequest paramsRequest) {
-		GetParametersByPathResult paramsResult = source.getParametersByPath(paramsRequest);
+		GetParametersByPathResult paramsResult = this.source.getParametersByPath(paramsRequest);
 		for (Parameter parameter : paramsResult.getParameters()) {
-			String key = parameter.getName().replace(context, "").replace('/', '.');
+			String key = parameter.getName().replace(this.context, "").replace('/', '.');
 			LOGGER.debug("Populating property retrieved from AWS Parameter Store: {}", key);
-			properties.put(key, parameter.getValue());
+			this.properties.put(key, parameter.getValue());
 		}
 		if (paramsResult.getNextToken() != null) {
 			getParameters(paramsRequest.withNextToken(paramsResult.getNextToken()));

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -31,7 +31,6 @@ import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Builds a {@link CompositePropertySource} with various

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -43,6 +43,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Joris Kuipers
  * @author Matej Nedic
+ * @author Eddú Meléndez
  * @since 2.0.0
  */
 public class AwsParamStorePropertySourceLocator implements PropertySourceLocator {
@@ -73,56 +74,20 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
 
-		String appName = properties.getName();
-
-		if (appName == null) {
-			appName = env.getProperty("spring.application.name");
-		}
+		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(this.properties, this.logger);
 
 		List<String> profiles = Arrays.asList(env.getActiveProfiles());
-
-		String prefix = this.properties.getPrefix();
-
-		String appContext = prefix + "/" + appName;
-		addProfiles(this.contexts, appContext, profiles);
-		this.contexts.add(appContext + "/");
-
-		String defaultContext = prefix + "/" + this.properties.getDefaultContext();
-		addProfiles(this.contexts, defaultContext, profiles);
-		this.contexts.add(defaultContext + "/");
+		this.contexts.addAll(sources.getAutomaticContexts(profiles));
 
 		CompositePropertySource composite = new CompositePropertySource("aws-param-store");
 
 		for (String propertySourceContext : this.contexts) {
-			try {
-				composite.addPropertySource(create(propertySourceContext));
-			}
-			catch (Exception e) {
-				if (this.properties.isFailFast()) {
-					logger.error(
-							"Fail fast is set and there was an error reading configuration from AWS Parameter Store:\n"
-									+ e.getMessage());
-					ReflectionUtils.rethrowRuntimeException(e);
-				}
-				else {
-					logger.warn("Unable to load AWS config from " + propertySourceContext, e);
-				}
-			}
+			PropertySource<AWSSimpleSystemsManagement> propertySource = sources
+					.createPropertySource(propertySourceContext, true, this.ssmClient);
+			composite.addPropertySource(propertySource);
 		}
 
 		return composite;
-	}
-
-	private AwsParamStorePropertySource create(String context) {
-		AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(context, this.ssmClient);
-		propertySource.init();
-		return propertySource;
-	}
-
-	private void addProfiles(Set<String> contexts, String baseContext, List<String> profiles) {
-		for (String profile : profiles) {
-			contexts.add(baseContext + this.properties.getProfileSeparator() + profile + "/");
-		}
 	}
 
 }

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySourceLocator.java
@@ -82,8 +82,10 @@ public class AwsParamStorePropertySourceLocator implements PropertySourceLocator
 
 		for (String propertySourceContext : this.contexts) {
 			PropertySource<AWSSimpleSystemsManagement> propertySource = sources
-					.createPropertySource(propertySourceContext, true, this.ssmClient);
-			composite.addPropertySource(propertySource);
+					.createPropertySource(propertySourceContext, !this.properties.isFailFast(), this.ssmClient);
+			if (propertySource != null) {
+				composite.addPropertySource(propertySource);
+			}
 		}
 
 		return composite;

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
@@ -24,6 +24,10 @@ import org.apache.commons.logging.Log;
 
 import org.springframework.util.StringUtils;
 
+/**
+ * @author Eddú Meléndez
+ * @since 2.3
+ */
 public class AwsParamStorePropertySources {
 
 	private final AwsParamStoreProperties properties;
@@ -64,6 +68,15 @@ public class AwsParamStorePropertySources {
 		}
 	}
 
+	/**
+	 * Creates property source for given context.
+	 * @param context property source context equivalent to the parameter name
+	 * @param optional if creating context should fail with exception if parameter cannot
+	 * be loaded
+	 * @param client System Manager Management client
+	 * @return a property source or null if parameter could not be loaded and optional is
+	 * set to true
+	 */
 	public AwsParamStorePropertySource createPropertySource(String context, boolean optional,
 			AWSSimpleSystemsManagement client) {
 		try {
@@ -73,11 +86,11 @@ public class AwsParamStorePropertySources {
 			// TODO: howto call close when /refresh
 		}
 		catch (Exception e) {
-			if (this.properties.isFailFast() || !optional) {
+			if (!optional) {
 				throw new AwsParameterPropertySourceNotFoundException(e);
 			}
 			else {
-				log.warn("Unable to load AWS parameter from " + context, e);
+				log.warn("Unable to load AWS parameter from " + context + ". " + e.getMessage());
 			}
 		}
 		return null;

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
@@ -79,7 +79,7 @@ public class AwsParamStorePropertySources {
 				throw new AwsParameterPropertySourceNotFoundException(e);
 			}
 			else {
-				log.warn("Unable to load AWS secret from " + context, e);
+				log.warn("Unable to load AWS parameter from " + context, e);
 			}
 		}
 		return null;

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
@@ -52,12 +52,10 @@ public class AwsParamStorePropertySources {
 	}
 
 	protected String getContext(String prefix, String context) {
-		if (StringUtils.isEmpty(prefix)) {
-			return context;
-		}
-		else {
+		if (StringUtils.hasLength(prefix)) {
 			return prefix + "/" + context;
 		}
+		return context;
 	}
 
 	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
@@ -44,10 +44,10 @@ public class AwsParamStorePropertySources {
 
 		String appContext = prefix + "/" + appName;
 		addProfiles(contexts, appContext, profiles);
-		contexts.add(appContext);
+		contexts.add(appContext + "/");
 
 		addProfiles(contexts, defaultContext, profiles);
-		contexts.add(defaultContext);
+		contexts.add(defaultContext + "/");
 		return contexts;
 	}
 
@@ -62,7 +62,7 @@ public class AwsParamStorePropertySources {
 
 	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
 		for (String profile : profiles) {
-			contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+			contexts.add(baseContext + this.properties.getProfileSeparator() + profile + "/");
 		}
 	}
 

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStorePropertySources.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.paramstore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import org.apache.commons.logging.Log;
+
+import org.springframework.util.StringUtils;
+
+public class AwsParamStorePropertySources {
+
+	private final AwsParamStoreProperties properties;
+
+	private final Log log;
+
+	public AwsParamStorePropertySources(AwsParamStoreProperties properties, Log log) {
+		this.properties = properties;
+		this.log = log;
+	}
+
+	public List<String> getAutomaticContexts(List<String> profiles) {
+		List<String> contexts = new ArrayList<>();
+		String prefix = this.properties.getPrefix();
+		String defaultContext = getContext(prefix, this.properties.getDefaultContext());
+
+		String appName = this.properties.getName();
+
+		String appContext = prefix + "/" + appName;
+		addProfiles(contexts, appContext, profiles);
+		contexts.add(appContext);
+
+		addProfiles(contexts, defaultContext, profiles);
+		contexts.add(defaultContext);
+		return contexts;
+	}
+
+	protected String getContext(String prefix, String context) {
+		if (StringUtils.isEmpty(prefix)) {
+			return context;
+		}
+		else {
+			return prefix + "/" + context;
+		}
+	}
+
+	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+		}
+	}
+
+	public AwsParamStorePropertySource createPropertySource(String context, boolean optional,
+			AWSSimpleSystemsManagement client) {
+		try {
+			AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(context, client);
+			propertySource.init();
+			return propertySource;
+			// TODO: howto call close when /refresh
+		}
+		catch (Exception e) {
+			if (this.properties.isFailFast() || !optional) {
+				throw new AwsParameterPropertySourceNotFoundException(e);
+			}
+			else {
+				log.warn("Unable to load AWS secret from " + context, e);
+			}
+		}
+		return null;
+	}
+
+	static class AwsParameterPropertySourceNotFoundException extends RuntimeException {
+
+		AwsParameterPropertySourceNotFoundException(Exception source) {
+			super(source);
+		}
+
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
@@ -55,6 +55,10 @@ public class AwsParamStoreBootstrapConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	AWSSimpleSystemsManagement ssmClient(AwsParamStoreProperties properties) {
+		return createSimpleSystemManagementClient(properties);
+	}
+
+	public static AWSSimpleSystemsManagement createSimpleSystemManagementClient(AwsParamStoreProperties properties) {
 		AWSSimpleSystemsManagementClientBuilder builder = AWSSimpleSystemsManagementClientBuilder.standard()
 				.withClientConfiguration(SpringCloudClientConfiguration.getClientConfiguration());
 		if (!StringUtils.isNullOrEmpty(properties.getRegion())) {

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreBootstrapConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.aws.paramstore.AwsParamStoreProperties;
 import org.springframework.cloud.aws.paramstore.AwsParamStorePropertySourceLocator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 /**
  * Spring Cloud Bootstrap Configuration for setting up an
@@ -46,9 +47,18 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = AwsParamStoreProperties.CONFIG_PREFIX, name = "enabled", matchIfMissing = true)
 public class AwsParamStoreBootstrapConfiguration {
 
+	private final Environment environment;
+
+	public AwsParamStoreBootstrapConfiguration(Environment environment) {
+		this.environment = environment;
+	}
+
 	@Bean
 	AwsParamStorePropertySourceLocator awsParamStorePropertySourceLocator(AWSSimpleSystemsManagement ssmClient,
 			AwsParamStoreProperties properties) {
+		if (StringUtils.isNullOrEmpty(properties.getName())) {
+			properties.setName(this.environment.getProperty("spring.application.name"));
+		}
 		return new AwsParamStorePropertySourceLocator(ssmClient, properties);
 	}
 

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
@@ -36,8 +36,8 @@ public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamS
 	public ConfigData load(ConfigDataLoaderContext context, AwsParamStoreConfigDataResource resource) {
 		try {
 			AWSSimpleSystemsManagement ssm = context.getBootstrapContext().get(AWSSimpleSystemsManagement.class);
-			AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(resource.getContext(), ssm);
-			propertySource.init();
+			AwsParamStorePropertySource propertySource = resource.getPropertySources()
+					.createPropertySource(resource.getContext(), resource.isOptional(), ssm);
 			return new ConfigData(Collections.singletonList(propertySource));
 		}
 		catch (Exception e) {

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.paramstore;
+
+import java.util.Collections;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigDataLoader;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.cloud.aws.paramstore.AwsParamStorePropertySource;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamStoreConfigDataResource> {
+
+	@Override
+	public ConfigData load(ConfigDataLoaderContext context, AwsParamStoreConfigDataResource resource) {
+		try {
+			AWSSimpleSystemsManagement ssm = context.getBootstrapContext().get(AWSSimpleSystemsManagement.class);
+			AwsParamStorePropertySource propertySource = new AwsParamStorePropertySource(resource.getContext(), ssm);
+			propertySource.init();
+			return new ConfigData(Collections.singletonList(propertySource));
+		}
+		catch (Exception e) {
+			throw new ConfigDataResourceNotFoundException(resource, e);
+		}
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLoader.java
@@ -38,7 +38,12 @@ public class AwsParamStoreConfigDataLoader implements ConfigDataLoader<AwsParamS
 			AWSSimpleSystemsManagement ssm = context.getBootstrapContext().get(AWSSimpleSystemsManagement.class);
 			AwsParamStorePropertySource propertySource = resource.getPropertySources()
 					.createPropertySource(resource.getContext(), resource.isOptional(), ssm);
-			return new ConfigData(Collections.singletonList(propertySource));
+			if (propertySource != null) {
+				return new ConfigData(Collections.singletonList(propertySource));
+			}
+			else {
+				return null;
+			}
 		}
 		catch (Exception e) {
 			throw new ConfigDataResourceNotFoundException(resource, e);

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -84,7 +84,7 @@ public class AwsParamStoreConfigDataLocationResolver
 				? sources.getAutomaticContexts(profiles.getAccepted())
 				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
 
-		ArrayList<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
+		List<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
 		contexts.forEach(propertySourceContext -> locations
 				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
 

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.paramstore;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.BootstrapContext;
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.ConfigurableBootstrapContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
+import org.springframework.boot.context.config.ConfigDataLocationResolver;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.cloud.aws.paramstore.AwsParamStoreProperties;
+import org.springframework.cloud.aws.paramstore.AwsParamStorePropertySources;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsParamStoreConfigDataLocationResolver
+		implements ConfigDataLocationResolver<AwsParamStoreConfigDataResource> {
+
+	/**
+	 * AWS ParameterStore Config Data prefix.
+	 */
+	public static final String PREFIX = "aws-parameterstore:";
+
+	private final Log log = LogFactory.getLog(AwsParamStoreConfigDataLocationResolver.class);
+
+	@Override
+	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
+		if (!location.hasPrefix(PREFIX)) {
+			return false;
+		}
+		return context.getBinder().bind(AwsParamStoreProperties.CONFIG_PREFIX + ".enabled", Boolean.class).orElse(true);
+	}
+
+	@Override
+	public List<AwsParamStoreConfigDataResource> resolve(ConfigDataLocationResolverContext context,
+			ConfigDataLocation location) throws ConfigDataLocationNotFoundException {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<AwsParamStoreConfigDataResource> resolveProfileSpecific(
+			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
+			throws ConfigDataLocationNotFoundException {
+		registerBean(resolverContext, AwsParamStoreProperties.class, loadProperties(resolverContext.getBinder()));
+
+		registerAndPromoteBean(resolverContext, AWSSimpleSystemsManagement.class,
+				this::createSimpleSystemManagementClient);
+
+		AwsParamStoreProperties properties = loadConfigProperties(resolverContext.getBinder());
+
+		AwsParamStorePropertySources sources = new AwsParamStorePropertySources(properties, log);
+
+		List<String> contexts = location.getValue().equals(PREFIX)
+				? sources.getAutomaticContexts(profiles.getAccepted())
+				: getCustomContexts(location.getNonPrefixedValue(PREFIX));
+
+		ArrayList<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
+		contexts.forEach(propertySourceContext -> locations
+				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional())));
+
+		return locations;
+	}
+
+	private List<String> getCustomContexts(String keys) {
+		if (StringUtils.isEmpty(keys)) {
+			return Collections.emptyList();
+		}
+
+		return Arrays.asList(keys.split(";"));
+	}
+
+	protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
+			BootstrapRegistry.InstanceSupplier<T> supplier) {
+		registerBean(context, type, supplier);
+		context.getBootstrapContext().addCloseListener(event -> {
+			T instance = event.getBootstrapContext().get(type);
+			event.getApplicationContext().getBeanFactory().registerSingleton("configData" + type.getSimpleName(),
+					instance);
+		});
+	}
+
+	public <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type, T instance) {
+		context.getBootstrapContext().registerIfAbsent(type, BootstrapRegistry.InstanceSupplier.of(instance));
+	}
+
+	protected <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type,
+			BootstrapRegistry.InstanceSupplier<T> supplier) {
+		ConfigurableBootstrapContext bootstrapContext = context.getBootstrapContext();
+		bootstrapContext.registerIfAbsent(type, supplier);
+	}
+
+	protected AWSSimpleSystemsManagement createSimpleSystemManagementClient(BootstrapContext context) {
+		AwsParamStoreProperties properties = context.get(AwsParamStoreProperties.class);
+
+		return AwsParamStoreBootstrapConfiguration.createSimpleSystemManagementClient(properties);
+	}
+
+	protected AwsParamStoreProperties loadProperties(Binder binder) {
+		AwsParamStoreProperties awsParamStoreProperties = binder
+				.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
+				.orElse(new AwsParamStoreProperties());
+
+		return awsParamStoreProperties;
+	}
+
+	protected AwsParamStoreProperties loadConfigProperties(Binder binder) {
+		AwsParamStoreProperties properties = binder
+				.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
+				.orElse(new AwsParamStoreProperties());
+
+		if (StringUtils.isEmpty(properties.getName())) {
+			properties.setName(binder.bind("spring.application.name", String.class).orElse("application"));
+		}
+
+		return properties;
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -125,11 +125,8 @@ public class AwsParamStoreConfigDataLocationResolver
 	}
 
 	protected AwsParamStoreProperties loadProperties(Binder binder) {
-		AwsParamStoreProperties awsParamStoreProperties = binder
-				.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
+		return binder.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
 				.orElseGet(AwsParamStoreProperties::new);
-
-		return awsParamStoreProperties;
 	}
 
 	protected AwsParamStoreProperties loadConfigProperties(Binder binder) {

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -86,7 +86,7 @@ public class AwsParamStoreConfigDataLocationResolver
 
 		ArrayList<AwsParamStoreConfigDataResource> locations = new ArrayList<>();
 		contexts.forEach(propertySourceContext -> locations
-				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional())));
+				.add(new AwsParamStoreConfigDataResource(propertySourceContext, location.isOptional(), sources)));
 
 		return locations;
 	}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolver.java
@@ -92,11 +92,10 @@ public class AwsParamStoreConfigDataLocationResolver
 	}
 
 	private List<String> getCustomContexts(String keys) {
-		if (StringUtils.isEmpty(keys)) {
-			return Collections.emptyList();
+		if (StringUtils.hasLength(keys)) {
+			return Arrays.asList(keys.split(";"));
 		}
-
-		return Arrays.asList(keys.split(";"));
+		return Collections.emptyList();
 	}
 
 	protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
@@ -128,7 +127,7 @@ public class AwsParamStoreConfigDataLocationResolver
 	protected AwsParamStoreProperties loadProperties(Binder binder) {
 		AwsParamStoreProperties awsParamStoreProperties = binder
 				.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
-				.orElse(new AwsParamStoreProperties());
+				.orElseGet(AwsParamStoreProperties::new);
 
 		return awsParamStoreProperties;
 	}
@@ -138,7 +137,7 @@ public class AwsParamStoreConfigDataLocationResolver
 				.bind(AwsParamStoreProperties.CONFIG_PREFIX, Bindable.of(AwsParamStoreProperties.class))
 				.orElse(new AwsParamStoreProperties());
 
-		if (StringUtils.isEmpty(properties.getName())) {
+		if (!StringUtils.hasLength(properties.getName())) {
 			properties.setName(binder.bind("spring.application.name", String.class).orElse("application"));
 		}
 

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
@@ -23,6 +23,8 @@ import org.springframework.cloud.aws.paramstore.AwsParamStorePropertySources;
 import org.springframework.core.style.ToStringCreator;
 
 /**
+ * Config data resource for AWS System Manager Management integration.
+ *
  * @author Eddú Meléndez
  * @since 2.3.0
  */
@@ -41,10 +43,18 @@ public class AwsParamStoreConfigDataResource extends ConfigDataResource {
 		this.propertySources = propertySources;
 	}
 
+	/**
+	 * Returns context which is equal to Secret Manager secret name.
+	 * @return the context
+	 */
 	public String getContext() {
 		return this.context;
 	}
 
+	/**
+	 * If application startup should fail when secret cannot be loaded or does not exist.
+	 * @return is optional
+	 */
 	public boolean isOptional() {
 		return this.optional;
 	}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.aws.autoconfigure.paramstore;
+
+import java.util.Objects;
+
+import org.springframework.boot.context.config.ConfigDataResource;
+import org.springframework.core.style.ToStringCreator;
+
+/**
+ * @author Eddú Meléndez
+ * @since 2.3.0
+ */
+public class AwsParamStoreConfigDataResource extends ConfigDataResource {
+
+	private final String context;
+
+	private final boolean optional;
+
+	public AwsParamStoreConfigDataResource(String context, boolean optional) {
+		this.context = context;
+		this.optional = optional;
+	}
+
+	public String getContext() {
+		return this.context;
+	}
+
+	public boolean isOptional() {
+		return this.optional;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AwsParamStoreConfigDataResource that = (AwsParamStoreConfigDataResource) o;
+		return this.optional == that.optional && this.context.equals(that.context);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.optional, this.context);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this).append("context", context).append("optional", optional).toString();
+
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataResource.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.autoconfigure.paramstore;
 import java.util.Objects;
 
 import org.springframework.boot.context.config.ConfigDataResource;
+import org.springframework.cloud.aws.paramstore.AwsParamStorePropertySources;
 import org.springframework.core.style.ToStringCreator;
 
 /**
@@ -31,9 +32,13 @@ public class AwsParamStoreConfigDataResource extends ConfigDataResource {
 
 	private final boolean optional;
 
-	public AwsParamStoreConfigDataResource(String context, boolean optional) {
+	private final AwsParamStorePropertySources propertySources;
+
+	public AwsParamStoreConfigDataResource(String context, boolean optional,
+			AwsParamStorePropertySources propertySources) {
 		this.context = context;
 		this.optional = optional;
+		this.propertySources = propertySources;
 	}
 
 	public String getContext() {
@@ -42,6 +47,10 @@ public class AwsParamStoreConfigDataResource extends ConfigDataResource {
 
 	public boolean isOptional() {
 		return this.optional;
+	}
+
+	public AwsParamStorePropertySources getPropertySources() {
+		return this.propertySources;
 	}
 
 	@Override

--- a/spring-cloud-starter-aws-parameter-store-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-aws-parameter-store-config/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,10 @@
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.aws.autoconfigure.paramstore.AwsParamStoreBootstrapConfiguration
+
+# ConfigData Location Resolvers
+org.springframework.boot.context.config.ConfigDataLocationResolver=\
+org.springframework.cloud.aws.autoconfigure.paramstore.AwsParamStoreConfigDataLocationResolver
+
+# ConfigData Loaders
+org.springframework.boot.context.config.ConfigDataLoader=\
+org.springframework.cloud.aws.autoconfigure.paramstore.AwsParamStoreConfigDataLoader

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
@@ -1,0 +1,75 @@
+package org.springframework.cloud.aws.autoconfigure.paramstore;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AwsParamStoreConfigDataLocationResolverTest {
+
+	@Test
+	void testResolveProfileSpecificWithAutomaticPaths() {
+		String location = "aws-parameterstore:";
+		List<AwsParamStoreConfigDataResource> locations = testResolveProfileSpecific(location);
+		assertThat(locations).hasSize(4);
+		assertThat(toContexts(locations)).containsExactly("/config/testapp_dev", "/config/testapp",
+				"/config/application_dev", "/config/application");
+	}
+
+	@Test
+	void testResolveProfileSpecificWithCustomPaths() {
+		String location = "aws-parameterstore:/mypath1;/mypath2;/mypath3";
+		List<AwsParamStoreConfigDataResource> locations = testResolveProfileSpecific(location);
+		assertThat(locations).hasSize(3);
+		assertThat(toContexts(locations)).containsExactly("/mypath1", "/mypath2", "/mypath3");
+	}
+
+	private List<String> toContexts(List<AwsParamStoreConfigDataResource> locations) {
+		return locations.stream().map(AwsParamStoreConfigDataResource::getContext).collect(Collectors.toList());
+	}
+
+	private List<AwsParamStoreConfigDataResource> testResolveProfileSpecific(String location) {
+		AwsParamStoreConfigDataLocationResolver resolver = createResolver();
+		ConfigDataLocationResolverContext context = mock(ConfigDataLocationResolverContext.class);
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("spring.application.name", "testapp");
+		when(context.getBinder()).thenReturn(Binder.get(env));
+		Profiles profiles = mock(Profiles.class);
+		when(profiles.getAccepted()).thenReturn(Collections.singletonList("dev"));
+		return resolver.resolveProfileSpecific(context, ConfigDataLocation.of(location), profiles);
+	}
+
+	private AwsParamStoreConfigDataLocationResolver createResolver() {
+		return new AwsParamStoreConfigDataLocationResolver() {
+			@Override
+			public <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type, T instance) {
+				// do nothing
+			}
+
+			@Override
+			protected <T> void registerBean(ConfigDataLocationResolverContext context, Class<T> type,
+					BootstrapRegistry.InstanceSupplier<T> supplier) {
+				// do nothing
+			}
+
+			@Override
+			protected <T> void registerAndPromoteBean(ConfigDataLocationResolverContext context, Class<T> type,
+					BootstrapRegistry.InstanceSupplier<T> supplier) {
+				// do nothing
+			}
+		};
+	}
+
+}

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.aws.autoconfigure.paramstore;
 
 import java.util.Collections;

--- a/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
+++ b/spring-cloud-starter-aws-parameter-store-config/src/test/java/org/springframework/cloud/aws/autoconfigure/paramstore/AwsParamStoreConfigDataLocationResolverTest.java
@@ -24,8 +24,8 @@ class AwsParamStoreConfigDataLocationResolverTest {
 		String location = "aws-parameterstore:";
 		List<AwsParamStoreConfigDataResource> locations = testResolveProfileSpecific(location);
 		assertThat(locations).hasSize(4);
-		assertThat(toContexts(locations)).containsExactly("/config/testapp_dev", "/config/testapp",
-				"/config/application_dev", "/config/application");
+		assertThat(toContexts(locations)).containsExactly("/config/testapp_dev/", "/config/testapp/",
+				"/config/application_dev/", "/config/application/");
 	}
 
 	@Test


### PR DESCRIPTION
In `spring-boot` 2.4, `Volume Mounted Config Directory Trees` was
added. This commit introduces the prefix `aws-parameterstore:` which
will resolve the values given the configuration properties supported
by parameter store integration. Also, if keys are added after the
prefix then just these will be resolved.

Use: `aws-parameterstore:` or `aws-parameterstore:my-config-key` or
`aws-parameterstore:my-config-key;my-anoter-config-key`

Closes gh-654
