### PR TITLE
Disable ContextInstanceDataAutoConfiguration by default.

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -27,6 +27,7 @@
 |cloud.aws.elasticache.default-expiration | 0 | Configures the default expiration time in seconds if there is no custom expiration time configuration with a {@link Cluster} configuration for the cache. The expiration time is implementation specific (e.g. Redis or Memcached) and could therefore differ in the behaviour based on the cache implementation.
 |cloud.aws.elasticache.enabled | true | Enables ElastiCache integration.
 |cloud.aws.elasticache.expiry-time-per-cache |  | 
+|cloud.aws.instance.data.enabled | false | Enables Instance Data integration.
 |cloud.aws.loader.core-pool-size | 1 | The core pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setCorePoolSize(int)
 |cloud.aws.loader.max-pool-size |  | The maximum pool size of the Task Executor used for parallel S3 interaction. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setMaxPoolSize(int)
 |cloud.aws.loader.queue-capacity |  | The maximum queue capacity for backed up S3 requests. @see org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor#setQueueCapacity(int)
@@ -55,6 +56,5 @@
 |cloud.aws.stack.auto | true | Enables the automatic stack name detection for the application.
 |cloud.aws.stack.enabled | true | Enables Stack integration.
 |cloud.aws.stack.name |  | The name of the manually configured stack name that will be used to retrieve the resources.
-|spring.cloud.aws.ses.region || The specific region for SES integration.
 
 |===

--- a/docs/src/main/asciidoc/spring-cloud-aws.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-aws.adoc
@@ -425,8 +425,8 @@ The next example shows a typical Spring `@Configuration` class that enables the 
 ----
 
 ==== Enabling instance metadata support in Spring Boot
-The instance metadata is automatically available in a Spring Boot application as a property source if the application
-is running on an EC2 instance.
+The instance metadata is available in a Spring Boot application as a property source if the application
+is running on an EC2 instance and `cloud.aws.instance.data.enabled` property is set to `true`.
 
 ==== Using instance metadata
 Instance metadata can be used in XML, Java placeholders and expressions. The example below demonstrates the usage of

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/condition/ConditionalOnAwsCloudEnvironment.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/condition/ConditionalOnAwsCloudEnvironment.java
@@ -29,6 +29,9 @@ import org.springframework.context.annotation.Conditional;
  * started inside an AWS cloud environment. Useful for beans that should only be created
  * if the application context is bootstrapped inside the AWS environment.
  *
+ * Note: if application does not run in AWS environment, evaluating this condition can
+ * take several seconds.
+ *
  * @author Agim Emruli
  * @author Eddú Meléndez
  */

--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextInstanceDataAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.aws.autoconfigure.context;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.aws.autoconfigure.condition.ConditionalOnAwsCloudEnvironment;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
@@ -28,9 +29,13 @@ import org.springframework.core.type.AnnotationMetadata;
 import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.registerInstanceDataPropertySource;
 
 /**
+ * Enables passing EC2 instance metadata into Spring
+ * {@link org.springframework.context.annotation.PropertySource}.
+ *
  * @author Agim Emruli
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "cloud.aws.instance.data.enabled", havingValue = "true")
 @ConditionalOnAwsCloudEnvironment
 @Import(ContextInstanceDataAutoConfiguration.Registrar.class)
 public class ContextInstanceDataAutoConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -63,6 +63,12 @@
 	  "type": "java.lang.String"
 	},
     {
+	  "defaultValue": false,
+	  "name": "cloud.aws.instance-data.enabled",
+	  "description": "Enables Instance Data integration.",
+	  "type": "java.lang.Boolean"
+    },
+    {
       "defaultValue": true,
       "name": "spring.cloud.aws.security.cognito.enabled",
       "description": "Enables Cognito integration.",

--- a/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-aws-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -64,7 +64,7 @@
 	},
     {
 	  "defaultValue": false,
-	  "name": "cloud.aws.instance-data.enabled",
+	  "name": "cloud.aws.instance.data.enabled",
 	  "description": "Enables Instance Data integration.",
 	  "type": "java.lang.Boolean"
     },


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This change makes `ContextInstanceDataAutoConfiguration` an opt-in feature - to use it users have to explicitly set the `cloud.aws.instance.data.enabled` to `true`.

It is a breaking change.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ContextInstanceDataAutoConfiguration has a condition to run only in AWS environment. This condition is expensive to run outside of AWS environment and it slows down application startup several seconds.


## :green_heart: How did you test it?

Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [ ] No breaking changes