### PR TITLE
Improve Region auto-configuration

### DIFF
--- a/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextRegionProviderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,14 @@
 
 package org.springframework.cloud.aws.autoconfigure.context;
 
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.cloud.aws.autoconfigure.context.properties.AwsRegionProperties;
-import org.springframework.cloud.aws.core.config.AmazonWebserviceClientConfigurationUtils;
 import org.springframework.cloud.aws.core.region.DefaultAwsRegionProviderChainDelegate;
+import org.springframework.cloud.aws.core.region.RegionProvider;
 import org.springframework.cloud.aws.core.region.StaticRegionProvider;
-import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.env.Environment;
-import org.springframework.core.type.AnnotationMetadata;
-
-import static org.springframework.cloud.aws.context.config.support.ContextConfigurationUtils.REGION_PROVIDER_BEAN_NAME;
 
 /**
  * Region auto configuration, based on <a
@@ -42,46 +33,26 @@ import static org.springframework.cloud.aws.context.config.support.ContextConfig
  * @author Agim Emruli
  * @author Petromir Dzhunev
  * @author Maciej Walkowiak
+ * @author Eddú Meléndez
  */
 // @checkstyle:off
 @Configuration(proxyBeanMethods = false)
-@Import(ContextRegionProviderAutoConfiguration.Registrar.class)
 @EnableConfigurationProperties(AwsRegionProperties.class)
 public class ContextRegionProviderAutoConfiguration {
 
-	static class Registrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
+	private final AwsRegionProperties properties;
 
-		private Environment environment;
+	public ContextRegionProviderAutoConfiguration(AwsRegionProperties properties) {
+		this.properties = properties;
+	}
 
-		@Override
-		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
-				BeanDefinitionRegistry registry) {
-			// Do not register region provider if already existing
-			if (!registry.containsBeanDefinition(REGION_PROVIDER_BEAN_NAME)) {
-				registry.registerBeanDefinition(REGION_PROVIDER_BEAN_NAME,
-						createRegionProviderBeanDefinition(awsRegionProperties()));
-				AmazonWebserviceClientConfigurationUtils.replaceDefaultRegionProvider(registry,
-						REGION_PROVIDER_BEAN_NAME);
-			}
+	@Bean
+	@ConditionalOnMissingBean
+	public RegionProvider regionProvider() {
+		if (this.properties.isStatic()) {
+			return new StaticRegionProvider(this.properties.getStatic());
 		}
-
-		@Override
-		public void setEnvironment(Environment environment) {
-			this.environment = environment;
-		}
-
-		private BeanDefinition createRegionProviderBeanDefinition(AwsRegionProperties properties) {
-			return properties.isStatic()
-					? BeanDefinitionBuilder.genericBeanDefinition(StaticRegionProvider.class)
-							.addConstructorArgValue(properties.getStatic()).getBeanDefinition()
-					: BeanDefinitionBuilder.genericBeanDefinition(DefaultAwsRegionProviderChainDelegate.class)
-							.getBeanDefinition();
-		}
-
-		private AwsRegionProperties awsRegionProperties() {
-			return Binder.get(this.environment).bindOrCreate(AwsRegionProperties.PREFIX, AwsRegionProperties.class);
-		}
-
+		return new DefaultAwsRegionProviderChainDelegate();
 	}
 
 }


### PR DESCRIPTION
Currently `ContextRegionProviderAutoConfiguration` uses
`BeanDefinitionRegistry`. This commit introduces `RegionProvider`
bean definition.
