### PR TITLE
Remove usage of StringUtils.isEmpty

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/jdbc/AmazonRdsDatabaseProperties.java
@@ -82,7 +82,7 @@ public class AmazonRdsDatabaseProperties extends AwsClientProperties {
 		private boolean readReplicaSupport = false;
 
 		public boolean hasRequiredPropertiesSet() {
-			return !StringUtils.isEmpty(this.getDbInstanceIdentifier()) && !StringUtils.isEmpty(this.getPassword());
+			return StringUtils.hasLength(this.getDbInstanceIdentifier()) && StringUtils.hasLength(this.getPassword());
 		}
 
 		public String getDbInstanceIdentifier() {

--- a/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
+++ b/spring-cloud-aws-context/src/main/java/org/springframework/cloud/aws/context/config/xml/StackConfigurationBeanDefinitionParser.java
@@ -107,10 +107,10 @@ class StackConfigurationBeanDefinitionParser extends AbstractSimpleBeanDefinitio
 		String stackName = element.getAttribute(STACK_NAME_ATTRIBUTE_NAME);
 
 		builder.addConstructorArgReference(amazonCloudFormationClientBeanName);
-		AbstractBeanDefinition stackNameProviderBeanDefinition = StringUtils.isEmpty(stackName)
-				? buildAutoDetectingStackNameProviderBeanDefinition(amazonCloudFormationClientBeanName,
-						amazonEc2ClientBeanName)
-				: buildStaticStackNameProviderBeanDefinition(stackName);
+		AbstractBeanDefinition stackNameProviderBeanDefinition = StringUtils.hasLength(stackName)
+				? buildStaticStackNameProviderBeanDefinition(stackName)
+				: buildAutoDetectingStackNameProviderBeanDefinition(amazonCloudFormationClientBeanName,
+						amazonEc2ClientBeanName);
 		builder.addConstructorArgValue(stackNameProviderBeanDefinition);
 
 		buildAndRegisterStackUserTagsIfNeeded(element, parserContext, amazonCloudFormationClientBeanName,

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/env/stack/config/StackResourceRegistryFactoryBean.java
@@ -115,7 +115,7 @@ public class StackResourceRegistryFactoryBean extends AbstractFactoryBean<Listab
 	}
 
 	private String toNestedResourceId(String prefix, String logicalResourceId) {
-		return StringUtils.isEmpty(prefix) ? logicalResourceId : prefix + "." + logicalResourceId;
+		return StringUtils.hasLength(prefix) ? prefix + "." + logicalResourceId : logicalResourceId;
 	}
 
 	/**

--- a/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
+++ b/spring-cloud-aws-core/src/main/java/org/springframework/cloud/aws/core/io/s3/SimpleStorageNameUtils.java
@@ -102,7 +102,7 @@ final class SimpleStorageNameUtils {
 
 	static String getContentTypeFromLocation(String location) {
 		String objectName = getObjectNameFromLocation(location);
-		if (!StringUtils.isEmpty(objectName)) {
+		if (StringUtils.hasLength(objectName)) {
 			return URLConnection.guessContentTypeFromName(objectName);
 		}
 		return null;

--- a/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
+++ b/spring-cloud-aws-parameter-store-config/src/main/java/org/springframework/cloud/aws/paramstore/AwsParamStoreProperties.java
@@ -92,15 +92,15 @@ public class AwsParamStoreProperties implements Validator {
 	public void validate(Object target, Errors errors) {
 		AwsParamStoreProperties properties = (AwsParamStoreProperties) target;
 
-		if (StringUtils.isEmpty(properties.getPrefix())) {
+		if (!StringUtils.hasLength(properties.getPrefix())) {
 			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
 		}
 
-		if (StringUtils.isEmpty(properties.getDefaultContext())) {
+		if (!StringUtils.hasLength(properties.getDefaultContext())) {
 			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
 		}
 
-		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
+		if (!StringUtils.hasLength(properties.getProfileSeparator())) {
 			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
 		}
 

--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -92,15 +92,15 @@ public class AwsSecretsManagerProperties implements Validator {
 	public void validate(Object target, Errors errors) {
 		AwsSecretsManagerProperties properties = (AwsSecretsManagerProperties) target;
 
-		if (StringUtils.isEmpty(properties.getPrefix())) {
+		if (!StringUtils.hasLength(properties.getPrefix())) {
 			errors.rejectValue("prefix", "NotEmpty", "prefix should not be empty or null.");
 		}
 
-		if (StringUtils.isEmpty(properties.getDefaultContext())) {
+		if (!StringUtils.hasLength(properties.getDefaultContext())) {
 			errors.rejectValue("defaultContext", "NotEmpty", "defaultContext should not be empty or null.");
 		}
 
-		if (StringUtils.isEmpty(properties.getProfileSeparator())) {
+		if (!StringUtils.hasLength(properties.getProfileSeparator())) {
 			errors.rejectValue("profileSeparator", "NotEmpty", "profileSeparator should not be empty or null.");
 		}
 


### PR DESCRIPTION
`StringUtils.isEmpty` has been deprecated in spring-framework 5.3.
