### PR TITLE
Add ability to pass AmazonS3 to SimpleStorageProtocolResolver via constructor.

### DIFF
--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageProtocolResolver.java
@@ -51,11 +51,7 @@ public class SimpleStorageProtocolResolver
 	public SimpleStorageProtocolResolver() {
 	}
 
-	/**
-	 * Used only for testing.
-	 * @param amazonS3 - the Amazon S3 client.
-	 */
-	SimpleStorageProtocolResolver(AmazonS3 amazonS3) {
+	public SimpleStorageProtocolResolver(AmazonS3 amazonS3) {
 		this.amazonS3 = AmazonS3ProxyFactory.createProxy(amazonS3);
 	}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Add ability to pass AmazonS3 to SimpleStorageProtocolResolver via constructor.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes gh-724

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes