### PR TITLE
Fix for #736 to allow security manager prefix without "/" in the front

### DIFF
--- a/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
+++ b/spring-cloud-aws-secrets-manager-config/src/main/java/org/springframework/cloud/aws/secretsmanager/AwsSecretsManagerProperties.java
@@ -43,7 +43,7 @@ public class AwsSecretsManagerProperties implements Validator {
 	/**
 	 * Pattern used for prefix validation.
 	 */
-	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/[a-zA-Z0-9.\\-_]+)*");
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(/)?([a-zA-Z0-9.\\-_]+)*");
 
 	/**
 	 * Pattern used for profileSeparator validation.


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The initial code always expected the "prefix" inside "secretmanager" to start with "/" in the front, which not be in true as AWS doesn't impose such restrictions. So the code change takes care of updating the regex to allow 0 or 1 occurrence of "/" as the first character while specifying the prefix inside "secretmanager"


## :bulb: Motivation and Context
#736

## :green_heart: How did you test it?
- All unit testcases passed. 
- Integration test was done using a spring boot application and everything worked as expected

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
No additional steps required