### PR TITLE
Introduce policies secret manager into docs

### DIFF
--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -68,6 +68,10 @@ dots, dashes, forward slashes, backward slashes and underscores next to alphanum
 |`aws.secretsmanager.enabled`
 |`true`
 |Can be used to disable the Secrets Manager Configuration support even though the auto-configuration is on the classpath.
+
+|`aws.secretsmanager.region`
+|`eu-central-1`
+|Can be used to set region for AWSSecretsManagerClient.
 |===
 
 In `spring-cloud` `2020.0.0` (aka Ilford), the bootstrap phase is no longer enabled by default. In order
@@ -85,3 +89,31 @@ enable it you need an additional dependency:
 However, starting at `spring-cloud-aws` `2.3`, allows import default aws' secretsmanager keys
 (`spring.config.import=aws-secretsmanager:`) or individual keys
 (`spring.config.import=aws-secretsmanager:secret-key;other-secret-key`)
+
+=== IAM Permissions
+Following IAM permissions are required by Spring Cloud AWS:
+
+[cols="2"]
+|===
+|  Get secret value:
+| `secretsmanager:GetSecretValue`
+
+
+|===
+
+Sample IAM policy granting access to Secret manager:
+
+[source,json,indent=0]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "yourArn"
+        }
+    ]
+}
+----

--- a/docs/src/main/asciidoc/secrets-manager.adoc
+++ b/docs/src/main/asciidoc/secrets-manager.adoc
@@ -109,7 +109,6 @@ Sample IAM policy granting access to Secret manager:
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": "secretsmanager:GetSecretValue",
             "Resource": "yourArn"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Added IAM policies needed for Secret manager into docs. Added region into docs as well.


## :bulb: Motivation and Context
Currently users need to guess which permissions are required to use certain Spring Cloud AWS features (see #341)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
