### PR TITLE
Add ability to provide custom client configuration

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -1,67 +1,68 @@
 |===
 |Name | Default | Description
 
-|aws.paramstore.default-context | application |
-|aws.paramstore.enabled | true | Is AWS Parameter Store support enabled.
+|aws.paramstore.default-context | `application` | 
+|aws.paramstore.enabled | `true` | Is AWS Parameter Store support enabled.
 |aws.paramstore.endpoint |  | Overrides the default endpoint.
-|aws.paramstore.fail-fast | true | Throw exceptions during config lookup if true, otherwise, log warnings.
+|aws.paramstore.fail-fast | `true` | Throw exceptions during config lookup if true, otherwise, log warnings.
 |aws.paramstore.name |  | Alternative to spring.application.name to use in looking up values in AWS Parameter Store.
-|aws.paramstore.prefix | /config | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
-|aws.paramstore.profile-separator | _ |
+|aws.paramstore.prefix | `/config` | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
+|aws.paramstore.profile-separator | `_` | 
 |aws.paramstore.region |  | If region value is not null or empty it will be used in creation of AWSSimpleSystemsManagement.
-|aws.secretsmanager.default-context | application |
-|aws.secretsmanager.enabled | true | Is AWS Secrets Manager support enabled.
+|aws.secretsmanager.default-context | `application` | 
+|aws.secretsmanager.enabled | `true` | Is AWS Secrets Manager support enabled.
 |aws.secretsmanager.endpoint |  | Overrides the default endpoint.
-|aws.secretsmanager.fail-fast | true | Throw exceptions during config lookup if true, otherwise, log warnings.
+|aws.secretsmanager.fail-fast | `true` | Throw exceptions during config lookup if true, otherwise, log warnings.
 |aws.secretsmanager.name |  | Alternative to spring.application.name to use in looking up values in AWS Secrets Manager.
-|aws.secretsmanager.prefix | /secret | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
-|aws.secretsmanager.profile-separator | _ |
+|aws.secretsmanager.prefix | `/secret` | Prefix indicating first level for every property. Value must start with a forward slash followed by a valid path segment or be empty. Defaults to "/config".
+|aws.secretsmanager.profile-separator | `_` | 
 |aws.secretsmanager.region |  | If region value is not null or empty it will be used in creation of AWSSecretsManager.
 |cloud.aws.credentials.access-key |  | The access key to be used with a static provider.
-|cloud.aws.credentials.instance-profile | false | Configures an instance profile credentials provider with no further configuration.
+|cloud.aws.credentials.instance-profile | `false` | Configures an instance profile credentials provider with no further configuration.
 |cloud.aws.credentials.profile-name |  | The AWS profile name.
 |cloud.aws.credentials.profile-path |  | The AWS profile path.
 |cloud.aws.credentials.secret-key |  | The secret key to be used with a static provider.
-|cloud.aws.elasticache.cache-names |  |
+|cloud.aws.elasticache.cache-names |  | 
 |cloud.aws.elasticache.clusters |  | Configures the cache clusters for the caching configuration. Support one or multiple caches {@link Cluster} configurations with their physical cache name (as configured in the ElastiCache service) or their logical cache name if the caches are configured inside a stack and {@link org.springframework.cloud.aws.context.config.annotation.EnableStackConfiguration} annotation is used inside the application.
-|cloud.aws.elasticache.default-expiration | 0 | Configures the default expiration time in seconds if there is no custom expiration time configuration with a {@link Cluster} configuration for the cache. The expiration time is implementation specific (e.g. Redis or Memcached) and could therefore differ in the behaviour based on the cache implementation.
-|cloud.aws.elasticache.enabled | true | Enables ElastiCache integration.
-|cloud.aws.elasticache.expiry-time-per-cache |  |
-|cloud.aws.instance.data.enabled | false | Enables Instance Data integration.
-|cloud.aws.loader.core-pool-size | 1 | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
+|cloud.aws.elasticache.default-expiration | `0` | Configures the default expiration time in seconds if there is no custom expiration time configuration with a {@link Cluster} configuration for the cache. The expiration time is implementation specific (e.g. Redis or Memcached) and could therefore differ in the behaviour based on the cache implementation.
+|cloud.aws.elasticache.enabled | `true` | Enables ElastiCache integration.
+|cloud.aws.elasticache.expiry-time-per-cache |  | 
+|cloud.aws.instance.data.enabled | `false` | Enables Instance Data integration.
+|cloud.aws.loader.core-pool-size | `1` | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
 |cloud.aws.loader.max-pool-size |  | The maximum pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
 |cloud.aws.loader.queue-capacity |  | The maximum queue capacity for backed up S3 requests. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
-|cloud.aws.mail.enabled | true | Enables Mail integration.
-|cloud.aws.mail.endpoint |  |
-|cloud.aws.mail.region |  |
-|cloud.aws.rds.enabled | true | Enables RDS integration.
-|cloud.aws.rds.endpoint |  |
+|cloud.aws.mail.enabled | `true` | Enables Mail integration.
+|cloud.aws.mail.endpoint |  | 
+|cloud.aws.mail.region |  | 
+|cloud.aws.rds.enabled | `true` | Enables RDS integration.
+|cloud.aws.rds.endpoint |  | 
 |cloud.aws.rds.instances |  | List of RdsInstances.
-|cloud.aws.rds.region |  |
+|cloud.aws.rds.region |  | 
+|cloud.aws.region.static |  | 
 |cloud.aws.s3.endpoint |  | Overrides the default endpoint.
 |cloud.aws.s3.region |  | Overrides the default region.
-|cloud.aws.sns.enabled | true | Enables SNS integration.
-|cloud.aws.sns.endpoint |  |
-|cloud.aws.sns.region |  |
-|cloud.aws.sqs.enabled | true | Enables SQS integration.
-|cloud.aws.sqs.endpoint |  |
+|cloud.aws.sns.enabled | `true` | Enables SNS integration.
+|cloud.aws.sns.endpoint |  | 
+|cloud.aws.sns.region |  | 
+|cloud.aws.sqs.enabled | `true` | Enables SQS integration.
+|cloud.aws.sqs.endpoint |  | 
 |cloud.aws.sqs.handler.default-deletion-policy |  | Configures global deletion policy used if deletion policy is not explicitly set on {@link SqsListener}.
-|cloud.aws.sqs.listener.auto-startup | true | Configures if this container should be automatically started.
+|cloud.aws.sqs.listener.auto-startup | `true` | Configures if this container should be automatically started.
 |cloud.aws.sqs.listener.back-off-time |  | The number of milliseconds the polling thread must wait before trying to recover when an error occurs (e.g. connection timeout).
-|cloud.aws.sqs.listener.max-number-of-messages | 10 | The maximum number of messages that should be retrieved during one poll to the Amazon SQS system. This number must be a positive, non-zero number that has a maximum number of 10. Values higher then 10 are currently not supported by the queueing system.
+|cloud.aws.sqs.listener.max-number-of-messages | `10` | The maximum number of messages that should be retrieved during one poll to the Amazon SQS system. This number must be a positive, non-zero number that has a maximum number of 10. Values higher then 10 are currently not supported by the queueing system.
 |cloud.aws.sqs.listener.queue-stop-timeout |  | The queue stop timeout that waits for a queue to stop before interrupting the running thread.
 |cloud.aws.sqs.listener.visibility-timeout |  | The duration (in seconds) that the received messages are hidden from subsequent poll requests after being retrieved from the system.
-|cloud.aws.sqs.listener.wait-timeout | 20 | The wait timeout that the poll request will wait for new message to arrive if the are currently no messages on the queue. Higher values will reduce poll request to the system significantly. The value should be between 1 and 20. For more information read the <a href= "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
-|cloud.aws.sqs.region |  |
-|cloud.aws.stack.auto | true | Enables the automatic stack name detection for the application.
-|cloud.aws.stack.enabled | true | Enables Stack integration.
+|cloud.aws.sqs.listener.wait-timeout | `20` | The wait timeout that the poll request will wait for new message to arrive if the are currently no messages on the queue. Higher values will reduce poll request to the system significantly. The value should be between 1 and 20. For more information read the <a href= "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html">documentation</a>.
+|cloud.aws.sqs.region |  | 
+|cloud.aws.stack.auto | `true` | Enables the automatic stack name detection for the application.
+|cloud.aws.stack.enabled | `true` | Enables Stack integration.
 |cloud.aws.stack.name |  | The name of the manually configured stack name that will be used to retrieve the resources.
-|spring.cloud.aws.security.cognito.algorithm | RS256 | Encryption algorithm used to sign the JWK token.
+|spring.cloud.aws.security.cognito.algorithm | `RS256` | Encryption algorithm used to sign the JWK token.
 |spring.cloud.aws.security.cognito.app-client-id |  | Non-dynamic audience string to validate.
-|spring.cloud.aws.security.cognito.enabled | true | Enables Cognito integration.
-|spring.cloud.aws.security.cognito.region |  |
-|spring.cloud.aws.security.cognito.user-pool-id |  |
-|spring.cloud.aws.ses.enabled | true | Enables Simple Email Service integration.
+|spring.cloud.aws.security.cognito.enabled | `true` | Enables Cognito integration.
+|spring.cloud.aws.security.cognito.region |  | 
+|spring.cloud.aws.security.cognito.user-pool-id |  | 
+|spring.cloud.aws.ses.enabled | `true` | Enables Simple Email Service integration.
 |spring.cloud.aws.ses.region |  | Overrides the default region.
 
 |===

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -383,6 +383,72 @@ cloud.aws.rds.endpoint=http://localhost:4566
 
 Using custom endpoint can be especially useful when using https://github.com/localstack/localstack[Localstack] in integration tests or integrating with AWS compatible 3rd party services like https://min.io/[MinIO].
 
+===== Configuring client configuration
+
+For some AWS service integrations you can configure Spring Cloud AWS to use custom `ClientConfiguration`.
+
+To override the default `ClientConfiguration` used by all integrations, create a bean of type `ClientConfiguration` with a name `com.amazonaws.ClientConfiguration.BEAN_NAME`.
+
+[source,java,indent=0]
+----
+@Configuration
+class CustomAwsConfiguration {
+
+    @Bean(name = "com.amazonaws.ClientConfiguration.BEAN_NAME")
+	ClientConfiguration clientConfiguration() {
+		ClientConfiguration clientConfiguration= new ClientConfiguration();
+		clientConfiguration.setProxyHost(proxyHost);
+		clientConfiguration.setProxyPort(proxyPort);
+		clientConfiguration.setProxyUsername(proxyUserName);
+		clientConfiguration.setProxyPassword(proxyPassword);
+		return clientConfiguration;
+	}
+}
+----
+
+It's also possible to provide `ClientConfiguration` for particular integration by defining a bean of type `ClientConfiguration` and a name specific to the integration:
+
+[cols="2"]
+|===
+| SQS
+| `sqsClientConfiguration`
+
+| SNS
+| `snsClientConfiguration`
+
+| SES
+| `sesClientConfiguration`
+
+| RDS
+| `rdsClientConfiguration`
+
+| ElastiCache
+| `elastiCacheClientConfiguration`
+
+| CloudWatch
+| `cloudWatchClientConfiguration`
+
+|===
+
+For example:
+
+[source,java,indent=0]
+----
+@Configuration
+class CustomSqsConfiguration {
+
+    @Bean
+    ClientConfiguration sqsClientConfiguration() {
+        ClientConfiguration clientConfiguration= new ClientConfiguration();
+		clientConfiguration.setProxyHost(proxyHost);
+		clientConfiguration.setProxyPort(proxyPort);
+		clientConfiguration.setProxyUsername(proxyUserName);
+		clientConfiguration.setProxyPassword(proxyPassword);
+		return clientConfiguration;
+    }
+}
+----
+
 == Cloud environment
 Applications often need environment specific configuration information, especially in changing environments like in the
 Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and use environment specific data inside the

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -48,6 +48,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
+
 /**
  * @author Agim Emruli
  * @author Eddú Meléndez
@@ -68,7 +70,7 @@ public class ElastiCacheAutoConfiguration {
 
 	public ElastiCacheAutoConfiguration(ElastiCacheProperties properties,
 			ObjectProvider<ListableStackResourceFactory> stackResourceFactory,
-			@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+			@Qualifier(GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME) ObjectProvider<ClientConfiguration> globalClientConfiguration,
 			@Qualifier("elastiCacheClientConfiguration") ObjectProvider<ClientConfiguration> elastiCacheClientConfiguration) {
 		this.properties = properties;
 		this.stackResourceFactory = stackResourceFactory.getIfAvailable();

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfiguration.java
@@ -19,12 +19,14 @@ package org.springframework.cloud.aws.autoconfigure.cache;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.elasticache.AmazonElastiCache;
 import com.amazonaws.services.elasticache.AmazonElastiCacheClient;
 import net.spy.memcached.MemcachedClient;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -62,10 +64,16 @@ public class ElastiCacheAutoConfiguration {
 
 	private final ListableStackResourceFactory stackResourceFactory;
 
+	private final ClientConfiguration clientConfiguration;
+
 	public ElastiCacheAutoConfiguration(ElastiCacheProperties properties,
-			ObjectProvider<ListableStackResourceFactory> stackResourceFactory) {
+			ObjectProvider<ListableStackResourceFactory> stackResourceFactory,
+			@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+			@Qualifier("elastiCacheClientConfiguration") ObjectProvider<ClientConfiguration> elastiCacheClientConfiguration) {
 		this.properties = properties;
 		this.stackResourceFactory = stackResourceFactory.getIfAvailable();
+		this.clientConfiguration = elastiCacheClientConfiguration
+				.getIfAvailable(globalClientConfiguration::getIfAvailable);
 	}
 
 	@Bean
@@ -73,7 +81,7 @@ public class ElastiCacheAutoConfiguration {
 	public AmazonWebserviceClientFactoryBean<AmazonElastiCacheClient> amazonElastiCache(
 			ObjectProvider<RegionProvider> regionProvider, ObjectProvider<AWSCredentialsProvider> credentialsProvider) {
 		return new AmazonWebserviceClientFactoryBean<>(AmazonElastiCacheClient.class,
-				credentialsProvider.getIfAvailable(), regionProvider.getIfAvailable());
+				credentialsProvider.getIfAvailable(), regionProvider.getIfAvailable(), clientConfiguration);
 	}
 
 	@Bean

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfiguration.java
@@ -81,7 +81,7 @@ public class AmazonRdsDatabaseAutoConfiguration {
 			String endpoint = properties.getEndpoint() != null ? properties.getEndpoint().toString() : null;
 			String amazonRdsClientBeanName = AmazonWebserviceClientConfigurationUtils
 					.registerAmazonWebserviceClient(this, registry, "com.amazonaws.services.rds.AmazonRDSClient", null,
-							properties.getRegion(), endpoint)
+							properties.getRegion(), endpoint, "rdsClientConfiguration")
 					.getBeanName();
 			properties.getInstances().stream().filter(RdsInstance::hasRequiredPropertiesSet)
 					.forEach(instance -> registerDatasource(registry, amazonRdsClientBeanName, instance));

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfiguration.java
@@ -19,11 +19,13 @@ package org.springframework.cloud.aws.autoconfigure.messaging;
 import java.util.List;
 import java.util.Optional;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClient;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -57,18 +59,23 @@ public class SnsAutoConfiguration {
 
 	private final RegionProvider regionProvider;
 
+	private final ClientConfiguration clientConfiguration;
+
 	SnsAutoConfiguration(ObjectProvider<AWSCredentialsProvider> awsCredentialsProvider,
-			ObjectProvider<RegionProvider> regionProvider, SnsProperties properties) {
+			ObjectProvider<RegionProvider> regionProvider, SnsProperties properties,
+			@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+			@Qualifier("snsClientConfiguration") ObjectProvider<ClientConfiguration> snsClientConfiguration) {
 		this.awsCredentialsProvider = awsCredentialsProvider.getIfAvailable();
 		this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()
 				: new StaticRegionProvider(properties.getRegion());
+		this.clientConfiguration = snsClientConfiguration.getIfAvailable(globalClientConfiguration::getIfAvailable);
 	}
 
 	@ConditionalOnMissingAmazonClient(AmazonSNS.class)
 	@Bean
 	public AmazonWebserviceClientFactoryBean<AmazonSNSClient> amazonSNS(SnsProperties properties) {
 		AmazonWebserviceClientFactoryBean<AmazonSNSClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
-				AmazonSNSClient.class, this.awsCredentialsProvider, this.regionProvider);
+				AmazonSNSClient.class, this.awsCredentialsProvider, this.regionProvider, this.clientConfiguration);
 		Optional.ofNullable(properties.getEndpoint()).ifPresent(clientFactoryBean::setCustomEndpoint);
 		return clientFactoryBean;
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 import static org.springframework.cloud.aws.messaging.endpoint.config.NotificationHandlerMethodArgumentResolverConfigurationUtils.getNotificationHandlerMethodArgumentResolver;
 
 /**
@@ -63,7 +64,7 @@ public class SnsAutoConfiguration {
 
 	SnsAutoConfiguration(ObjectProvider<AWSCredentialsProvider> awsCredentialsProvider,
 			ObjectProvider<RegionProvider> regionProvider, SnsProperties properties,
-			@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+			@Qualifier(GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME) ObjectProvider<ClientConfiguration> globalClientConfiguration,
 			@Qualifier("snsClientConfiguration") ObjectProvider<ClientConfiguration> snsClientConfiguration) {
 		this.awsCredentialsProvider = awsCredentialsProvider.getIfAvailable();
 		this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.aws.autoconfigure.messaging;
 import java.util.Arrays;
 import java.util.Optional;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -70,19 +72,25 @@ public class SqsAutoConfiguration {
 
 		private final SqsProperties properties;
 
+		private final ClientConfiguration clientConfiguration;
+
 		SqsClientConfiguration(ObjectProvider<AWSCredentialsProvider> awsCredentialsProvider,
-				ObjectProvider<RegionProvider> regionProvider, SqsProperties properties) {
+				ObjectProvider<RegionProvider> regionProvider, SqsProperties properties,
+				@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+				@Qualifier("sqsClientConfiguration") ObjectProvider<ClientConfiguration> sqsClientConfiguration) {
 			this.awsCredentialsProvider = awsCredentialsProvider.getIfAvailable();
 			this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()
 					: new StaticRegionProvider(properties.getRegion());
 			this.properties = properties;
+			this.clientConfiguration = sqsClientConfiguration.getIfAvailable(globalClientConfiguration::getIfAvailable);
 		}
 
 		@Lazy
 		@Bean(destroyMethod = "shutdown")
 		public AmazonSQSBufferedAsyncClient amazonSQS() throws Exception {
 			AmazonWebserviceClientFactoryBean<AmazonSQSAsyncClient> clientFactoryBean = new AmazonWebserviceClientFactoryBean<>(
-					AmazonSQSAsyncClient.class, this.awsCredentialsProvider, this.regionProvider);
+					AmazonSQSAsyncClient.class, this.awsCredentialsProvider, this.regionProvider,
+					this.clientConfiguration);
 			Optional.ofNullable(properties.getEndpoint()).ifPresent(clientFactoryBean::setCustomEndpoint);
 			clientFactoryBean.afterPropertiesSet();
 			return new AmazonSQSBufferedAsyncClient(clientFactoryBean.getObject());

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfiguration.java
@@ -50,6 +50,8 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.util.CollectionUtils;
 
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
+
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for SQS integration.
  *
@@ -76,7 +78,7 @@ public class SqsAutoConfiguration {
 
 		SqsClientConfiguration(ObjectProvider<AWSCredentialsProvider> awsCredentialsProvider,
 				ObjectProvider<RegionProvider> regionProvider, SqsProperties properties,
-				@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+				@Qualifier(GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME) ObjectProvider<ClientConfiguration> globalClientConfiguration,
 				@Qualifier("sqsClientConfiguration") ObjectProvider<ClientConfiguration> sqsClientConfiguration) {
 			this.awsCredentialsProvider = awsCredentialsProvider.getIfAvailable();
 			this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfiguration.java
@@ -46,6 +46,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
+
 /**
  * Configuration for exporting metrics to CloudWatch.
  *
@@ -72,7 +74,7 @@ public class CloudWatchExportAutoConfiguration {
 
 	public CloudWatchExportAutoConfiguration(AWSCredentialsProvider credentialsProvider,
 			ObjectProvider<RegionProvider> regionProvider, CloudWatchProperties properties,
-			@Qualifier("globalClientConfiguration") ObjectProvider<ClientConfiguration> globalClientConfiguration,
+			@Qualifier(GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME) ObjectProvider<ClientConfiguration> globalClientConfiguration,
 			@Qualifier("cloudWatchClientConfiguration") ObjectProvider<ClientConfiguration> cloudWatchClientConfiguration) {
 		this.credentialsProvider = credentialsProvider;
 		this.regionProvider = properties.getRegion() == null ? regionProvider.getIfAvailable()

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
@@ -193,44 +193,6 @@ class ElastiCacheAutoConfigurationTest {
 		});
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	static class MockCacheConfigurationWithStackCaches {
-
-		@Bean
-		AmazonElastiCache amazonElastiCache() {
-			AmazonElastiCache amazonElastiCache = mock(AmazonElastiCache.class);
-			int port = TestMemcacheServer.startServer();
-			DescribeCacheClustersRequest sampleCacheOneLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheOneLogical");
-			sampleCacheOneLogical.setShowCacheNodeInfo(true);
-
-			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheOneLogical))
-					.thenReturn(new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint().withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
-
-			DescribeCacheClustersRequest sampleCacheTwoLogical = new DescribeCacheClustersRequest()
-					.withCacheClusterId("sampleCacheTwoLogical");
-			sampleCacheTwoLogical.setShowCacheNodeInfo(true);
-
-			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheTwoLogical))
-					.thenReturn(new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
-							.withConfigurationEndpoint(new Endpoint().withAddress("localhost").withPort(port))
-							.withEngine("memcached")));
-			return amazonElastiCache;
-		}
-
-		@Bean
-		ListableStackResourceFactory stackResourceFactory() {
-			ListableStackResourceFactory resourceFactory = mock(ListableStackResourceFactory.class);
-			Mockito.when(resourceFactory.resourcesByType("AWS::ElastiCache::CacheCluster")).thenReturn(Arrays.asList(
-					new StackResource("sampleCacheOneLogical", "sampleCacheOne", "AWS::ElastiCache::CacheCluster"),
-					new StackResource("sampleCacheTwoLogical", "sampleCacheTwo", "AWS::ElastiCache::CacheCluster")));
-			return resourceFactory;
-		}
-
-	}
-
 	@Test
 	void configuration_withGlobalClientConfiguration_shouldUseItForClient() {
 		// Arrange & Act
@@ -270,6 +232,44 @@ class ElastiCacheAutoConfigurationTest {
 							"clientConfiguration");
 					assertThat(clientConfiguration.getProxyHost()).isEqualTo("elastiCache");
 				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MockCacheConfigurationWithStackCaches {
+
+		@Bean
+		AmazonElastiCache amazonElastiCache() {
+			AmazonElastiCache amazonElastiCache = mock(AmazonElastiCache.class);
+			int port = TestMemcacheServer.startServer();
+			DescribeCacheClustersRequest sampleCacheOneLogical = new DescribeCacheClustersRequest()
+					.withCacheClusterId("sampleCacheOneLogical");
+			sampleCacheOneLogical.setShowCacheNodeInfo(true);
+
+			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheOneLogical))
+					.thenReturn(new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
+							.withConfigurationEndpoint(new Endpoint().withAddress("localhost").withPort(port))
+							.withEngine("memcached")));
+
+			DescribeCacheClustersRequest sampleCacheTwoLogical = new DescribeCacheClustersRequest()
+					.withCacheClusterId("sampleCacheTwoLogical");
+			sampleCacheTwoLogical.setShowCacheNodeInfo(true);
+
+			Mockito.when(amazonElastiCache.describeCacheClusters(sampleCacheTwoLogical))
+					.thenReturn(new DescribeCacheClustersResult().withCacheClusters(new CacheCluster()
+							.withConfigurationEndpoint(new Endpoint().withAddress("localhost").withPort(port))
+							.withEngine("memcached")));
+			return amazonElastiCache;
+		}
+
+		@Bean
+		ListableStackResourceFactory stackResourceFactory() {
+			ListableStackResourceFactory resourceFactory = mock(ListableStackResourceFactory.class);
+			Mockito.when(resourceFactory.resourcesByType("AWS::ElastiCache::CacheCluster")).thenReturn(Arrays.asList(
+					new StackResource("sampleCacheOneLogical", "sampleCacheOne", "AWS::ElastiCache::CacheCluster"),
+					new StackResource("sampleCacheTwoLogical", "sampleCacheTwo", "AWS::ElastiCache::CacheCluster")));
+			return resourceFactory;
+		}
+
 	}
 
 	@Configuration

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/cache/ElastiCacheAutoConfigurationTest.java
@@ -43,6 +43,7 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 
 /**
  * Tests for {@link ElastiCacheAutoConfiguration}.
@@ -295,7 +296,7 @@ class ElastiCacheAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -320,7 +321,7 @@ class ElastiCacheAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("elastiCache");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
@@ -36,6 +36,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 
 class ContextResourceLoaderAutoConfigurationTest {
 
@@ -152,7 +153,7 @@ class ContextResourceLoaderAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -177,7 +178,7 @@ class ContextResourceLoaderAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("s3");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/context/ContextResourceLoaderAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.context;
 
 import java.net.URI;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -28,6 +29,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.aws.autoconfigure.context.properties.AwsS3ResourceLoaderProperties;
 import org.springframework.cloud.aws.context.support.io.SimpleStorageProtocolResolverConfigurer;
 import org.springframework.cloud.aws.core.io.s3.SimpleStorageProtocolResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -104,6 +107,81 @@ class ContextResourceLoaderAutoConfigurationTest {
 			Object region = ReflectionTestUtils.getField(client, "signingRegion");
 			assertThat(region).isEqualTo(Regions.US_EAST_1.getName());
 		});
+	}
+
+	@Test
+	void configuration_withGlobalClientConfiguration_shouldUseItForClient() {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithGlobalClientConfiguration.class).run((context) -> {
+			AmazonS3 client = context.getBean(AmazonS3.class);
+
+			// Assert
+			ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+					"clientConfiguration");
+			assertThat(clientConfiguration.getProxyHost()).isEqualTo("global");
+		});
+	}
+
+	@Test
+	void configuration_withS3ClientConfiguration_shouldUseItForClient() {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithS3ClientConfiguration.class).run((context) -> {
+			AmazonS3 client = context.getBean(AmazonS3.class);
+
+			// Assert
+			ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+					"clientConfiguration");
+			assertThat(clientConfiguration.getProxyHost()).isEqualTo("s3");
+		});
+	}
+
+	@Test
+	void configuration_withGlobalAndS3ClientConfigurations_shouldUseSqsConfigurationForClient() {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithGlobalAndS3ClientConfiguration.class)
+				.run((context) -> {
+					AmazonS3 client = context.getBean(AmazonS3.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("s3");
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalClientConfiguration {
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithS3ClientConfiguration {
+
+		@Bean
+		ClientConfiguration s3ClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("s3");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalAndS3ClientConfiguration {
+
+		@Bean
+		ClientConfiguration s3ClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("s3");
+		}
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseAutoConfigurationTest.java
@@ -43,6 +43,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 
 class AmazonRdsDatabaseAutoConfigurationTest {
 
@@ -283,7 +284,7 @@ class AmazonRdsDatabaseAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -308,7 +309,7 @@ class AmazonRdsDatabaseAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("rds");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.aws.autoconfigure.mail;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import org.junit.jupiter.api.Test;
@@ -23,11 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 
 class SimpleEmailAutoConfigurationTest {
 
@@ -77,6 +81,85 @@ class SimpleEmailAutoConfigurationTest {
 			assertThat(context).doesNotHaveBean(MailSender.class);
 			assertThat(context).doesNotHaveBean(JavaMailSender.class);
 		});
+	}
+
+	@Test
+	void configuration_withGlobalClientConfiguration_shouldUseItForClient() {
+		// Arrange & Act
+		this.contextRunner
+				.withUserConfiguration(SesAutoConfigurationTest.ConfigurationWithGlobalClientConfiguration.class)
+				.run((context) -> {
+					AmazonSimpleEmailServiceClient client = context.getBean(AmazonSimpleEmailServiceClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("global");
+				});
+	}
+
+	@Test
+	void configuration_withSesClientConfiguration_shouldUseItForClient() {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(SesAutoConfigurationTest.ConfigurationWithSesClientConfiguration.class)
+				.run((context) -> {
+					AmazonSimpleEmailServiceClient client = context.getBean(AmazonSimpleEmailServiceClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("ses");
+				});
+	}
+
+	@Test
+	void configuration_withGlobalAndSesClientConfigurations_shouldUseSqsConfigurationForClient() {
+		// Arrange & Act
+		this.contextRunner
+				.withUserConfiguration(SesAutoConfigurationTest.ConfigurationWithGlobalAndSesClientConfiguration.class)
+				.run((context) -> {
+					AmazonSimpleEmailServiceClient client = context.getBean(AmazonSimpleEmailServiceClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("ses");
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalClientConfiguration {
+
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithSesClientConfiguration {
+
+		@Bean
+		ClientConfiguration sesClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("ses");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalAndSesClientConfiguration {
+
+		@Bean
+		ClientConfiguration sesClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("ses");
+		}
+
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
@@ -42,6 +42,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
 
 /**
@@ -244,7 +245,7 @@ class SnsAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -269,7 +270,7 @@ class SnsAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("sns");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SnsAutoConfigurationTest.java
@@ -25,8 +25,6 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClient;
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.regions.Region;
@@ -277,6 +278,52 @@ class SqsAutoConfigurationTest {
 	}
 
 	@Test
+	void configuration_withGlobalClientConfiguration_shouldUseItForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithGlobalClientConfiguration.class).run((context) -> {
+			AmazonSQSAsync bufferedAmazonSqsClient = context.getBean(AmazonSQSAsync.class);
+			AmazonSQSAsyncClient amazonSqs = (AmazonSQSAsyncClient) ReflectionTestUtils
+					.getField(bufferedAmazonSqsClient, "realSQS");
+
+			// Assert
+			ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(amazonSqs,
+					"clientConfiguration");
+			assertThat(clientConfiguration.getProxyHost()).isEqualTo("global");
+		});
+	}
+
+	@Test
+	void configuration_withSqsClientConfiguration_shouldUseItForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithSqsClientConfiguration.class).run((context) -> {
+			AmazonSQSAsync bufferedAmazonSqsClient = context.getBean(AmazonSQSAsync.class);
+			AmazonSQSAsyncClient amazonSqs = (AmazonSQSAsyncClient) ReflectionTestUtils
+					.getField(bufferedAmazonSqsClient, "realSQS");
+
+			// Assert
+			ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(amazonSqs,
+					"clientConfiguration");
+			assertThat(clientConfiguration.getProxyHost()).isEqualTo("sqs");
+		});
+	}
+
+	@Test
+	void configuration_withGlobalAndSqsClientConfigurations_shouldUseSqsConfigurationForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withUserConfiguration(ConfigurationWithGlobalAndSqsClientConfiguration.class)
+				.run((context) -> {
+					AmazonSQSAsync bufferedAmazonSqsClient = context.getBean(AmazonSQSAsync.class);
+					AmazonSQSAsyncClient amazonSqs = (AmazonSQSAsyncClient) ReflectionTestUtils
+							.getField(bufferedAmazonSqsClient, "realSQS");
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils
+							.getField(amazonSqs, "clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("sqs");
+				});
+	}
+
+	@Test
 	void disableSqs() {
 		this.contextRunner.withPropertyValues("cloud.aws.sqs.enabled:false").run(context -> {
 			assertThat(context).doesNotHaveBean(AmazonSQSAsync.class);
@@ -457,6 +504,41 @@ class SqsAutoConfigurationTest {
 		@Bean(name = REGION_PROVIDER_BEAN_NAME)
 		RegionProvider regionProvider() {
 			return new StaticRegionProvider("eu-west-1");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalClientConfiguration {
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithSqsClientConfiguration {
+
+		@Bean
+		ClientConfiguration sqsClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("sqs");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalAndSqsClientConfiguration {
+
+		@Bean
+		ClientConfiguration sqsClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("sqs");
+		}
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
 		}
 
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/messaging/SqsAutoConfigurationTest.java
@@ -57,6 +57,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
 
 /**
@@ -511,7 +512,7 @@ class SqsAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -536,7 +537,7 @@ class SqsAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("sqs");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
@@ -145,7 +145,7 @@ class CloudWatchExportAutoConfigurationTest {
 	}
 
 	@Test
-	void configuration_withGlobalAndCloudWatchClientConfigurations_shouldUseCloudWatchConfigurationForClient() throws Exception {
+	void configuration_withGlobalAndCloudWatchClientConfigurations_shouldUseCloudWatchConfigurationForClient() {
 		// Arrange & Act
 		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test")
 				.withUserConfiguration(ConfigurationWithGlobalAndCloudWatchClientConfiguration.class).run((context) -> {

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils.GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME;
 
 /**
  * Test for the {@link CloudWatchExportAutoConfiguration}.
@@ -161,7 +162,7 @@ class CloudWatchExportAutoConfigurationTest {
 	@Configuration(proxyBeanMethods = false)
 	static class ConfigurationWithGlobalClientConfiguration {
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}
@@ -186,7 +187,7 @@ class CloudWatchExportAutoConfigurationTest {
 			return new ClientConfiguration().withProxyHost("cloudWatch");
 		}
 
-		@Bean
+		@Bean(name = GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)
 		ClientConfiguration globalClientConfiguration() {
 			return new ClientConfiguration().withProxyHost("global");
 		}

--- a/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/org/springframework/cloud/aws/autoconfigure/metrics/CloudWatchExportAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.aws.autoconfigure.metrics;
 
 import java.net.URI;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient;
 import io.micrometer.cloudwatch.CloudWatchConfig;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,6 +114,83 @@ class CloudWatchExportAutoConfigurationTest {
 							"isEndpointOverridden");
 					assertThat(isEndpointOverridden).isTrue();
 				});
+	}
+
+	@Test
+	void configuration_withGlobalClientConfiguration_shouldUseItForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test")
+				.withUserConfiguration(ConfigurationWithGlobalClientConfiguration.class).run((context) -> {
+					AmazonCloudWatchAsyncClient client = context.getBean(AmazonCloudWatchAsyncClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("global");
+				});
+	}
+
+	@Test
+	void configuration_withCloudWatchClientConfiguration_shouldUseItForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test")
+				.withUserConfiguration(ConfigurationWithCloudWatchClientConfiguration.class).run((context) -> {
+					AmazonCloudWatchAsyncClient client = context.getBean(AmazonCloudWatchAsyncClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("cloudWatch");
+				});
+	}
+
+	@Test
+	void configuration_withGlobalAndCloudWatchClientConfigurations_shouldUseCloudWatchConfigurationForClient() throws Exception {
+		// Arrange & Act
+		this.contextRunner.withPropertyValues("management.metrics.export.cloudwatch.namespace:test")
+				.withUserConfiguration(ConfigurationWithGlobalAndCloudWatchClientConfiguration.class).run((context) -> {
+					AmazonCloudWatchAsyncClient client = context.getBean(AmazonCloudWatchAsyncClient.class);
+
+					// Assert
+					ClientConfiguration clientConfiguration = (ClientConfiguration) ReflectionTestUtils.getField(client,
+							"clientConfiguration");
+					assertThat(clientConfiguration.getProxyHost()).isEqualTo("cloudWatch");
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalClientConfiguration {
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithCloudWatchClientConfiguration {
+
+		@Bean
+		ClientConfiguration cloudWatchClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("cloudWatch");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConfigurationWithGlobalAndCloudWatchClientConfiguration {
+
+		@Bean
+		ClientConfiguration cloudWatchClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("cloudWatch");
+		}
+
+		@Bean
+		ClientConfiguration globalClientConfiguration() {
+			return new ClientConfiguration().withProxyHost("global");
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/annotation/ContextResourceLoaderConfiguration.java
@@ -57,7 +57,7 @@ public class ContextResourceLoaderConfiguration {
 				BeanDefinitionRegistry registry) {
 			BeanDefinitionHolder client = AmazonWebserviceClientConfigurationUtils.registerAmazonWebserviceClient(this,
 					registry, AmazonS3Client.class.getName(), null, this.environment.getProperty("cloud.aws.s3.region"),
-					this.environment.getProperty("cloud.aws.s3.endpoint"));
+					this.environment.getProperty("cloud.aws.s3.endpoint"), "s3ClientConfiguration");
 
 			BeanDefinitionBuilder configurer = BeanDefinitionBuilder
 					.genericBeanDefinition(SimpleStorageProtocolResolverConfigurer.class);

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/SpringCloudClientConfiguration.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/SpringCloudClientConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.core;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.PredefinedClientConfigurations;
 
 /**
@@ -37,7 +38,13 @@ public final class SpringCloudClientConfiguration {
 	}
 
 	public static ClientConfiguration getClientConfiguration() {
-		return PredefinedClientConfigurations.defaultConfig().withUserAgentSuffix(getUserAgent());
+		return getClientConfiguration(PredefinedClientConfigurations.defaultConfig());
+	}
+
+	public static ClientConfiguration getClientConfiguration(ClientConfiguration clientConfiguration) {
+		ClientConfiguration config = clientConfiguration != null ? clientConfiguration
+				: PredefinedClientConfigurations.defaultConfig();
+		return config.withUserAgentSuffix(getUserAgent());
 	}
 
 }

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/SpringCloudClientConfiguration.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/SpringCloudClientConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.aws.core;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.PredefinedClientConfigurations;
 
 /**

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Agim Emruli
  * @author Alain Sahli
+ * @author Maciej Walkowiak
  */
 public final class AmazonWebserviceClientConfigurationUtils {
 

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -62,13 +62,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source, BeanDefinitionRegistry registry,
 			String serviceNameClassName, String customRegionProvider, String customRegion) {
 		return registerAmazonWebserviceClient(source, registry, serviceNameClassName, customRegionProvider,
-				customRegion, null);
-	}
-
-	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source, BeanDefinitionRegistry registry,
-			String serviceNameClassName, String customRegionProvider, String customRegion, String customEndpoint) {
-		return registerAmazonWebserviceClient(source, registry, serviceNameClassName, customRegionProvider,
-				customRegion, customEndpoint, null);
+				customRegion, null, null);
 	}
 
 	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source, BeanDefinitionRegistry registry,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -45,6 +45,8 @@ public final class AmazonWebserviceClientConfigurationUtils {
 	// @checkstyle:off
 	public static final String REGION_PROVIDER_BEAN_NAME = "org.springframework.cloud.aws.core.region.RegionProvider.BEAN_NAME";
 
+	public static final String GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME = "com.amazonaws.ClientConfiguration.BEAN_NAME";
+
 	// @checkstyle:on
 
 	/**
@@ -124,8 +126,8 @@ public final class AmazonWebserviceClientConfigurationUtils {
 				&& beanDefinitionRegistry.containsBeanDefinition(clientConfigurationBeanName)) {
 			builder.addPropertyReference("clientConfiguration", clientConfigurationBeanName);
 		}
-		else if (beanDefinitionRegistry.containsBeanDefinition("globalClientConfiguration")) {
-			builder.addPropertyReference("clientConfiguration", "globalClientConfiguration");
+		else if (beanDefinitionRegistry.containsBeanDefinition(GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME)) {
+			builder.addPropertyReference("clientConfiguration", GLOBAL_CLIENT_CONFIGURATION_BEAN_NAME);
 		}
 
 		return builder.getBeanDefinition();

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientConfigurationUtils.java
@@ -67,6 +67,13 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source, BeanDefinitionRegistry registry,
 			String serviceNameClassName, String customRegionProvider, String customRegion, String customEndpoint) {
+		return registerAmazonWebserviceClient(source, registry, serviceNameClassName, customRegionProvider,
+				customRegion, customEndpoint, null);
+	}
+
+	public static BeanDefinitionHolder registerAmazonWebserviceClient(Object source, BeanDefinitionRegistry registry,
+			String serviceNameClassName, String customRegionProvider, String customRegion, String customEndpoint,
+			String clientConfigurationBeanName) {
 
 		String beanName = getBeanName(serviceNameClassName);
 
@@ -75,7 +82,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		}
 
 		BeanDefinition definition = getAmazonWebserviceClientBeanDefinition(source, serviceNameClassName,
-				customRegionProvider, customRegion, customEndpoint, registry);
+				customRegionProvider, customRegion, customEndpoint, registry, clientConfigurationBeanName);
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(definition, beanName);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
 
@@ -84,7 +91,7 @@ public final class AmazonWebserviceClientConfigurationUtils {
 
 	public static AbstractBeanDefinition getAmazonWebserviceClientBeanDefinition(Object source,
 			String serviceNameClassName, String customRegionProvider, String customRegion, String customEndpoint,
-			BeanDefinitionRegistry beanDefinitionRegistry) {
+			BeanDefinitionRegistry beanDefinitionRegistry, String clientConfigurationBeanName) {
 
 		if (StringUtils.hasText(customRegionProvider) && StringUtils.hasText(customRegion)) {
 			throw new IllegalArgumentException("Only region or regionProvider can be configured, but not both");
@@ -115,6 +122,15 @@ public final class AmazonWebserviceClientConfigurationUtils {
 		else {
 			registerRegionProviderBeanIfNeeded(beanDefinitionRegistry);
 			builder.addPropertyReference("regionProvider", REGION_PROVIDER_BEAN_NAME);
+		}
+
+		// configure client configuration
+		if (clientConfigurationBeanName != null
+				&& beanDefinitionRegistry.containsBeanDefinition(clientConfigurationBeanName)) {
+			builder.addPropertyReference("clientConfiguration", clientConfigurationBeanName);
+		}
+		else if (beanDefinitionRegistry.containsBeanDefinition("globalClientConfiguration")) {
+			builder.addPropertyReference("clientConfiguration", "globalClientConfiguration");
 		}
 
 		return builder.getBeanDefinition();

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/AmazonWebserviceClientFactoryBean.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 import com.amazonaws.AmazonWebServiceClient;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsAsyncClientBuilder;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -61,6 +62,8 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 
 	private URI customEndpoint;
 
+	private ClientConfiguration clientConfiguration;
+
 	public AmazonWebserviceClientFactoryBean(Class<T> clientClass, AWSCredentialsProvider credentialsProvider) {
 		this.clientClass = clientClass;
 		this.credentialsProvider = credentialsProvider;
@@ -70,6 +73,13 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 			RegionProvider regionProvider) {
 		this(clientClass, credentialsProvider);
 		setRegionProvider(regionProvider);
+	}
+
+	public AmazonWebserviceClientFactoryBean(Class<T> clientClass, AWSCredentialsProvider credentialsProvider,
+			RegionProvider regionProvider, ClientConfiguration clientConfiguration) {
+		this(clientClass, credentialsProvider);
+		setRegionProvider(regionProvider);
+		setClientConfiguration(clientConfiguration);
 	}
 
 	@Override
@@ -94,7 +104,7 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 			asyncBuilder.withExecutorFactory((ExecutorFactory) () -> this.executor);
 		}
 
-		builder.withClientConfiguration(SpringCloudClientConfiguration.getClientConfiguration());
+		builder.withClientConfiguration(SpringCloudClientConfiguration.getClientConfiguration(clientConfiguration));
 
 		if (this.credentialsProvider != null) {
 			builder.withCredentials(this.credentialsProvider);
@@ -132,6 +142,10 @@ public class AmazonWebserviceClientFactoryBean<T extends AmazonWebServiceClient>
 
 	public void setExecutor(ExecutorService executor) {
 		this.executor = executor;
+	}
+
+	public void setClientConfiguration(ClientConfiguration clientConfiguration) {
+		this.clientConfiguration = clientConfiguration;
 	}
 
 	@Override

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/config/xml/XmlWebserviceConfigurationUtils.java
@@ -57,7 +57,7 @@ public final class XmlWebserviceConfigurationUtils {
 		try {
 			return getAmazonWebserviceClientBeanDefinition(source, serviceClassName,
 					element.getAttribute(REGION_PROVIDER_ATTRIBUTE_NAME), element.getAttribute(REGION_ATTRIBUTE_NAME),
-					null, parserContext.getRegistry());
+					null, parserContext.getRegistry(), null);
 		}
 		catch (Exception e) {
 			parserContext.getReaderContext().error(e.getMessage(), source, e);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

One common request is to add simple way to provide custom `ClientConfiguration` for different integrations. This change enables users to define a bean of name `com.amazonaws.ClientConfiguration.BEAN_NAME` that would be by default set on all AWS clients and in addition to that, define `ClientConfiguration` per client.

Client-specific beans must have specific name, for example - SQS `ClientConfiguration` bean must be named - `sqsClientConfiguration`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Common request:
- https://github.com/spring-cloud/spring-cloud-aws/issues/412
- https://github.com/spring-cloud/spring-cloud-aws/issues/63


## :green_heart: How did you test it?

Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

- [x] Add support for modules once PRs are merged:
  - Parameter Store (https://github.com/spring-cloud/spring-cloud-aws/pull/723)
  - Secrets Manager (https://github.com/spring-cloud/spring-cloud-aws/pull/721)
  - SES (https://github.com/spring-cloud/spring-cloud-aws/pull/669)
- [x] Update reference docs
