### PR TITLE
Fix ClassNotFoundException caused by `SesAutoConfiguration`.

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SesAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SesAutoConfiguration.java
@@ -55,7 +55,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(MailSenderAutoConfiguration.class)
 @AutoConfigureBefore(SimpleEmailAutoConfiguration.class)
-@ConditionalOnClass({ AmazonSimpleEmailService.class, MailSender.class })
+@ConditionalOnClass({ AmazonSimpleEmailService.class, MailSender.class, SimpleEmailServiceJavaMailSender.class })
 @ConditionalOnMissingBean(MailSender.class)
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableConfigurationProperties(SesProperties.class)

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/mail/SimpleEmailAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 /**
  * @author Agim Emruli
  * @author Eddú Meléndez
+ * @deprecated Use `spring-cloud-starter-aws-ses`
  */
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(MailSenderAutoConfiguration.class)
@@ -56,6 +57,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 @Import(ContextCredentialsAutoConfiguration.class)
 @EnableConfigurationProperties(SimpleEmailProperties.class)
 @ConditionalOnProperty(name = "cloud.aws.mail.enabled", havingValue = "true", matchIfMissing = true)
+@Deprecated
 public class SimpleEmailAutoConfiguration {
 
 	private final RegionProvider regionProvider;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fix ClassNotFoundException caused by `SesAutoConfiguration`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Auto-Configuration was triggered even if SES module was not on the classpath causing an exception.


## :green_heart: How did you test it?

Integration tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes
